### PR TITLE
Add FLAGS_allocator_strategy=naive_best_fit to some models

### DIFF
--- a/static_graph/Mask-RCNN/paddle/run_benchmark.sh
+++ b/static_graph/Mask-RCNN/paddle/run_benchmark.sh
@@ -42,6 +42,7 @@ function _set_env(){
    export FLAGS_fraction_of_gpu_memory_to_use=0.98
    export FLAGS_memory_fraction_of_eager_deletion=1.0
    export FLAGS_conv_workspace_size_limit=500
+   export FLAGS_allocator_strategy=naive_best_fit
 }
 
 function _train(){

--- a/static_graph/Transformer/paddle/run_benchmark.sh
+++ b/static_graph/Transformer/paddle/run_benchmark.sh
@@ -42,6 +42,7 @@ function _set_env(){
     export FLAGS_fraction_of_gpu_memory_to_use=1.0
     export FLAGS_eager_delete_tensor_gb=0.0
     export FLAGS_memory_fraction_of_eager_deletion=0.99999
+    export FLAGS_allocator_strategy=naive_best_fit
 }
 
 function _train(){

--- a/static_graph/deeplabv3+/paddle/run_benchmark.sh
+++ b/static_graph/deeplabv3+/paddle/run_benchmark.sh
@@ -43,6 +43,7 @@ function _set_params(){
 function _set_env(){
    export FLAGS_eager_delete_tensor_gb=0.0
    export FLAGS_fast_eager_deletion_mode=1
+   export FLAGS_allocator_strategy=naive_best_fit
 }
 
 function _train(){


### PR DESCRIPTION
因易用性需要，Auto growth显存分配策略已于https://github.com/PaddlePaddle/Paddle/pull/21837 默认打开，但有个别模型会因此最大batch size会下降。经与Paddle core team讨论，在个别模型benchmark中打开naive_best_fit原策略。