### PR TITLE
Add the performance test of elementwise_mul

### DIFF
--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -75,7 +75,7 @@ class PaddleAPIBenchmarkBase(object):
         executor.run(self.startup_program)
 
         if feed is None:
-            feed = self._feed_random_data(use_gpu, as_lodtensor=True)
+            feed = self._feed_random_data(use_gpu, as_lodtensor=False)
 
         runtimes = []
         fetches = []
@@ -198,8 +198,8 @@ class PaddleAPIBenchmarkBase(object):
         print("feed random data")
         feed = {}
         if use_gpu and as_lodtensor:
-            #place = fluid.CPUPlace()
-            place = fluid.CUDAPinnedPlace()
+            place = fluid.CPUPlace()
+            #place = fluid.CUDAPinnedPlace()
         for var in self.feed_vars:
             if var.type != fluid.core.VarDesc.VarType.LOD_TENSOR:
                 raise TypeError("Feed data of non LoDTensor is not supported.")

--- a/api/paddle/abs.py
+++ b/api/paddle/abs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from args import parse_args
+from main import parse_args, test_speed_main
 import paddle.fluid as fluid
 
 import sys
@@ -28,26 +28,10 @@ class abs(paddle_api.PaddleAPIBenchmarkBase):
             result = fluid.layers.abs(x=data)
 
             self.feed_vars = [data]
+            self.fetch_vars = [result]
             if backward:
-                gradients = fluid.backward.calc_gradient(result, [data])
-                self.fetch_vars = [result, gradients]
-            else:
-                self.fetch_vars = [result]
+                self.append_gradients(result, [data])
 
 
 if __name__ == '__main__':
-    args = parse_args()
-    obj = abs()
-    obj.build_program(backward=args.backward)
-    if args.run_with_executor:
-        obj.run_with_executor(use_gpu=args.use_gpu,
-                              repeat=args.repeat,
-                              log_level=args.log_level,
-                              check_output=args.check_output,
-                              profiler=args.profiler)
-    else:
-        obj.run_with_core_executor(use_gpu=args.use_gpu,
-                                   repeat=args.repeat,
-                                   log_level=args.log_level,
-                                   check_output=args.check_output,
-                                   profiler=args.profiler)
+    test_speed_main(abs())

--- a/api/paddle/elementwise_mul.py
+++ b/api/paddle/elementwise_mul.py
@@ -1,0 +1,40 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from main import parse_args, test_speed_main
+import paddle.fluid as fluid
+
+import sys
+sys.path.append("..")
+from common import paddle_api_benchmark as paddle_api
+
+class elementwise_mul(paddle_api.PaddleAPIBenchmarkBase):
+    def build_program(self, backward=False):
+        with fluid.program_guard(self.main_program, self.startup_program):
+            x = fluid.data(
+                name='x', shape=[50, 128, 1000], dtype='float32', lod_level=0)
+            y = fluid.data(
+                name='y', shape=[128, 1000], dtype='float32', lod_level=0)
+            x.stop_gradient = False
+            y.stop_gradient = False
+            result = fluid.layers.elementwise_mul(x, y)
+
+            self.feed_vars = [x, y]
+            self.fetch_vars = [result]
+            if backward:
+                self.append_gradients(result, [x, y])
+
+
+if __name__ == '__main__':
+    test_speed_main(elementwise_mul())

--- a/api/paddle/elementwise_mul.py
+++ b/api/paddle/elementwise_mul.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import parse_args, test_speed_main
+from main import test_speed_main
 import paddle.fluid as fluid
 
 import sys
@@ -25,7 +25,7 @@ class elementwise_mul(paddle_api.PaddleAPIBenchmarkBase):
             x = fluid.data(
                 name='x', shape=[50, 128, 1000], dtype='float32', lod_level=0)
             y = fluid.data(
-                name='y', shape=[128, 1000], dtype='float32', lod_level=0)
+                name='y', shape=[1, 128, 1000], dtype='float32', lod_level=0)
             x.stop_gradient = False
             y.stop_gradient = False
             result = fluid.layers.elementwise_mul(x, y)

--- a/api/paddle/main.py
+++ b/api/paddle/main.py
@@ -74,3 +74,19 @@ def parse_args():
         print("CUDA_VISIBLE_DEVICES is None, set to CUDA_VISIBLE_DEVICES={}".format(gpu_id))
         os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
     return args
+
+def test_speed_main(obj):
+    args = parse_args()
+    obj.build_program(backward=args.backward)
+    if args.run_with_executor:
+        obj.run_with_executor(use_gpu=args.use_gpu,
+                              repeat=args.repeat,
+                              log_level=args.log_level,
+                              check_output=args.check_output,
+                              profiler=args.profiler)
+    else:
+        obj.run_with_core_executor(use_gpu=args.use_gpu,
+                                   repeat=args.repeat,
+                                   log_level=args.log_level,
+                                   check_output=args.check_output,
+                                   profiler=args.profiler)

