### PR TITLE
Implement dynamic params in API test (FC as an example)

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -41,6 +41,13 @@ class APIConfig(object):
             data = json.load(f) 
             self.name = data[pos]["op"]
             self.params = data[pos]["param_info"]
+            self.convert_params_list()
+            for params in self.params_list:
+                self.dy_param(params.name.encode('utf-8'), params.type.encode('utf-8'), params.value.encode('utf-8'));
+            for input_p in self.input_list:
+                shape=input_p.shape.encode('utf-8')
+                shape=shape.replace("L","").replace("[","").replace("]","").split(',')
+                self.dy_input_param(pos, input_p.name.encode('utf-8'), input_p.dtype.encode('utf-8'), shape,input_p.lod_level)
         return self
 
     def _convert_params_to_str(self):
@@ -98,7 +105,6 @@ class APIConfig(object):
         elif type == "string":
             if value=="None":
                 value_t=None
-               
             else:
                 value_t=value
             setattr(self, name, value_t)
@@ -108,15 +114,4 @@ class APIConfig(object):
         setattr(self, name + '_shape', map(int, shape) )
         setattr(self, name + '_dtype', dtype )
         setattr(self, name + '_name', name + str(pos) )
-        return self
-
-    def dynamic_pb_config(self, filename, pos):
-        self.init_from_json(filename, pos)
-        self.convert_params_list()
-        for params in self.params_list:
-            self.dy_param(params.name.encode('utf-8'), params.type.encode('utf-8'), params.value.encode('utf-8'));
-        for input_p in self.input_list:
-            shape=input_p.shape.encode('utf-8')
-            shape=shape.replace("L","").replace("[","").replace("]","").split(',')
-            self.dy_input_param(pos, input_p.name.encode('utf-8'), input_p.dtype.encode('utf-8'), shape,input_p.lod_level)
         return self

--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -29,6 +29,13 @@ class APIConfig(object):
         self.input_list = []
         self.params_list = []
 
+
+    def list_all_member(self):
+        print('\nAPI params:')
+        for name,value in vars(self).items():
+            if name not in ['name', 'params', 'input_list', 'params_list']:
+                print('%s=%s'%(name,value))
+
     def init_from_json(self, filename, pos=0):
         with open(filename, 'r') as f:
             data = json.load(f) 
@@ -81,19 +88,26 @@ class APIConfig(object):
     def dy_param(self, name, type, value):
         if type == "float":
             value_t=float(value)
-            setattr(self, name, value_t);
+            setattr(self, name, value_t)
         elif type == "int":
             value_t=int(value)
-            setattr(self, name, value_t);
+            setattr(self, name, value_t)
         elif type == "bool":
             value_t=bool(value)
-            setattr(self, name, value_t);
+            setattr(self, name, value_t)
+        elif type == "string":
+            if value=="None":
+                value_t=None
+               
+            else:
+                value_t=value
+            setattr(self, name, value_t)
         return self
 
     def dy_input_param(self, pos, name, dtype, shape, lod_level ):
-        setattr(self, name + '_shape', map(int, shape) );
-        setattr(self, name + '_dtype', dtype );
-        setattr(self, name + '_name', name + str(pos) );
+        setattr(self, name + '_shape', map(int, shape) )
+        setattr(self, name + '_dtype', dtype )
+        setattr(self, name + '_name', name + str(pos) )
         return self
 
     def dynamic_pb_config(self, filename, pos):

