### PR TITLE
Update script files of detection models.

### DIFF
--- a/scripts/analysis.py
+++ b/scripts/analysis.py
@@ -78,6 +78,7 @@ class TimeAnalyzer(object):
                         result = line.split(self.separator)[self.position]
                     else:
                         result = line.split()[self.position]
+                    result = result.replace("\"", "")
                     result = result[0:] if not self.range else result[0:self.range]
                     self.records.append(float(result))
                 except Exception as exc:

--- a/static_graph/Detection/pytorch/run_detectron.sh
+++ b/static_graph/Detection/pytorch/run_detectron.sh
@@ -9,22 +9,28 @@ if [[ $# -lt 3 ]]; then
 fi
 
 function _set_params(){
-    index=$1                         # 速度(speed)|显存占用(mem)|单卡最大支持batch_size(maxbs)(必填)
-    base_batch_size=2                # 单卡的batch_size，如果固定的，可以写死（必填）
-    model_name=$2                    # 模型名字如。如果是固定的，可以写死，如果需要其他参数可以参考bert实现（必填）
-    run_log_path=${4:-$(pwd)}        # 训练保存的日志目录（必填）
+    index=$1                        # 速度(speed)|显存占用(mem)|单卡最大支持batch_size(maxbs)(必填)
+    base_batch_size=2               # 单卡的batch_size，如果固定的，可以写死（必填），注意该值将会用于解析日志
+    model_name=$2                   # 模型名字如。如果是固定的，可以写死，如果需要其他参数可以参考bert实现（必填）
+    run_log_path=${4:-$(pwd)}       # 训练保存的日志目录（必填）
     run_mode=${3:-"sp"}
-    skip_steps=2                     # 解析日志，有些模型前几个step耗时长，需要跳过(必填)
-    keyword="json_stats"             # 解析日志，筛选出数据所在行的关键字(必填)
-    separator=" "                    # 解析日志，数据所在行的分隔符(必填)
 
-    model_mode=0                     # 解析日志，s/step -> samples/s (必填)
+    skip_steps=2                    # 解析日志，有些模型前几个step耗时长，需要跳过(必填)
+    keyword="json_stats:"           # 解析日志，筛选出数据所在行的关键字(必填)
+    separator=""                    # 解析日志，数据所在行的分隔符(必填)
+    model_mode=0                    # 解析日志，s/step -> samples/s (必填)
+    position=-1                     # 解析日志，需要提取的数据所在的位置，-1表示是最后一个
     range=-1
+
     device=${CUDA_VISIBLE_DEVICES//,/ }
     arr=($device)
     num_gpu_devices=${#arr[*]}
 
-    log_file=${run_log_path}/${model_name}_${index}_${num_gpu_devices}_${run_mode}
+    if [[ ${index} = "analysis" ]]; then
+        log_file=${run_log_path}/${model_name}_speed_${num_gpu_devices}_${run_mode}
+    else
+        log_file=${run_log_path}/${model_name}_${index}_${num_gpu_devices}_${run_mode}
+    fi
     log_parse_file=${log_file}
 
 }
@@ -40,19 +46,15 @@ function _train(){
         cp -f ${WORK_ROOT}/Detectron/detectron/utils/env.py ${WORK_ROOT}/Detectron-Cascade-RCNN/detectron/utils/env.py
         DETECTRON_REPO_NAME=Detectron-Cascade-RCNN
         train_cmd="--cfg configs/e2e_cascade_rcnn_R-50-FPN_1x.yaml OUTPUT_DIR ./output"
-        position=64
     elif [[ ${model_name} = "mask_rcnn_fpn_resnet" ]]; then
         DETECTRON_REPO_NAME=Detectron
         train_cmd="--cfg configs/e2e_mask_rcnn_R-101-FPN_1x.yaml OUTPUT_DIR ./output"
-        position=42
     elif [[ ${model_name} = "mask_rcnn_fpn_resnext" ]];then
         DETECTRON_REPO_NAME=Detectron
-        train_cmd="--cfg configs/12_2017_baselines/e2e_mask_rcnn_X-101-64x4d-FPN_1x.yaml OUTPUT_DIR ./output"
-        position=44
+        train_cmd="--cfg configs/e2e_mask_rcnn_X-101-64x4d-FPN_1x.yaml OUTPUT_DIR ./output"
     elif [[ ${model_name} = "retinanet_rcnn_fpn" ]];then
         DETECTRON_REPO_NAME=Detectron
-        train_cmd="--cfg configs/12_2017_baselines/retinanet_R-50-FPN_1x.yaml OUTPUT_DIR ./output"
-        position=38
+        train_cmd="--cfg configs/retinanet_R-50-FPN_1x.yaml OUTPUT_DIR ./output"
     else
         echo "model_name must be mask_rcnn_fpn_resnet | mask_rcnn_fpn_resnext | retinanet_rcnn_fpn | cascade_fpn_rcnn"
         exit 1


### PR DESCRIPTION
#233 没有验证所有的检测模型。这个PR对他们进行了验证，4个检测模型的解析结果如下：

- Cascade-RCNN
```
+ python /work/benchmark/scripts/analysis.py --filename /work/benchmark/static_graph/Detection/pytorch/cascade_fpn_rcnn_speed_1_sp --keyword json_stats: --separator '' --position -1 --base_batch_size 2 --skip_steps 2 --model_mode 0 --model_name cascade_fpn_rcnn --run_mode sp --index analysis --gpu_num 1 --range -1
Extract 76 records: separator=; position=-1
average latency of 76 steps, skip 0 step:
	Avg: 0.389 s/step
	FPS: 5.140 samples/s
average latency of 76 steps, skip 2 steps:
	Avg: 0.237 s/step
	Min: 0.234 s/step
	Max: 0.263 s/step
	FPS: 8.424 samples/s
FINAL_RESULT=8.424
{"index": "analysis", "log_file": "/work/benchmark/static_graph/Detection/pytorch/cascade_fpn_rcnn_speed_1_sp", "gpu_num": 1, "model_name": "cascade_fpn_rcnn", "run_mode": "sp"}
```

- Mask-RCNN_FPN_ResNet
```
+ python /work/benchmark/scripts/analysis.py --filename /work/benchmark/static_graph/Detection/pytorch/mask_rcnn_fpn_resnet_speed_1_sp --keyword json_stats: --separator '' --position -1 --base_batch_size 2 --skip_steps 2 --model_mode 0 --model_name mask_rcnn_fpn_resnet --run_mode sp --index analysis --gpu_num 1 --range -1
Extract 47 records: separator=; position=-1
average latency of 47 steps, skip 0 step:
	Avg: 0.608 s/step
	FPS: 3.288 samples/s
average latency of 47 steps, skip 2 steps:
	Avg: 0.334 s/step
	Min: 0.327 s/step
	Max: 0.344 s/step
	FPS: 5.992 samples/s
FINAL_RESULT=5.992
{"index": "analysis", "log_file": "/work/benchmark/static_graph/Detection/pytorch/mask_rcnn_fpn_resnet_speed_1_sp", "gpu_num": 1, "model_name": "mask_rcnn_fpn_resnet", "run_mode": "sp"}
```

- Mask-RCNN_FPN_ResNeXt
```
+ python /work/benchmark/scripts/analysis.py --filename /work/benchmark/static_graph/Detection/pytorch/mask_rcnn_fpn_resnext_speed_1_sp --keyword json_stats: --separator '' --position -1 --base_batch_size 2 --skip_steps 2 --model_mode 0 --model_name mask_rcnn_fpn_resnext --run_mode sp --index speed --gpu_num 1 --range -1
Extract 17 records: separator=; position=-1
average latency of 17 steps, skip 0 step:
	Avg: 1.390 s/step
	FPS: 1.439 samples/s
average latency of 17 steps, skip 2 steps:
	Avg: 0.743 s/step
	Min: 0.699 s/step
	Max: 0.753 s/step
	FPS: 2.691 samples/s
FINAL_RESULT=2.691
{"index": "speed", "log_file": "/work/benchmark/static_graph/Detection/pytorch/mask_rcnn_fpn_resnext_speed_1_sp", "gpu_num": 1, "model_name": "mask_rcnn_fpn_resnext", "run_mode": "sp"}
```

- RetinaNet-RCNN_FPN
```
+ python /work/benchmark/scripts/analysis.py --filename /work/benchmark/static_graph/Detection/pytorch/retinanet_rcnn_fpn_speed_1_sp --keyword json_stats: --separator '' --position -1 --base_batch_size 2 --skip_steps 2 --model_mode 0 --model_name retinanet_rcnn_fpn --run_mode sp --index speed --gpu_num 1 --range -1
Extract 75 records: separator=; position=-1
average latency of 75 steps, skip 0 step:
	Avg: 0.393 s/step
	FPS: 5.087 samples/s
average latency of 75 steps, skip 2 steps:
	Avg: 0.236 s/step
	Min: 0.236 s/step
	Max: 0.238 s/step
	FPS: 8.462 samples/s
FINAL_RESULT=8.462
{"index": "speed", "log_file": "/work/benchmark/static_graph/Detection/pytorch/retinanet_rcnn_fpn_speed_1_sp", "gpu_num": 1, "model_name": "retinanet_rcnn_fpn", "run_mode": "sp"}
```