--- a/api/paddle/run.sh
+++ b/api/paddle/run.sh
@@ -5,7 +5,7 @@ export CUDA_VISIBLE_DEVICES="1"
 
 name=${1:-"abs"}
 
-nvprof python ${name}.py \
+python ${name}.py \
       --run_with_executor True \
       --check_output False \
       --profiler "none" \

--- a/api/paddle/run.sh
+++ b/api/paddle/run.sh
@@ -3,11 +3,13 @@
 export CUDA_VISIBLE_DEVICES="1"
 #export GLOG_v=4
 
-python abs.py \
+name=${1:-"abs"}
+
+nvprof python ${name}.py \
       --run_with_executor True \
       --check_output False \
       --profiler "none" \
-      --backward False \
+      --backward True \
       --use_gpu True \
-      --repeat 1000 \
+      --repeat 100 \
       --log_level 1

--- a/api/tensorflow/abs.py
+++ b/api/tensorflow/abs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from args import parse_args
+from main import test_speed_main
 import tensorflow as tf
 
 import sys
@@ -25,20 +25,10 @@ class abs(tensorflow_api.TensorflowAPIBenchmarkBase):
         result = tf.abs(x=data)
 
         self.feed_list = [data]
+        self.fetch_list = [result]
         if backward:
-            gradients = tf.gradients(result, [data])
-            self.fetch_list = [result, gradients[0]]
-        else:
-            self.fetch_list = [result]
+            self.append_gradients(result, [data])
 
 
 if __name__ == '__main__':
-    args = parse_args()
-    obj = abs()
-    obj.build_graph(backward=args.backward)
-    obj.run(use_gpu=args.use_gpu,
-            repeat=args.repeat,
-            log_level=args.log_level,
-            check_output=args.check_output,
-            profile=args.profile)
-    
+    test_speed_main(abs())

--- a/api/tensorflow/elementwise_mul.py
+++ b/api/tensorflow/elementwise_mul.py
@@ -13,25 +13,23 @@
 # limitations under the License.
 
 from main import test_speed_main
-import paddle.fluid as fluid
+import tensorflow as tf
 
 import sys
 sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
+from common import tensorflow_api_benchmark as tensorflow_api
 
-class abs(paddle_api.PaddleAPIBenchmarkBase):
-    def build_program(self, backward=False):
-        with fluid.program_guard(self.main_program, self.startup_program):
-            data = fluid.data(
-                name='data', shape=[10, 10, 100, 100], dtype='float32', lod_level=0)
-            data.stop_gradient = False
-            result = fluid.layers.abs(x=data)
+class elementwise_mul(tensorflow_api.TensorflowAPIBenchmarkBase):
+    def build_graph(self, backward=False):
+        x = tf.placeholder(name='x', shape=[50, 128, 1000], dtype=tf.float32)
+        y = tf.placeholder(name='y', shape=[1, 128, 1000], dtype=tf.float32)
+        result = tf.multiply(x, y)
 
-            self.feed_vars = [data]
-            self.fetch_vars = [result]
-            if backward:
-                self.append_gradients(result, [data])
+        self.feed_list = [x, y]
+        self.fetch_list = [result]
+        if backward:
+            self.append_gradients(result, [x, y])
 
 
 if __name__ == '__main__':
-    test_speed_main(abs())
+    test_speed_main(elementwise_mul())

--- a/api/tensorflow/main.py
+++ b/api/tensorflow/main.py
@@ -69,3 +69,12 @@ def parse_args():
         print("CUDA_VISIABLE_DEVICES is None, set to CUDA_VISIABLE_DEVICES={}".format(gpu_id))
         os.environ["CUDA_VISIABLE_DEVICES"] = str(gpu_id)
     return args
+
+def test_speed_main(obj):
+    args = parse_args()
+    obj.build_graph(backward=args.backward)
+    obj.run(use_gpu=args.use_gpu,
+            repeat=args.repeat,
+            log_level=args.log_level,
+            check_output=args.check_output,
+            profile=args.profile)

--- a/api/tensorflow/run.sh
+++ b/api/tensorflow/run.sh
@@ -4,10 +4,12 @@ set -xe
 
 export CUDA_VISIBLE_DEVICES="0"
 
-python abs.py \
+name=${1:-"abs"}
+
+nvprof python ${name}.py \
       --check_output False \
       --profile False \
-      --backward False \
+      --backward True \
       --use_gpu True \
       --gpu_id 0 \
       --repeat 100 \


### PR DESCRIPTION
elementwise_mul和grad在一些broadcast的情况，性能表现不正常。