--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -1,0 +1,108 @@
+import json
+
+class BaseParamInfo(object):
+    def __init__(self, op_type, type, value):
+        self.name = op_type
+        self.type = type
+        self.value = value
+
+    def convert_params_to_str(self):
+         param = self.name + '--' + self.type + '| '+ self.value +'\n '
+         return param
+ 
+class VarParamInfo(object):
+    def __init__(self, name, type, dtype, shape, lod_level=0):
+        self.name = name
+        self.type = type
+        self.dtype = dtype
+        self.shape = shape
+        self.lod_level = lod_level
+
+    def convert_params_to_str(self):
+         param = self.name + '--' + self.type + '| '+ self.dtype + '| shape:'+ self.shape +'\n '
+         return param
+
+class APIConfig(object):
+    def __init__(self,name,params):
+        self.name = name
+        self.params = params
+        self.input_list = []
+        self.params_list = []
+
+    def init_from_json(self, filename, pos=0):
+        with open(filename, 'r') as f:
+            data = json.load(f) 
+            self.name = data[pos]["op"]
+            self.params = data[pos]["param_info"]
+        return self
+
+    def _convert_params_to_str(self):
+        params=""
+        for p_key, p_value in self.params.items():
+            params_str=""
+            param_name=p_key
+            dtype=p_value["dtype"]
+            type=""
+            v_type = 0
+            for v_k in p_value.keys():
+                if v_k == "type":
+                    v_type = 1
+            if v_type ==1:
+                type=p_value["type"]
+                shape=p_value["shape"]
+                var_ = VarParamInfo(param_name, type, dtype, shape)
+            else:
+                value=p_value["value"]
+                var_ = BaseParamInfo(param_name, dtype, value)
+            params_str=var_.convert_params_to_str()
+            params=params+params_str
+        return params
+
+    def convert_params_list(self):
+        for p_key, p_value in self.params.items():
+            param_name=p_key
+            dtype=p_value["dtype"]
+            type=""
+            v_type = 0
+            for v_k in p_value.keys():
+                if v_k == "type":
+                    v_type = 1
+            if v_type ==1:
+                type=p_value["type"]
+                shape=p_value["shape"]
+                var_ = VarParamInfo(param_name, type, dtype, shape)
+                self.input_list.append(var_)
+            else:
+                value=p_value["value"] 
+                var_ = BaseParamInfo(param_name, dtype, value)
+                self.params_list.append(var_)
+        return self
+
+    def dy_param(self, name, type, value):
+        if type == "float":
+            value_t=float(value)
+            setattr(self, name, value_t);
+        elif type == "int":
+            value_t=int(value)
+            setattr(self, name, value_t);
+        elif type == "bool":
+            value_t=bool(value)
+            setattr(self, name, value_t);
+        return self
+
+    def dy_input_param(self, pos, name, dtype, shape, lod_level ):
+        setattr(self, name + '_shape', map(int, shape) );
+        setattr(self, name + '_dtype', dtype );
+        setattr(self, name + '_name', name + str(pos) );
+        return self
+
+    def dynamic_pb_config(self, filename, pos):
+        self.init_from_json(filename, pos)
+        self.convert_params_list()
+        for params in self.params_list:
+            self.dy_param(params.name.encode('utf-8'), params.type.encode('utf-8'), params.value.encode('utf-8'));
+        for input_p in self.input_list:
+            shape=input_p.shape.encode('utf-8')
+            shape=shape.replace("L","").replace("[","").replace("]","").split(',')
+            self.dy_input_param(pos, input_p.name.encode('utf-8'), input_p.dtype.encode('utf-8'), shape,input_p.lod_level)
+        return self

--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -86,6 +86,10 @@ class PaddleAPIBenchmarkBase(object):
     def build_program(self, backward=False, dtype=None):
         pass
 
+    def create_progrom(self):
+        self.main_program = fluid.Program()
+        self.startup_program = fluid.Program()
+
     def append_gradients(self, targets, inputs):
         if isinstance(inputs, fluid.framework.Variable):
             inputs = [inputs]

--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -83,7 +83,7 @@ class PaddleAPIBenchmarkBase(object):
         self.feed_tensors = {}
 
     @abc.abstractmethod
-    def build_program(self, backward=False, dtype=None):
+    def build_program(self, config=None):
         pass
 
     def create_progrom(self):

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -90,7 +90,7 @@ class TensorflowAPIBenchmarkBase(object):
         self.allow_growth = False
 
     @abc.abstractmethod
-    def build_graph(self, backward=False):
+    def build_graph(self, config=None):
         pass
 
     def append_gradients(self, targets, inputs):

--- a/api/tests/fc.py
+++ b/api/tests/fc.py
@@ -41,7 +41,7 @@ class FCConfig(api_param.APIConfig):
         self.input_dtype=dtype
 
 class PDFC(paddle_api.PaddleAPIBenchmarkBase):
-    def build_program(self, backward=False, dtype=None):
+    def build_program(self, backward=False):
         import paddle.fluid as fluid
 
         self.name = "fc"
@@ -68,7 +68,7 @@ class PDFC(paddle_api.PaddleAPIBenchmarkBase):
 
 
 class TFFC(tensorflow_api.TensorflowAPIBenchmarkBase):
-    def build_graph(self, backward=False, dtype=None):
+    def build_graph(self, backward=False):
         import tensorflow as tf
 
         self.name = "fc"

--- a/api/tests/fc.py
+++ b/api/tests/fc.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import paddle.fluid as fluid
+import tensorflow as tf
 from main import test_main
 
 import sys
@@ -23,30 +24,15 @@ from common import api_param
 
 
 class FCConfig(api_param.APIConfig):
-    def __init__(self, input_shape=[1,256,6,6], size=1, num_flatten_dims=-1, act=None, dtype='float32'):
+    def __init__(self):
         super(FCConfig, self).__init__('fc','')
