### PR TITLE
remove init_on_cpu because it is not used

### DIFF
--- a/static_graph/OCR/paddle/ocr_recognition/crnn_ctc_model.py
+++ b/static_graph/OCR/paddle/ocr_recognition/crnn_ctc_model.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 import paddle.fluid as fluid
 from paddle.fluid.layers.learning_rate_scheduler import _decay_step_counter
-from paddle.fluid.initializer import init_on_cpu
 import math
 import six
 


### PR DESCRIPTION
`init_on_cpu` is imported but not used, so remove it.