### x的维度为[50, 128, 1000]，y的维度为[128, 1000]
- Paddle的profiler结果
```
Event                                Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::fetch                       300         2305.62     1204.518357 (0.522428)  1101.096985 (0.477572)  0.285183    45.8856     7.68538     0.97407
  GpuMemcpySync:GPU->CPU             300         2297.03     1195.933500 (0.520643)  1101.096985 (0.479357)  0.26762     45.848      7.65677     0.970443
thread0::elementwise_mul             100         23.7226     16.769691 (0.706907)    6.952947 (0.293093)     0.171141    4.42502     0.237226    0.0100223
thread0::elementwise_mul_grad        100         21.9666     5.858711 (0.266710)     16.107847 (0.733290)    0.202275    0.949005    0.219666    0.00928037
thread0::fill_constant               100         9.79861     6.807061 (0.694697)     2.991548 (0.305303)     0.077164    0.853258    0.0979861   0.00413969
thread0::shape                       100         3.63414     3.634142 (1.000000)     0.000000 (0.000000)     0.024594    0.35555     0.0363414   0.00153534
thread0::feed                        200         2.25312     2.253125 (1.000000)     0.000000 (0.000000)     0.00425     0.041404    0.0112656   0.000951894
```

- nvprof结果
```
==12816== Profiling application: python elementwise_mul.py --run_with_executor True --check_output False --profiler none --backward True --use_gpu True --repeat 100 --log_level 1
==12816== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   63.69%  1.01601s       300  3.3867ms  64.895us  22.704ms  [CUDA memcpy DtoH]
                   34.69%  553.35ms       203  2.7259ms  1.7920us  5.6226ms  [CUDA memcpy HtoD]
                    1.00%  15.957ms       100  159.57us  154.46us  165.66us  void paddle::operators::FastElemwiseGradBroadcast1CUDAKernel<float, paddle::operators::MulGradDX<float>, paddle::operators::MulGradDY<float>>(float const *, float const , float const , float const , int, int, bool, float, paddle::operators::MulGradDX<float>, paddle::operators::FastElemwiseGradBroadcast1CUDAKernel<float, paddle::operators::MulGradDX<float>, paddle::operators::MulGradDY<float>>*, paddle::operators::MulGradDX<float>)
                    0.44%  6.9460ms       100  69.460us  69.056us  70.368us  void thrust::cuda_cub::core::_kernel_agent<thrust::cuda_cub::__parallel_for::ParallelForAgent<thrust::cuda_cub::__transform::binary_transform_f<thrust::device_ptr<float const >, paddle::operators::RowwiseTransformIterator<float, paddle::platform::CUDADeviceContext>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::MulFunctor<float, void>, thrust::cuda_cub::__transform::always_true_predicate>, long>, thrust::cuda_cub::__transform::binary_transform_f<thrust::device_ptr<float const >, paddle::operators::RowwiseTransformIterator<float, paddle::platform::CUDADeviceContext>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::MulFunctor<float, void>, thrust::cuda_cub::__transform::always_true_predicate>, long>(thrust::device_ptr<float const >, float)
                    0.19%  2.9965ms       100  29.965us  29.440us  31.072us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                    0.00%  7.5200us         4  1.8800us  1.6960us  2.4320us  [CUDA memset]
      API calls:   42.32%  3.51827s         8  439.78ms  2.2020us  3.51788s  cudaStreamCreateWithFlags
                   20.11%  1.67203s       503  3.3241ms  17.302us  24.050ms  cudaMemcpy
                   15.93%  1.32419s         1  1.32419s  1.32419s  1.32419s  cudaStreamCreate
                   12.14%  1.00967s       406  2.4869ms  5.6870us  92.761ms  cuModuleUnload
                    9.21%  766.00ms         4  191.50ms     861ns  766.00ms  cudaFree
                    0.10%  8.2670ms       300  27.556us  11.805us  80.276us  cudaLaunchKernel
```

### x的维度为[50, 128, 1000]，y的维度为[1, 128, 1000]
- Paddle的profiler结果
```
Event                                Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::fetch                       300         3124.64     2082.841218 (0.666585)  1041.801211 (0.333415)  0.278865    62.1187     10.4155     0.74831
  GpuMemcpySync:GPU->CPU             300         3118.28     2076.478909 (0.665905)  1041.801211 (0.334095)  0.260588    62.0773     10.3943     0.746787
thread0::elementwise_mul_grad        100         986.426     15.685429 (0.015901)    970.740232 (0.984099)   9.66347     11.7238     9.86426     0.236236
  GpuMemcpyAsync:CPU->GPU            700         7.27964     6.039801 (0.829684)     1.239836 (0.170316)     0.008401    0.031365    0.0103995   0.00174338
thread0::elementwise_mul             100         49.7139     38.551686 (0.775471)    11.162240 (0.224529)    0.2414      23.5943     0.497139    0.0119058
  GpuMemcpyAsync:CPU->GPU            300         5.01273     4.485882 (0.894899)     0.526844 (0.105101)     0.009114    0.056394    0.0167091   0.00120048
thread0::fill_constant               100         9.72317     6.762663 (0.695521)     2.960505 (0.304479)     0.075553    0.968543    0.0972317   0.00232857
thread0::shape                       100         3.1957      3.195695 (1.000000)     0.000000 (0.000000)     0.024766    0.218068    0.031957    0.000765326
thread0::feed                        200         1.89678     1.896784 (1.000000)     0.000000 (0.000000)     0.004085    0.029974    0.00948392  0.000454255
```