-        row = 1
-        col = 1
-        if num_flatten_dims < 0:
-            num_flatten_dims = num_flatten_dims + len(input_shape)
-        for i in range(len(input_shape)):
-            if i < num_flatten_dims:
-                row = row * input_shape[i]
-            else:
-                col = col * input_shape[i]
-        self.input_shape = [row, col]
-        self.size = size
-        self.num_flatten_dims = num_flatten_dims
-        self.act=act
-        self.input_dtype=dtype
 
 class PDFC(paddle_api.PaddleAPIBenchmarkBase):
     def build_program(self, backward=False):
-        import paddle.fluid as fluid
+
+        FCconfig.list_all_member()
 
         self.name = "fc"
-        self.main_program=fluid.Program()
-        self.startup_program=fluid.Program()
         with fluid.program_guard(self.main_program, self.startup_program):
             input = fluid.data(
                 name=FCconfig.input_name, shape=FCconfig.input_shape, dtype=FCconfig.input_dtype, lod_level=0)
@@ -69,7 +55,6 @@ class PDFC(paddle_api.PaddleAPIBenchmarkBase):
 
 class TFFC(tensorflow_api.TensorflowAPIBenchmarkBase):
     def build_graph(self, backward=False):
-        import tensorflow as tf
 
         self.name = "fc"
         self.allow_growth = True
@@ -80,7 +65,7 @@ class TFFC(tensorflow_api.TensorflowAPIBenchmarkBase):
             num_outputs=FCconfig.size,
             weights_initializer=tf.constant_initializer(0.5),
             biases_initializer=tf.constant_initializer(0.1),
-            activation_fn=FCconfig.act)
+            activation_fn=None)
 
         self.feed_list = [input]
         self.fetch_list = [result]

--- a/api/tests/fc.py
+++ b/api/tests/fc.py
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import paddle.fluid as fluid
 from main import test_main
 
 import sys
 sys.path.append("..")
 from common import paddle_api_benchmark as paddle_api
 from common import tensorflow_api_benchmark as tensorflow_api
+from common import api_param
 
 
-class FCConfig(object):
-    def __init__(self, input_shape, size, num_flatten_dims=-1):
+class FCConfig(api_param.APIConfig):
+    def __init__(self, input_shape=[1,256,6,6], size=1, num_flatten_dims=-1, act=None, dtype='float32'):
+        super(FCConfig, self).__init__('fc','')
         row = 1
         col = 1
         if num_flatten_dims < 0:
@@ -33,30 +36,32 @@ class FCConfig(object):
                 col = col * input_shape[i]
         self.input_shape = [row, col]
         self.size = size
-
-
-config = FCConfig(input_shape=[16384, 4],
-                  size=4)
-
+        self.num_flatten_dims = num_flatten_dims
+        self.act=act
+        self.input_dtype=dtype
 
 class PDFC(paddle_api.PaddleAPIBenchmarkBase):
     def build_program(self, backward=False, dtype=None):
         import paddle.fluid as fluid
 
         self.name = "fc"
+        self.main_program=fluid.Program()
+        self.startup_program=fluid.Program()
         with fluid.program_guard(self.main_program, self.startup_program):
             input = fluid.data(
-                name='input', shape=config.input_shape, dtype='float32', lod_level=0)
+                name=FCconfig.input_name, shape=FCconfig.input_shape, dtype=FCconfig.input_dtype, lod_level=0)
+            print(FCconfig.input_name)
+            print(FCconfig.input_shape)
             input.stop_gradient = False
             result = fluid.layers.fc(
                 input=input,
-                size=config.size,
-                num_flatten_dims=-1,
+                size=FCconfig.size,
+                num_flatten_dims=FCconfig.num_flatten_dims,
                 param_attr=fluid.ParamAttr(
                     initializer=fluid.initializer.ConstantInitializer(0.5)),
                 bias_attr=fluid.ParamAttr(
                     initializer=fluid.initializer.ConstantInitializer(0.1)),
-                act=None)
+                act=FCconfig.act)
 
             self.feed_vars = [input]
             self.fetch_vars = [result]
@@ -71,13 +76,13 @@ class TFFC(tensorflow_api.TensorflowAPIBenchmarkBase):
         self.name = "fc"
         self.allow_growth = True
 
-        input = tf.placeholder(name='input', shape=config.input_shape, dtype=tf.float32)
+        input = tf.placeholder(name=FCconfig.input_name, shape=FCconfig.input_shape, dtype=tf.as_dtype(FCconfig.input_dtype))
         result = tf.contrib.layers.fully_connected(
             inputs=input,
-            num_outputs=config.size,
+            num_outputs=FCconfig.size,
             weights_initializer=tf.constant_initializer(0.5),
             biases_initializer=tf.constant_initializer(0.1),
-            activation_fn=None)
+            activation_fn=FCconfig.act)
 
         self.feed_list = [input]
         self.fetch_list = [result]
@@ -86,4 +91,5 @@ class TFFC(tensorflow_api.TensorflowAPIBenchmarkBase):
 
 
 if __name__ == '__main__':
