### PR TITLE
Refine the pe options for padding-rnn and mask-rcnn.

### DIFF
--- a/Mask-RCNN/paddle/rcnn/train.py
+++ b/Mask-RCNN/paddle/rcnn/train.py
@@ -101,6 +101,7 @@ def train():
 
         exec_strategy = fluid.ExecutionStrategy()
         exec_strategy.use_experimental_executor = True
+        exec_strategy.num_iteration_per_drop_scope = 100
         train_exe = fluid.ParallelExecutor(
             use_cuda=bool(cfg.use_gpu), loss_name=loss.name, build_strategy=build_strategy, exec_strategy=exec_strategy)
     else:

--- a/PaddingRNN/lstm_paddle/train.py
+++ b/PaddingRNN/lstm_paddle/train.py
@@ -227,7 +227,6 @@ def main():
     build_strategy.remove_unnecessary_lock = True
     build_strategy.enable_sequential_execution = False
     build_strategy.cache_runtime_context = True
-    build_strategy.cache_expected_kernel = True
     build_strategy.fuse_all_optimizer_ops = True
 
     if args.parallel:


### PR DESCRIPTION
`cache_expected_kernel` is deleted in Paddle's develop branch.