### PR TITLE
Add accuracy benchmark between paddle and tensorflow API

### DIFF
--- a/api/accuracy/assign.py
+++ b/api/accuracy/assign.py
@@ -1,0 +1,69 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+os.environ["FLAGS_fraction_of_gpu_memory_to_use"] = "0.01"
+
+import paddle.fluid as fluid
+import tensorflow as tf
+import numpy as np
+
+from args import parse_args
+from abs import feed_random_data, run_and_check
+
+import sys
+sys.path.append("..")
+from common import paddle_api_benchmark as paddle_api
+from common import tensorflow_api_benchmark as tensorflow_api
+from common import utils
+      
+class PaddleAssign(paddle_api.PaddleAPIBenchmarkBase):
+    def build_program(self, backward=False):
+        self.name = "assign"
+        with fluid.program_guard(self.main_program, self.startup_program):
+            data = fluid.data(
+                name='data', shape=[10, 10, 100, 100], dtype='float32', lod_level=0)
+            data.stop_gradient = False
+            result = fluid.layers.assign(data)
+
+            self.feed_vars = [data]
+            self.fetch_vars = [result]
+            if backward:
+                self.append_gradients(result, [data])
+
+
+class TensorflowAssign(tensorflow_api.TensorflowAPIBenchmarkBase):
+    def build_graph(self, backward=False):
+        self.name = "assign"
+        self.allow_growth = True
+
+        data = tf.placeholder(name='data', shape=[10, 10, 100, 100], dtype=tf.float32)
+        ref = tf.Variable(tf.zeros([10, 10,100,100]), name='target', dtype=tf.float32)
+        assigns=tf.assign(ref, data)
+
+        self.feed_list = [data]
+        self.fetch_list = [assigns]
+        if backward:
+            self.append_gradients(assigns, [data])
+
+def main(backward, use_gpu):
+    pd_obj = PaddleAssign()
+    tf_obj = TensorflowAssign()
+    run_and_check(pd_obj, tf_obj, backward, use_gpu, name="assign")
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(backward=args.backward, use_gpu=args.use_gpu)

--- a/api/accuracy/cast.py
+++ b/api/accuracy/cast.py
@@ -1,0 +1,102 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+os.environ["FLAGS_fraction_of_gpu_memory_to_use"] = "0.01"
+
+import paddle.fluid as fluid
+import tensorflow as tf
+import numpy as np
+
+from args import parse_args
+
+import sys
+sys.path.append("..")
+from common import paddle_api_benchmark as paddle_api
+from common import tensorflow_api_benchmark as tensorflow_api
+from common import utils
+      
+class PaddleCast(paddle_api.PaddleAPIBenchmarkBase):
+    def build_program(self, backward=False):
+        self.name = "cast"
+        with fluid.program_guard(self.main_program, self.startup_program):
+            data = fluid.data(
+                name='data', shape=[10, 10, 100, 100], dtype='float32', lod_level=0)
+            data.stop_gradient = False
+            result = fluid.layers.cast(data, dtype="uint8")
+
+            self.feed_vars = [data]
+            self.fetch_vars = [result]
+            if backward:
+                self.append_gradients(result, [data])
+
+
+class TensorflowCast(tensorflow_api.TensorflowAPIBenchmarkBase):
+    def build_graph(self, backward=False):
+        self.name = "cast"
+        self.allow_growth = True
+
+        data = tf.placeholder(name='data', shape=[10, 10, 100, 100], dtype=tf.float32)
+        result = tf.cast(data, dtype="uint8")
+
+        self.feed_list = [data]
+        self.fetch_list = [result]
+        if backward:
+            self.append_gradients(result, [data])
+
+
+def feed_random_data(pd_obj, tf_obj):
+    assert len(pd_obj.feed_vars) == len(tf_obj.feed_list)
+
+    pd_feed = {}
+    tf_feed = {}
+    for i in xrange(len(pd_obj.feed_vars)):
+        pd_var = pd_obj.feed_vars[i]
+        tf_var = tf_obj.feed_list[i]
+
+        assert pd_var.shape == tf_var.shape
+        assert pd_obj.convert_dtype(pd_var.dtype) == tf_obj.convert_dtype(tf_var.dtype)
+        data = np.random.random(pd_var.shape).astype(pd_obj.convert_dtype(pd_var.dtype))
+
+        pd_feed[pd_var.name] = data
+        tf_feed[tf_var] = data
+    return pd_feed, tf_feed
+
+def run_and_check(pd_obj, tf_obj, backward, use_gpu, name):
+    # Define Paddle program
+    pd_obj.build_program(backward=backward)
+
+    # Define Tensorflow graph
+    tf_obj.build_graph(backward=backward)
+
+    pd_feed, tf_feed = feed_random_data(pd_obj, tf_obj)
+
+    # Run Paddle
+    pd_outputs = pd_obj.run_with_executor(use_gpu=use_gpu, feed=pd_feed, check_output=False)
+
+    # Run Tensorflow
+    tf_outputs = tf_obj.run(use_gpu=use_gpu, feed=tf_feed, check_output=False)
+
+    utils.check_outputs(pd_outputs, tf_outputs, name=name)
+
+def main(backward, use_gpu):
+    pd_obj = PaddleCast()
+    tf_obj = TensorflowCast()
+    run_and_check(pd_obj, tf_obj, backward, use_gpu, name="cast")
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(backward=args.backward, use_gpu=args.use_gpu)