-    test_main(PDFC(), TFFC(), feed_spec=None)
+    FCconfig = FCConfig()
+    test_main(PDFC(), TFFC(), FCconfig, feed_spec=None)

--- a/api/tests/fc_param.json
+++ b/api/tests/fc_param.json
@@ -1,0 +1,20 @@
+[
+{
+"op":"fc",
+"param_info":{
+    "act": {"dtype": "string", "value": "relu"},
+    "input": {"type": "Variable", "dtype": "float32", "shape": "[16L, 256L, 6L, 6L]"},
+    "num_flatten_dims": {"dtype": "int", "value": "1"},
+    "size": {"dtype": "int", "value": "4096"}
+}
+},
+{
+"op":"fc",
+"param_info":{
+    "act": {"dtype": "string", "value": "None"},
+    "input": {"type": "Variable", "dtype": "float32", "shape": "[16L, 256L, 5L, 5L]"},
+    "num_flatten_dims": {"dtype": "int", "value": "1"},
+    "size": {"dtype": "int", "value": "4096"}
+}
+}
+]

--- a/api/tests/feeder.py
+++ b/api/tests/feeder.py
@@ -43,8 +43,11 @@ def feed_var(spec):
         data = spec["data"]
     else:
         if dtype == "int64" or dtype == "int32":
-            assert range is not None
-            data = np.random.randint(range[0], range[1], shape).astype(dtype)
+            data = np.random.randint(100, size=shape, dtype=dtype)
+            if range is not None:
+                data = np.random.randint(range[0],range[1], size=shape, dtype=dtype)
+        if dtype == "bool":
+            data = np.random.randint(2, size=shape, dtype=bool)
         else:
             data = np.random.random(shape).astype(dtype)
             if range is not None:

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -191,6 +191,7 @@ def test_run(pd_obj=None, tf_obj=None, feed_spec=None):
     if args.task == "accuracy" or args.framework in ["paddle", "both"]:
         if pd_obj is None:
             raise ValueError("Paddle object is None.")
+        pd_obj.create_progrom()
         pd_obj.build_program(backward=args.backward)
         feed_list = feeder.feed_paddle(pd_obj, feed_spec)
         pd_outputs = test_paddle(args.task, pd_obj, args, feed_list)

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -45,11 +45,6 @@ def parse_args():
         default="paddle",
         help='Specify the framework: [paddle|tensorflow|tf|both]')
     parser.add_argument(
-        '--dtype',
-        type=str,
-        default="float32",
-        help='Specify the data type of api')
-    parser.add_argument(
         '--json_file',
         type=str,
         default="api_params.json",
@@ -108,8 +103,6 @@ def parse_args():
         raise ValueError("task should be speed, accuracy")
     if args.framework not in ["paddle", "tensorflow", "tf", "both"]:
         raise ValueError("task should be paddle, tensorflow, tf, both")
-    if args.dtype not in ["float32", "float16", "float64", "int32", "int64", "bool"]:
-        raise ValueError("dtype should be float32, float16, float64, int32, int64, bool")
     return args
 
 def test_paddle(task, obj, args, feed_list=None):
@@ -175,7 +168,7 @@ def test_tensorflow(task, obj, args, feed_list=None):
 
 def test_speed_main(obj):
     args = parse_args()
-    obj.build_program(backward=args.backward, dtype=args.dtype)
+    obj.build_program(backward=args.backward)
     test_paddle("speed", obj, args)
 
 
@@ -198,14 +191,14 @@ def test_run(pd_obj=None, tf_obj=None, feed_spec=None):
     if args.task == "accuracy" or args.framework in ["paddle", "both"]:
         if pd_obj is None:
             raise ValueError("Paddle object is None.")
-        pd_obj.build_program(backward=args.backward, dtype=args.dtype)
+        pd_obj.build_program(backward=args.backward)
         feed_list = feeder.feed_paddle(pd_obj, feed_spec)
         pd_outputs = test_paddle(args.task, pd_obj, args, feed_list)
 
     if args.task == "accuracy" or args.framework in ["tensorflow", "tf", "both"]:
         if tf_obj is None:
             raise ValueError("TensorFlow object is None.")
-        tf_obj.build_graph(backward=args.backward, dtype=args.dtype)
+        tf_obj.build_graph(backward=args.backward)
         feed_list = feeder.feed_tensorflow(tf_obj, feed_list, feed_spec)
         tf_outputs = test_tensorflow(args.task, tf_obj, args, feed_list)
 


### PR DESCRIPTION
Implement dynamic params in API test (FC as an example)：

- 测试fc所有配置，执行命令：
python fc.py --framework=both --check_output=True --json_file=fc_param.json

- 测试fc第0个配置，执行命令：
python fc.py --framework=both --check_output=True --json_file=fc_param.json --pos=0

- FC的TF暂未对齐
