### PR TITLE
Add api benchmark for conv2d_transpose.

### DIFF
--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -26,10 +26,10 @@ import utils
 
 @contextlib.contextmanager
 def profile_context(name, use_gpu, profiler):
-    if profiler == "native":
+    if profiler in ["Default", "OpDetail", "AllOpDetail"]:
         profile_type = "All" if use_gpu else "CPU"
         output_file = name + ".profile"
-        with fluid.profiler.profiler(profile_type, 'total', output_file):
+        with fluid.profiler.profiler(profile_type, 'total', output_file, tracer_option=profiler):
             yield
     elif profiler == "nvprof" and use_gpu:
         output_file = name + ".nvprof"
@@ -52,7 +52,7 @@ class PaddleAPIBenchmarkBase(object):
         self.feed_tensors = {}
 
     @abc.abstractmethod
-    def build_program(self, backward=False):
+    def build_program(self, backward=False, dtype=None):
         pass
 
     def append_gradients(self, targets, inputs):

--- a/api/paddle/abs.py
+++ b/api/paddle/abs.py
@@ -20,7 +20,7 @@ sys.path.append("..")
 from common import paddle_api_benchmark as paddle_api
 
 class abs(paddle_api.PaddleAPIBenchmarkBase):
-    def build_program(self, backward=False):
+    def build_program(self, backward=False, dtype=None):
         with fluid.program_guard(self.main_program, self.startup_program):
             data = fluid.data(
                 name='data', shape=[10, 10, 100, 100], dtype='float32', lod_level=0)

--- a/api/paddle/conv2d_transpose.py
+++ b/api/paddle/conv2d_transpose.py
@@ -19,22 +19,25 @@ import sys
 sys.path.append("..")
 from common import paddle_api_benchmark as paddle_api
 
-class elementwise_mul(paddle_api.PaddleAPIBenchmarkBase):
+class conv2d_transpose(paddle_api.PaddleAPIBenchmarkBase):
     def build_program(self, backward=False, dtype=None):
         with fluid.program_guard(self.main_program, self.startup_program):
-            x = fluid.data(
-                name='x', shape=[50, 128, 1000], dtype='float32', lod_level=0)
-            y = fluid.data(
-                name='y', shape=[1, 128, 1000], dtype='float32', lod_level=0)
-            x.stop_gradient = False
-            y.stop_gradient = False
-            result = fluid.layers.elementwise_mul(x, y)
+            input = fluid.data(
+                name='input', shape=[1, 1, 80, 63], dtype=dtype, lod_level=0)
+            input.stop_gradient = False
+            result = fluid.layers.conv2d_transpose(input=input,
+                num_filters=1,
+                filter_size=(3, 32),
+                padding=(1, 8),
+                stride=(1, 16),
+                bias_attr=False,
+                use_cudnn=True)
 
-            self.feed_vars = [x, y]
+            self.feed_vars = [input]
             self.fetch_vars = [result]
             if backward:
-                self.append_gradients(result, [x, y])
+                self.append_gradients(result, [input])
 
 
 if __name__ == '__main__':
-    test_speed_main(elementwise_mul())
+    test_speed_main(conv2d_transpose())