--- a/api/accuracy/concat.py
+++ b/api/accuracy/concat.py
@@ -1,0 +1,106 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+os.environ["FLAGS_fraction_of_gpu_memory_to_use"] = "0.01"
+
+import paddle.fluid as fluid
+import tensorflow as tf
+import numpy as np
+
+from args import parse_args
+
+import sys
+sys.path.append("..")
+from common import paddle_api_benchmark as paddle_api
+from common import tensorflow_api_benchmark as tensorflow_api
+from common import utils
+      
+class PaddleConcat(paddle_api.PaddleAPIBenchmarkBase):
+    def build_program(self, backward=False):
+        self.name = "concat"
+        with fluid.program_guard(self.main_program, self.startup_program):
+            data1 = fluid.data(
+                name='data1', shape=[100, 200], dtype='float32', lod_level=0)
+            data2 = fluid.data(
+                name='data2', shape=[100, 200], dtype='float32', lod_level=0)
+            data1.stop_gradient = False
+            data2.stop_gradient = False
+            result = fluid.layers.concat([data1, data2], axis=0)
+
+            self.feed_vars = [data1, data2]
+            self.fetch_vars = [result]
+            if backward:
+                self.append_gradients(result, [data1, data2])
+
+
+class TensorflowConcat(tensorflow_api.TensorflowAPIBenchmarkBase):
+    def build_graph(self, backward=False):
+        self.name = "concat"
+        self.allow_growth = True
+
+        data1 = tf.placeholder(name='data1', shape=[100, 200], dtype=tf.float32)
+        data2 = tf.placeholder(name='data2', shape=[100, 200], dtype=tf.float32)
+        result = tf.concat([data1, data2], 0)
+
+        self.feed_list = [data1, data2]
+        self.fetch_list = [result]
+        if backward:
+            self.append_gradients(result, [data1, data2])
+
+
+def feed_random_data(pd_obj, tf_obj):
+    assert len(pd_obj.feed_vars) == len(tf_obj.feed_list)
+
+    pd_feed = {}
+    tf_feed = {}
+    for i in xrange(len(pd_obj.feed_vars)):
+        pd_var = pd_obj.feed_vars[i]
+        tf_var = tf_obj.feed_list[i]
+
+        assert pd_var.shape == tf_var.shape
+        assert pd_obj.convert_dtype(pd_var.dtype) == tf_obj.convert_dtype(tf_var.dtype)
+        data = np.random.random(pd_var.shape).astype(pd_obj.convert_dtype(pd_var.dtype))
+
+        pd_feed[pd_var.name] = data
+        tf_feed[tf_var] = data
+    return pd_feed, tf_feed
+
+def run_and_check(pd_obj, tf_obj, backward, use_gpu, name):
+    # Define Paddle program
+    pd_obj.build_program(backward=backward)
+
+    # Define Tensorflow graph
+    tf_obj.build_graph(backward=backward)
+
+    pd_feed, tf_feed = feed_random_data(pd_obj, tf_obj)
+
+    # Run Paddle
+    pd_outputs = pd_obj.run_with_executor(use_gpu=use_gpu, feed=pd_feed, check_output=False)
+
+    # Run Tensorflow
+    tf_outputs = tf_obj.run(use_gpu=use_gpu, feed=tf_feed, check_output=False)
+
+    utils.check_outputs(pd_outputs, tf_outputs, name=name)
+
+def main(backward, use_gpu):
+    pd_obj = PaddleConcat()
+    tf_obj = TensorflowConcat()
+    run_and_check(pd_obj, tf_obj, backward, use_gpu, name="concat")
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(backward=args.backward, use_gpu=args.use_gpu)