- nvprof结果
```
==12721== Profiling application: python elementwise_mul.py --run_with_executor True --check_output False --profiler none --backward True --use_gpu True --repeat 100 --log_level 1
==12721== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   39.80%  1.01693s       300  3.3898ms  64.672us  22.061ms  [CUDA memcpy DtoH]
                   35.81%  914.82ms       100  9.1482ms  9.0331ms  10.475ms  void paddle::operators::CommonGradBroadcastCUDAKernel<float, paddle::operators::MulGradDX<float>>(int const *, int const , int const , int const , int const , float const *, float const , float const , float const , int const **, int, int, int, float)
                   21.95%  560.67ms      1203  466.06us  1.6960us  5.6681ms  [CUDA memcpy HtoD]
                    1.92%  49.027ms       100  490.27us  481.31us  568.41us  void paddle::operators::CommonGradBroadcastCUDAKernel<float, paddle::operators::MulGradDY<float>>(int const *, int const , int const , int const , int const , float const *, float const , float const , float const , int const **, int, int, int, float)
                    0.41%  10.415ms       100  104.15us  102.53us  118.91us  void paddle::operators::CommonForwardBroadcastCUDAKernel<paddle::operators::MulFunctor<float, void>, float>(int const *, int const , int const , void const *, void const , int const **, int, int, float, bool)
                    0.12%  2.9795ms       100  29.794us  29.344us  30.752us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                    0.00%  7.3280us         4  1.8320us  1.6960us  2.1440us  [CUDA memset]
      API calls:   38.01%  3.42403s         8  428.00ms  2.5070us  3.42333s  cudaStreamCreateWithFlags
                   29.14%  2.62466s       503  5.2180ms  18.225us  34.345ms  cudaMemcpy
                   13.40%  1.20703s         1  1.20703s  1.20703s  1.20703s  cudaStreamCreate
                   10.80%  972.58ms       406  2.3955ms  5.5990us  72.422ms  cuModuleUnload
                    8.09%  728.98ms         4  182.24ms  1.0270us  728.97ms  cudaFree
                    0.26%  23.190ms        20  1.1595ms  6.6880us  20.855ms  cudaMalloc
                    0.10%  8.8163ms       400  22.040us  10.085us  60.295us  cudaLaunchKernel
```

TensorFlow的nvprof结果：
```
==14455== Profiling application: python elementwise_mul.py --check_output False --profile False --backward True --use_gpu True --gpu_id 0 --repeat 100 --log_level 1
==14455== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   58.09%  768.26ms       300  2.5609ms  64.447us  3.8251ms  [CUDA memcpy DtoH]
                   39.85%  527.11ms       201  2.6224ms  85.535us  6.5813ms  [CUDA memcpy HtoD]
                    1.04%  13.815ms       200  69.077us  64.255us  75.552us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=2, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float, float>, Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, int>, int=16, Eigen::MakePointer> const , Eigen::TensorBroadcastingOp<Eigen::array<long, unsigned long=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, int>, int=16, Eigen::MakePointer> const > const > const > const , Eigen::GpuDevice>, int>(float, int=2)
                    0.72%  9.5879ms       100  95.878us  93.152us  98.496us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float, float>, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const , Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, long>, int=16, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                    0.29%  3.8295ms       100  38.295us  37.376us  39.296us  void tensorflow::functor::ColumnReduceSimpleKernel<float*, float*, tensorflow::functor::Sum<float>>(float*, float*, int, int, int, float)
                    0.00%  2.4320us         1  2.4320us  2.4320us  2.4320us  [CUDA memset]
      API calls:   39.89%  1.52898s      1002  1.5259ms     811ns  1.52289s  cudaPointerGetAttributes
                   19.73%  756.10ms       102  7.4127ms  21.644us  8.4232ms  cuCtxSynchronize
                   18.53%  710.21ms       201  3.5334ms  21.473us  6.8715ms  cuMemcpyHtoDAsync
                    8.54%  327.52ms         1  327.52ms  327.52ms  327.52ms  cuDevicePrimaryCtxRetain
                    3.78%  144.91ms       400  362.29us  11.212us  5.9616ms  cudaLaunchKernel
```