### PR TITLE
update_for_detection

### DIFF
--- a/scripts/auto_run_paddle.sh
+++ b/scripts/auto_run_paddle.sh
@@ -452,7 +452,7 @@ image_classification(){
 
 #run_detection
 detection(){
-    cur_model_path=${BENCHMARK_ROOT}/models/PaddleCV/PaddleDetection
+    cur_model_path=${BENCHMARK_ROOT}/PaddleDetection
     cd ${cur_model_path}
     # Prepare data
     ln -s ${data_path}/COCO17/annotations ${cur_model_path}/dataset/coco/annotations


### PR DESCRIPTION
 + PaddleDetection变更为与models平级的子库后，更新benchmark auto_run中detection的对应路径