--- a/api/accuracy/elementwise_mul.py
+++ b/api/accuracy/elementwise_mul.py
@@ -1,0 +1,76 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+os.environ["FLAGS_fraction_of_gpu_memory_to_use"] = "0.01"
+
+import paddle.fluid as fluid
+import tensorflow as tf
+import numpy as np
+
+from args import parse_args
+from abs import feed_random_data, run_and_check
+
+import sys
+sys.path.append("..")
+from common import paddle_api_benchmark as paddle_api
+from common import tensorflow_api_benchmark as tensorflow_api
+from common import utils
+      
+class PaddleElementwiseMul(paddle_api.PaddleAPIBenchmarkBase):
+    def build_program(self, backward=False):
+        self.name = "elementwise_mul"
+        with fluid.program_guard(self.main_program, self.startup_program):
+            x = fluid.data(
+                name='x', shape=[1, 32, 10, 768], dtype='float32', lod_level=0)
+            y = fluid.data(
+                name='y', shape=[10, 768], dtype='float32', lod_level=0)
+            x.stop_gradient = False
+            y.stop_gradient = False
+            result = fluid.layers.elementwise_mul(x=x,
+                                                  y=y,
+                                                  axis=-1,
+                                                  act=None)
+
+            self.feed_vars = [x, y]
+            self.fetch_vars = [result]
+            if backward:
+                self.append_gradients(result, [x, y])
+
+
+class TensorflowElementwiseMul(tensorflow_api.TensorflowAPIBenchmarkBase):
+    def build_graph(self, backward=False):
+        self.name = "elementwise_mul"
+        self.allow_growth = True
+
+        x = tf.placeholder(name='x', shape=[1, 32, 10, 768], dtype=tf.float32)
+        y = tf.placeholder(name='y', shape=[10, 768], dtype=tf.float32)
+        result = tf.multiply(x=x, y=y)
+
+        self.feed_list = [x, y]
+        self.fetch_list = [result]
+        if backward:
+            self.append_gradients(result, [x, y])
+
+
+def main(backward, use_gpu):
+    pd_obj = PaddleElementwiseMul()
+    tf_obj = TensorflowElementwiseMul()
+    run_and_check(pd_obj, tf_obj, backward, use_gpu, name="elementwise_mul")
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(backward=args.backward, use_gpu=args.use_gpu)

