### PR TITLE
Add api benchmark for conv2d.

### DIFF
--- a/api/paddle/conv2d.py
+++ b/api/paddle/conv2d.py
@@ -19,26 +19,29 @@ import sys
 sys.path.append("..")
 from common import paddle_api_benchmark as paddle_api
 
-class conv2d_transpose(paddle_api.PaddleAPIBenchmarkBase):
+class conv2d(paddle_api.PaddleAPIBenchmarkBase):
     def build_program(self, backward=False, dtype=None):
         with fluid.program_guard(self.main_program, self.startup_program):
             input = fluid.data(
-                name='input', shape=[1, 1, 80, 63], dtype=dtype, lod_level=0)
+                name='input', shape=[1, 1, 80, 1008], dtype=dtype, lod_level=0)
+            filters = fluid.layers.create_parameter(
+                name='filters', shape=[1, 1, 3, 32], dtype=dtype)
             input.stop_gradient = False
-            result = fluid.layers.conv2d_transpose(
+            result = fluid.layers.conv2d(
                 input=input,
                 num_filters=1,
                 filter_size=(3, 32),
                 padding=(1, 8),
                 stride=(1, 16),
+                param_attr='filters',
                 bias_attr=False,
                 use_cudnn=True)
 
-            self.feed_vars = [input]
+            self.feed_vars = [input, filters]
             self.fetch_vars = [result]
             if backward:
-                self.append_gradients(result, [input])
+                self.append_gradients(result, [input, filters])
 
 
 if __name__ == '__main__':
-    test_speed_main(conv2d_transpose())
+    test_speed_main(conv2d())


### PR DESCRIPTION
既然`conv2d_transpose`的前向是调用`cudnnConvolutionBackwardData`来计算的，这个PR里面构造了和https://github.com/PaddlePaddle/benchmark/pull/331 中对应的conv2d的测试，测试结果如下：

- float32类型，profiler结果
```
Event                         Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::fetch                300         78.5796     74.478601 (0.947810)    4.101045 (0.052190)     0.034396    0.586047    0.261932    0.425027
  GpuMemcpySync:GPU->CPU      300         75.3874     71.286402 (0.945600)    4.101045 (0.054400)     0.026945    0.573778    0.251291    0.407761
thread0::conv2d_grad          100         75.9718     19.653840 (0.258699)    56.317981 (0.741301)    0.741165    1.10181     0.759718    0.410921
thread0::conv2d               100         20.4319     18.083340 (0.885055)    2.348542 (0.114945)     0.150736    4.68862     0.204319    0.110513
thread0::shape                100         4.80619     4.806195 (1.000000)     0.000000 (0.000000)     0.021315    2.50651     0.0480619   0.0259961
thread0::fill_constant        100         3.91354     3.781409 (0.966238)     0.132128 (0.033762)     0.035526    0.089274    0.0391354   0.0211678
thread0::feed                 200         1.17859     1.178593 (1.000000)     0.000000 (0.000000)     0.002841    0.063989    0.00589296  0.00637485
```

- float16类型，profiler结果
```
Event                         Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::conv2d_grad          100         109.575     35.192199 (0.321171)    74.382426 (0.678829)    1.01224     1.46658     1.09575     0.506927
thread0::fetch                300         80.2066     78.412345 (0.977629)    1.794302 (0.022371)     0.033982    0.696074    0.267355    0.371061
  GpuMemcpySync:GPU->CPU      300         77.0463     75.252040 (0.976711)    1.794302 (0.023289)     0.026706    0.683678    0.256821    0.356441
thread0::conv2d               100         18.5606     17.243563 (0.929042)    1.317024 (0.070958)     0.133554    4.45449     0.185606    0.0858672
thread0::fill_constant        100         4.15166     4.011408 (0.966217)     0.140256 (0.033783)     0.036993    0.12293     0.0415166   0.0192069
thread0::shape                100         2.62214     2.622142 (1.000000)     0.000000 (0.000000)     0.021407    0.31404     0.0262214   0.0121309
thread0::feed                 200         1.03897     1.038966 (1.000000)     0.000000 (0.000000)     0.002857    0.021063    0.00519483  0.00480659
```

可以看到，float16相对于float32类型，conv2d的GPU时间减少了，conv2d_grad的GPU时间却增加了。而且conv2d_grad的GPU时间大大长于conv2d的GPU时间。