### PR TITLE
Enable fusion_group for PaddingRNN

### DIFF
--- a/static_graph/PaddingRNN/lstm_paddle/run_benchmark.sh
+++ b/static_graph/PaddingRNN/lstm_paddle/run_benchmark.sh
@@ -55,6 +55,7 @@ function _set_env(){
 
 function _train(){
     echo "current CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES, gpus=$num_gpu_devices, batch_size=$batch_size"
+    python -c "import paddle; print(paddle.__version__)"
     train_cmd="--data_path data/simple-examples/data/ \
       --model_type $model_type \
       --use_gpu True \
@@ -62,6 +63,7 @@ function _train(){
       --max_epoch=${max_epoch} \
       --rnn_model ${rnn_type} \
       --use_dataloader True \
+      --enable_auto_fusion True \
       --profile ${is_profiler} \
       --profiler_path=${profiler_path} \
       --batch_size ${batch_size}"


### PR DESCRIPTION
https://github.com/PaddlePaddle/models/pull/4252 中，language_model添加了`enable_auto_fusion`参数，以打开fusion_group的功能。本PR在脚本中设置`--enable_auto_fusion=True`，以在Benchmark系统中打开fusion_group功能。

注意：Paddle中fusion_group功能没有cherry-pick的1.7分支中。