--- a/api/accuracy/fc.py
+++ b/api/accuracy/fc.py
@@ -1,0 +1,120 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+os.environ["FLAGS_fraction_of_gpu_memory_to_use"] = "0.01"
+
+import paddle.fluid as fluid
+import tensorflow as tf
+import numpy as np
+
+from args import parse_args
+from abs import feed_random_data, run_and_check
+
+import sys
+sys.path.append("..")
+from common import paddle_api_benchmark as paddle_api
+from common import tensorflow_api_benchmark as tensorflow_api
+from common import utils
+      
+class PaddleFC(paddle_api.PaddleAPIBenchmarkBase):
+    def build_program(self, backward=False):
+        self.name = "fc"
+        with fluid.program_guard(self.main_program, self.startup_program):
+            data = fluid.data(
+                name='data', shape=[32,32], dtype='float32', lod_level=0)
+            data.stop_gradient = False
+            #w = fluid.layers.create_parameter(
+            #    shape=[32, 1000], dtype='float32', name='filters')
+            w_param_attrs = fluid.ParamAttr(name="fc_weight",
+                                initializer=fluid.initializer.ConstantInitializer(0.5),
+                                learning_rate=1,
+                                trainable=True)
+            b_param_attrs = fluid.ParamAttr(name="fc_bias",
+                                initializer=fluid.initializer.ConstantInitializer(0.1),
+                                learning_rate=1,
+                                trainable=True)
+            result = fluid.layers.fc(input=data, size=1000, act='tanh', param_attr=w_param_attrs,
+                                     bias_attr=b_param_attrs)
+
+            self.feed_vars = [data]
+            self.fetch_vars = [result]
+            if backward:
+                self.append_gradients(result, [data])
+
+
+class TensorflowFC(tensorflow_api.TensorflowAPIBenchmarkBase):
+    def build_graph(self, backward=False):
+        self.name = "fully_connected"
+        self.allow_growth = True
+
+        data = tf.placeholder(name='data', shape=[32,32], dtype=tf.float32)
+        #w = tf.placeholder(name='w', shape=[1000, 32], dtype=tf.float32)
+
+        result = tf.contrib.layers.fully_connected(inputs=data, num_outputs=1000, activation_fn=tf.nn.tanh,
+                                                   weights_initializer=tf.constant_initializer(0.5),
+                                                   biases_initializer=tf.constant_initializer(0.1))
+
+        self.feed_list = [data]
+        self.fetch_list = [result]
+        if backward:
+            self.append_gradients(result, [data])
+
+
+def feed_random_data(pd_obj, tf_obj):
+    assert len(pd_obj.feed_vars) == len(tf_obj.feed_list)
+
+    pd_feed = {}
+    tf_feed = {}
+    for i in xrange(len(pd_obj.feed_vars)):
+        pd_var = pd_obj.feed_vars[i]
+        tf_var = tf_obj.feed_list[i]
+
+        assert pd_var.shape == tf_var.shape
+        assert pd_obj.convert_dtype(pd_var.dtype) == tf_obj.convert_dtype(tf_var.dtype)
+        data = np.random.random(pd_var.shape).astype(pd_obj.convert_dtype(pd_var.dtype))
+
+        pd_feed[pd_var.name] = data
+        tf_feed[tf_var] = data
+    return pd_feed, tf_feed
+
+def run_and_check(pd_obj, tf_obj, backward, use_gpu, name):
+    # Define Paddle program
+    pd_obj.build_program(backward=backward)
+
+    # Define Tensorflow graph
+    tf_obj.build_graph(backward=backward)
+
+    pd_feed, tf_feed = feed_random_data(pd_obj, tf_obj)
+
+    # Run Paddle
+    pd_outputs = pd_obj.run_with_executor(use_gpu=use_gpu, feed=pd_feed, check_output=False)
+
+    # Run Tensorflow
+    tf_outputs = tf_obj.run(use_gpu=use_gpu, feed=tf_feed, check_output=False)
+
+    utils.check_outputs(pd_outputs, tf_outputs, name=name)
+
+def main(backward, use_gpu):
+    pd_obj = PaddleFC()
+    tf_obj = TensorflowFC()
+
+
+    run_and_check(pd_obj, tf_obj, backward, use_gpu, name="fc")
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(backward=args.backward, use_gpu=args.use_gpu)