--- a/api/paddle/main.py
+++ b/api/paddle/main.py
@@ -29,6 +29,11 @@ def str2bool(v):
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
+        '--dtype',
+        type=str,
+        default="float32",
+        help='Specify the data type of api')
+    parser.add_argument(
         '--run_with_executor',
         type=str2bool,
         default=True,
@@ -42,7 +47,7 @@ def parse_args():
         '--profiler',
         type=str,
         default="none",
-        help='Choose which profiler to use [\"none\"|\"native\"|\"nvprof\"]')
+        help='Choose which profiler to use [\"none\"|\"Default\"|\"OpDetail\"|\"AllOpDetail\"|\"nvprof\"]')
     parser.add_argument(
         '--backward',
         type=str2bool,
@@ -73,11 +78,13 @@ def parse_args():
     if os.environ.get("CUDA_VISIBLE_DEVICES", None) is None:
         print("CUDA_VISIBLE_DEVICES is None, set to CUDA_VISIBLE_DEVICES={}".format(gpu_id))
         os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+    if args.dtype not in ["float32", "float16"]:
+        raise ValueError("dtype should be float32, float16")
     return args
 
 def test_speed_main(obj):
     args = parse_args()
-    obj.build_program(backward=args.backward)
+    obj.build_program(backward=args.backward, dtype=args.dtype)
     if args.run_with_executor:
         obj.run_with_executor(use_gpu=args.use_gpu,
                               repeat=args.repeat,

--- a/api/paddle/run.sh
+++ b/api/paddle/run.sh
@@ -2,14 +2,16 @@
 
 export CUDA_VISIBLE_DEVICES="1"
 #export GLOG_v=4
+#export LD_LIBRARY_PATH=/work/cudnn-7.6/lib64:${LD_LIBRARY_PATH}
 
 name=${1:-"abs"}
 
 python ${name}.py \
+      --dtype "float32" \
       --run_with_executor True \
       --check_output False \
       --profiler "none" \
-      --backward True \
+      --backward False \
       --use_gpu True \
       --repeat 100 \
-      --log_level 1
+      --log_level 0


### PR DESCRIPTION
conv2d_tranpose当前只有cudnn版本支持float16类型。而**float16类型的性能比float32差上很多**。以下是该PR中添加的conv2d_transpose在不同情况下的profile数据。

conv2d_transpose op的所有配置：
```
I0313 02:25:06.001768 17773 conv_transpose_op.cc:145] input: 1, 1, 80, 63
I0313 02:25:06.001809 17773 conv_transpose_op.cc:146] filter: 1, 1, 3, 32
I0313 02:25:06.001821 17773 conv_transpose_op.cc:150] output: {1, 1, 80, 1008}
I0313 02:25:06.001827 17773 conv_transpose_op.cc:151] groups: 1
I0313 02:25:06.001832 17773 conv_transpose_op.cc:152] output_size: {}
I0313 02:25:06.001838 17773 conv_transpose_op.cc:153] dilations: {1, 1}
I0313 02:25:06.001844 17773 conv_transpose_op.cc:154] strides: {1, 16}
I0313 02:25:06.001850 17773 conv_transpose_op.cc:155] paddings: {1, 8}
I0313 02:25:06.001857 17773 conv_transpose_op.cc:156] is_test: 0
I0313 02:25:06.001863 17773 conv_transpose_op.cc:157] use_cudnn: 1
I0313 02:25:06.001868 17773 conv_transpose_op.cc:158] use_mkldnn: 0
I0313 02:25:06.001873 17773 conv_transpose_op.cc:159] fuse_relu: 0
I0313 02:25:06.001878 17773 conv_transpose_op.cc:160] fuse_alpha: 0
I0313 02:25:06.001904 17773 conv_transpose_op.cc:161] fuse_beta: 0
I0313 02:25:06.001910 17773 conv_transpose_op.cc:162] data_format: NCHW
I0313 02:25:06.001915 17773 conv_transpose_op.cc:163] padding_algorithm: EXPLICIT
I0313 02:25:06.001920 17773 conv_transpose_op.cc:164] workspace_size_MB: 512
```

### develop代码
#### float32类型
- float32类型，profiler结果
```
Event                            Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::fetch                   100         17.5        13.884887 (0.793421)    3.615130 (0.206579)     0.160679    0.804905    0.175       0.497906
  GpuMemcpySync:GPU->CPU         100         15.7081     12.092997 (0.769856)    3.615130 (0.230144)     0.147474    0.46661     0.157081    0.446924
thread0::conv2d_transpose        100         16.9835     15.454648 (0.909981)    1.528827 (0.090019)     0.123946    3.9317      0.169835    0.483209
thread0::feed                    100         0.663743    0.663743 (1.000000)     0.000000 (0.000000)     0.00607     0.017372    0.00663743  0.0188846
```

- float32类型，nvprof结果
```
==19256== Profiling application: python conv2d_transpose.py --run_with_executor True --check_output False --profiler none --backward False --use_gpu True --repeat 100 --log_level 1
==19256== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   65.10%  3.6167ms       100  36.167us  36.096us  36.640us  [CUDA memcpy DtoH]
                   24.33%  1.3515ms       100  13.514us  13.216us  20.448us  void cudnn::detail::dgrad_engine<float, int=128, int=6, int=8, int=3, int=3, int=5, bool=1>(int, int, int, float const *, int, float const , int, cudnn::detail::dgrad_engine<float, int=128, int=6, int=8, int=3, int=3, int=5, bool=1>*, kernel_grad_params, int, int, float, int, int, int)
                    7.35%  408.32us       103  3.9640us  1.8240us  4.3520us  [CUDA memcpy HtoD]
                    3.03%  168.22us       100  1.6820us  1.6640us  2.1120us  void scalePackedTensor_kernel<float, float>(cudnnTensor4dStruct, float*, float)
                    0.13%  7.2640us         4  1.8160us  1.6960us  2.1760us  [CUDA memset]
                    0.06%  3.4240us         1  3.4240us  3.4240us  3.4240us  void thrust::cuda_cub::core::_kernel_agent<thrust::cuda_cub::__parallel_for::ParallelForAgent<thrust::cuda_cub::__transform::unary_transform_f<thrust::counting_iterator<unsigned int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::UniformGenerator<float>, thrust::cuda_cub::__transform::always_true_predicate>, long>, thrust::cuda_cub::__transform::unary_transform_f<thrust::counting_iterator<unsigned int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::UniformGenerator<float>, thrust::cuda_cub::__transform::always_true_predicate>, long>(thrust::use_default, thrust::use_default)
```

#### float16类型
- float16类型，profiler结果
```
Event                            Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::conv2d_transpose        100         37.3018     15.651116 (0.419581)    21.650644 (0.580419)    0.294378    4.14709     0.373018    0.554841
thread0::fetch                   100         29.2807     27.926610 (0.953754)    1.354110 (0.046246)     0.247463    1.53163     0.292807    0.435533
  GpuMemcpySync:GPU->CPU         100         26.5793     25.225233 (0.949054)    1.354110 (0.050946)     0.231274    0.328086    0.265793    0.395351
thread0::feed                    100         0.647171    0.647171 (1.000000)     0.000000 (0.000000)     0.00561     0.021623    0.00647171  0.00962627
```
- float16类型，nvprof结果
```
==19358== Profiling application: python conv2d_transpose.py --run_with_executor True --check_output False --profiler none --backward False --use_gpu True --repeat 100 --log_level 1
==19358== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   92.06%  21.359ms       100  213.59us  181.22us  260.74us  void cudnn::detail::dgrad_engine<__half, int=128, int=6, int=8, int=3, int=3, int=5, bool=1>(int, int, int, __half const *, int, __half const , int, cudnn::detail::dgrad_engine<__half, int=128, int=6, int=8, int=3, int=3, int=5, bool=1>*, kernel_grad_params, int, int, float, int, int, int)
                    5.80%  1.3460ms       100  13.459us  13.407us  13.984us  [CUDA memcpy DtoH]
                    1.28%  297.41us       103  2.8870us  1.8230us  3.2320us  [CUDA memcpy HtoD]
                    0.81%  186.88us       100  1.8680us  1.8550us  2.5920us  void scalePackedTensor_kernel<__half, float>(cudnnTensor4dStruct, __half*, float)
                    0.03%  7.3280us         4  1.8320us  1.7280us  2.1440us  [CUDA memset]
                    0.01%  3.3920us         1  3.3920us  3.3920us  3.3920us  void thrust::cuda_cub::core::_kernel_agent<thrust::cuda_cub::__parallel_for::ParallelForAgent<thrust::cuda_cub::__transform::unary_transform_f<thrust::counting_iterator<unsigned int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::UniformGenerator<float>, thrust::cuda_cub::__transform::always_true_predicate>, long>, thrust::cuda_cub::__transform::unary_transform_f<thrust::counting_iterator<unsigned int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::UniformGenerator<float>, thrust::cuda_cub::__transform::always_true_predicate>, long>(thrust::use_default, thrust::use_default)
                    0.01%  1.6000us         1  1.6000us  1.6000us  1.6000us  void thrust::cuda_cub::core::_kernel_agent<thrust::cuda_cub::__parallel_for::ParallelForAgent<thrust::cuda_cub::__transform::unary_transform_f<thrust::device_ptr<float const >, thrust::device_ptr<paddle::platform::float16>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::CastOpTransformFunctor<float, paddle::platform::float16>, thrust::cuda_cub::__transform::always_true_predicate>, long>, thrust::cuda_cub::__transform::unary_transform_f<thrust::device_ptr<float const >, thrust::device_ptr<paddle::platform::float16>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::CastOpTransformFunctor<float, paddle::platform::float16>, thrust::cuda_cub::__transform::always_true_predicate>, long>(thrust::device_ptr<float const >, paddle::platform::float16)
```

### 基于https://github.com/PaddlePaddle/Paddle/pull/19738 ，升级到cudnn v7接口
- float16类型，profiler结果
```
Event                              Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::conv2d_transpose          100         40.9483     31.689974 (0.773903)    9.258284 (0.226097)     0.341311    4.80021     0.409483    0.754033
thread0::fetch                     100         12.6861     11.334355 (0.893449)    1.351710 (0.106551)     0.101502    1.85335     0.126861    0.233605
  GpuMemcpySync:GPU->CPU           100         9.6974      8.345691 (0.860611)     1.351710 (0.139389)     0.088394    0.284136    0.096974    0.178571
thread0::feed                      100         0.671348    0.671348 (1.000000)     0.000000 (0.000000)     0.005551    0.025228    0.00671348  0.0123624
```

**注意**：
- 我将运行环境的cudnn版本升级到了7.6，才得到如上profiler结果。conv2d_transpose的GPU时间有明显减少，但仍然慢于float32类型
- 升级cudnn v7之前，我发现cudnn选择的是算法0；升级之后选择的是算法1。