### PR TITLE
Disable fusion_group for PaddingRNN.

### DIFF
--- a/static_graph/PaddingRNN/lstm_paddle/run_benchmark.sh
+++ b/static_graph/PaddingRNN/lstm_paddle/run_benchmark.sh
@@ -63,7 +63,7 @@ function _train(){
       --max_epoch=${max_epoch} \
       --rnn_model ${rnn_type} \
       --use_dataloader True \
-      --enable_auto_fusion True \
+      --enable_auto_fusion False \
       --profile ${is_profiler} \
       --profiler_path=${profiler_path} \
       --batch_size ${batch_size}"


### PR DESCRIPTION
在Benchmark用的cuda10的docker环境里面，会出现找不到nvrtc库的错误、以及编译失败的问题，因此暂时先关闭fusion_group功能，等修复了再打开。