--- a/api/accuracy/pool2d.py
+++ b/api/accuracy/pool2d.py
@@ -1,0 +1,103 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+os.environ["FLAGS_fraction_of_gpu_memory_to_use"] = "0.01"
+
+import paddle.fluid as fluid
+import tensorflow as tf
+import numpy as np
+
+from args import parse_args
+
+import sys
+sys.path.append("..")
+from common import paddle_api_benchmark as paddle_api
+from common import tensorflow_api_benchmark as tensorflow_api
+from common import utils
+      
+class PaddlePool2d(paddle_api.PaddleAPIBenchmarkBase):
+    def build_program(self, backward=False):
+        self.name = "pool2d"
+        with fluid.program_guard(self.main_program, self.startup_program):
+            data = fluid.data(
+                name='data', shape=[10, 10, 100, 100], dtype='float32', lod_level=0)
+            data.stop_gradient = False
+            result = fluid.layers.pool2d(data, pool_size=[3,3],pool_type='avg', pool_stride=[3,3],
+                                          pool_padding="SAME",data_format="NCHW")
+
+            self.feed_vars = [data]
+            self.fetch_vars = [result]
+            if backward:
+                self.append_gradients(result, [data])
+
+
+class TensorflowPool2d(tensorflow_api.TensorflowAPIBenchmarkBase):
+    def build_graph(self, backward=False):
+        self.name = "pool"
+        self.allow_growth = True
+
+        data = tf.placeholder(name='data', shape=[10, 10, 100, 100], dtype=tf.float32)
+        result = tf.nn.pool(data, window_shape=[3, 3], pooling_type="AVG", strides=[3, 3], padding="SAME", data_format="NCHW")
+
+        self.feed_list = [data]
+        self.fetch_list = [result]
+        if backward:
+            self.append_gradients(result, [data])
+
+
+def feed_random_data(pd_obj, tf_obj):
+    assert len(pd_obj.feed_vars) == len(tf_obj.feed_list)
+
+    pd_feed = {}
+    tf_feed = {}
+    for i in xrange(len(pd_obj.feed_vars)):
+        pd_var = pd_obj.feed_vars[i]
+        tf_var = tf_obj.feed_list[i]
+
+        assert pd_var.shape == tf_var.shape
+        assert pd_obj.convert_dtype(pd_var.dtype) == tf_obj.convert_dtype(tf_var.dtype)
+        data = np.random.random(pd_var.shape).astype(pd_obj.convert_dtype(pd_var.dtype))
+
+        pd_feed[pd_var.name] = data
+        tf_feed[tf_var] = data
+    return pd_feed, tf_feed
+
+def run_and_check(pd_obj, tf_obj, backward, use_gpu, name):
+    # Define Paddle program
+    pd_obj.build_program(backward=backward)
+
+    # Define Tensorflow graph
+    tf_obj.build_graph(backward=backward)
+
+    pd_feed, tf_feed = feed_random_data(pd_obj, tf_obj)
+
+    # Run Paddle
+    pd_outputs = pd_obj.run_with_executor(use_gpu=use_gpu, feed=pd_feed, check_output=False)
+
+    # Run Tensorflow
+    tf_outputs = tf_obj.run(use_gpu=use_gpu, feed=tf_feed, check_output=False)
+
+    utils.check_outputs(pd_outputs, tf_outputs, name=name)
+
+def main(backward, use_gpu):
+    pd_obj = PaddlePool2d()
+    tf_obj = TensorflowPool2d()
+    run_and_check(pd_obj, tf_obj, backward, use_gpu, name="pool2d")
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(backward=args.backward, use_gpu=args.use_gpu)

