### PR TITLE
Refine gan gpu memory

### DIFF
--- a/CycleGAN/paddle/train.py
+++ b/CycleGAN/paddle/train.py
@@ -149,7 +149,7 @@ def train(args):
     t_time = 0
     build_strategy = fluid.BuildStrategy()
     build_strategy.enable_inplace = False
-    build_strategy.memory_optimize = True
+    build_strategy.memory_optimize = False
     
     exec_strategy = fluid.ExecutionStrategy()
     exec_strategy.num_threads = 1

--- a/CycleGAN/paddle/train.sh
+++ b/CycleGAN/paddle/train.sh
@@ -1,4 +1,14 @@
 
 export CUDA_VISIBLE_DEVICES=0
 export FLAGS_cudnn_exhaustive_search=1
+export FLAGS_eager_delete_tensor_gb=0.0
+
+workspace_size_limit=256
+if [ $# -ge 1 ]; then
+  workspace_size_limit=$1
+fi
+
+echo "export FLAGS_conv_workspace_size_limit=$workspace_size_limit"
+export FLAGS_conv_workspace_size_limit=$workspace_size_limit
+
 python train.py


### PR DESCRIPTION
This changing is related to https://github.com/PaddlePaddle/Paddle/pull/17036.

Speed is unchanged, i.e., 0.15s/batch on V100 GPU machine when using only 256MB workspace, but saving lots of gpu memory.