--- a/api/accuracy/reshape.py
+++ b/api/accuracy/reshape.py
@@ -1,0 +1,104 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+os.environ["FLAGS_fraction_of_gpu_memory_to_use"] = "0.01"
+
+import paddle.fluid as fluid
+import tensorflow as tf
+import numpy as np
+
+from args import parse_args
+
+import sys
+sys.path.append("..")
+from common import paddle_api_benchmark as paddle_api
+from common import tensorflow_api_benchmark as tensorflow_api
+from common import utils
+      
+class PaddleReshape(paddle_api.PaddleAPIBenchmarkBase):
+    def build_program(self, backward=False):
+        self.name = "reshape"
+        with fluid.program_guard(self.main_program, self.startup_program):
+            data = fluid.data(
+                name='data', shape=[10, 32, 8, 1024], dtype='float32', lod_level=0)
+            data.stop_gradient = False
+            rshape=[10, 32, 32, 256]
+            result = fluid.layers.reshape(x=data, shape=rshape)
+
+            self.feed_vars = [data]
+            self.fetch_vars = [result]
+            if backward:
+                self.append_gradients(result, [data])
+
+
+class TensorflowReshape(tensorflow_api.TensorflowAPIBenchmarkBase):
+    def build_graph(self, backward=False):
+        self.name = "reshape"
+        self.allow_growth = True
+
+        data = tf.placeholder(name='data', shape=[10, 32, 8, 1024], dtype=tf.float32)
+        rshape=[10, 32, 32, 256]
+        result = tf.reshape(tensor=data, shape=rshape)
+
+        self.feed_list = [data]
+        self.fetch_list = [result]
+        if backward:
+            self.append_gradients(result, [data])
+
+
+def feed_random_data(pd_obj, tf_obj):
+    assert len(pd_obj.feed_vars) == len(tf_obj.feed_list)
+
+    pd_feed = {}
+    tf_feed = {}
+    for i in xrange(len(pd_obj.feed_vars)):
+        pd_var = pd_obj.feed_vars[i]
+        tf_var = tf_obj.feed_list[i]
+
+        assert pd_var.shape == tf_var.shape
+        assert pd_obj.convert_dtype(pd_var.dtype) == tf_obj.convert_dtype(tf_var.dtype)
+        data = np.random.random(pd_var.shape).astype(pd_obj.convert_dtype(pd_var.dtype))
+
+        pd_feed[pd_var.name] = data
+        tf_feed[tf_var] = data
+    return pd_feed, tf_feed
+
+def run_and_check(pd_obj, tf_obj, backward, use_gpu, name):
+    # Define Paddle program
+    pd_obj.build_program(backward=backward)
+
+    # Define Tensorflow graph
+    tf_obj.build_graph(backward=backward)
+
+    pd_feed, tf_feed = feed_random_data(pd_obj, tf_obj)
+
+    # Run Paddle
+    pd_outputs = pd_obj.run_with_executor(use_gpu=use_gpu, feed=pd_feed, check_output=False)
+
+    # Run Tensorflow
+    tf_outputs = tf_obj.run(use_gpu=use_gpu, feed=tf_feed, check_output=False)
+
+    utils.check_outputs(pd_outputs, tf_outputs, name=name)
+
+def main(backward, use_gpu):
+    pd_obj = PaddleReshape()
+    tf_obj = TensorflowReshape()
+    run_and_check(pd_obj, tf_obj, backward, use_gpu, name="reshape")
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(backward=args.backward, use_gpu=args.use_gpu)

--- a/api/accuracy/softmax.py
+++ b/api/accuracy/softmax.py
@@ -1,0 +1,68 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+os.environ["FLAGS_fraction_of_gpu_memory_to_use"] = "0.01"
+
+import paddle.fluid as fluid
+import tensorflow as tf
+import numpy as np
+
+from args import parse_args
+from abs import feed_random_data, run_and_check
+
+import sys
+sys.path.append("..")
+from common import paddle_api_benchmark as paddle_api
+from common import tensorflow_api_benchmark as tensorflow_api
+from common import utils
+      
+class PaddleSoftmax(paddle_api.PaddleAPIBenchmarkBase):
+    def build_program(self, backward=False):
+        self.name = "softmax"
+        with fluid.program_guard(self.main_program, self.startup_program):
+            data = fluid.data(
+                name='data', shape=[10, 10, 100, 100], dtype='float32', lod_level=0)
+            data.stop_gradient = False
+            result = fluid.layers.softmax(data)
+
+            self.feed_vars = [data]
+            self.fetch_vars = [result]
+            if backward:
+                self.append_gradients(result, [data])
+
+
+class TensorflowSoftmax(tensorflow_api.TensorflowAPIBenchmarkBase):
+    def build_graph(self, backward=False):
+        self.name = "softmax"
+        self.allow_growth = True
+
+        data = tf.placeholder(name='data', shape=[10, 10, 100, 100], dtype=tf.float32)
+        result = tf.nn.softmax(data)
+
+        self.feed_list = [data]
+        self.fetch_list = [result]
+        if backward:
+            self.append_gradients(result, [data])
+
+def main(backward, use_gpu):
+    pd_obj = PaddleSoftmax()
+    tf_obj = TensorflowSoftmax()
+    run_and_check(pd_obj, tf_obj, backward, use_gpu, name="softmax")
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(backward=args.backward, use_gpu=args.use_gpu)

--- a/api/accuracy/softmax_with_cross_entropy.py
+++ b/api/accuracy/softmax_with_cross_entropy.py
@@ -1,0 +1,105 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+os.environ["FLAGS_fraction_of_gpu_memory_to_use"] = "0.01"
+
+import paddle.fluid as fluid
+import tensorflow as tf
+import numpy as np
+
+from args import parse_args
+
+import sys
+sys.path.append("..")
+from common import paddle_api_benchmark as paddle_api
+from common import tensorflow_api_benchmark as tensorflow_api
+from common import utils
+      
+class PaddleSoftmaxWithCrossEntropy(paddle_api.PaddleAPIBenchmarkBase):
+    def build_program(self, backward=False):
+        self.name = "softmax_with_cross_entropy"
+        with fluid.program_guard(self.main_program, self.startup_program):
+            data = fluid.data(
+                name='data', shape=[128, 100], dtype='float32', lod_level=0)
+            label = fluid.data(name="label", shape=[128, 1], dtype="int64")
+            
+            data.stop_gradient = False
+            label.stop_gradient = False
+            result = fluid.layers.softmax_with_cross_entropy(data, label, soft_label=False)
+
+            self.feed_vars = [data, label]
+            self.fetch_vars = [result]
+            if backward:
+                self.append_gradients(result, [data])
+
+class TensorflowSoftmaxWithCrossEntropy(tensorflow_api.TensorflowAPIBenchmarkBase):
+    def build_graph(self, backward=False):
+        self.name = "softmax_with_cross_entropy"
+        self.allow_growth = True
+
+        data = tf.placeholder(name='data', shape=[128, 100], dtype=tf.float32)
+        label = tf.placeholder(name='label', shape=[128, 1], dtype=tf.float32)
+
+        result = tf.nn.softmax_cross_entropy_with_logits(labels=label, logits=data)
+
+        self.feed_list = [data, label]
+        self.fetch_list = [result]
+        if backward:
+            self.append_gradients(result, [data])
+
+
+def feed_random_data(pd_obj, tf_obj):
+    assert len(pd_obj.feed_vars) == len(tf_obj.feed_list)
+
+    pd_feed = {}
+    tf_feed = {}
+    for i in xrange(len(pd_obj.feed_vars)):
+        pd_var = pd_obj.feed_vars[i]
+        tf_var = tf_obj.feed_list[i]
+
+        assert pd_var.shape == tf_var.shape
+        data = np.random.random(pd_var.shape).astype(pd_obj.convert_dtype(pd_var.dtype))
+
+        pd_feed[pd_var.name] = data
+        tf_feed[tf_var] = data
+    return pd_feed, tf_feed
+
+def run_and_check(pd_obj, tf_obj, backward, use_gpu, name):
+    # Define Paddle program
+    pd_obj.build_program(backward=backward)
+
+    # Define Tensorflow graph
+    tf_obj.build_graph(backward=backward)
+
+    pd_feed, tf_feed = feed_random_data(pd_obj, tf_obj)
+
+    # Run Paddle
+    pd_outputs = pd_obj.run_with_executor(use_gpu=use_gpu, feed=pd_feed, check_output=False)
+
+    # Run Tensorflow
+    tf_outputs = tf_obj.run(use_gpu=use_gpu, feed=tf_feed, check_output=False)
+
+    utils.check_outputs(pd_outputs, tf_outputs, name=name)
+
+def main(backward, use_gpu):
+    pd_obj = PaddleSoftmaxWithCrossEntropy()
+    tf_obj = TensorflowSoftmaxWithCrossEntropy()
+    run_and_check(pd_obj, tf_obj, backward, use_gpu, name="softmax_with_cross_entropy")
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(backward=args.backward, use_gpu=args.use_gpu)


### PR DESCRIPTION
This PR benchmark accuracy between paddle and tensorflow API， including:
assign fc reshape concat pool2d cast softmax_with_cross_entropy softmax elementwise_mul