### PR TITLE
Update the support of tensorflow

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -15,28 +15,56 @@
 import json
 
 
+def parse_list(value_str, sub_dtype="int"):
+    if sub_dtype in ["int", "int64"]:
+        value_str = value_str.replace("L", "").replace("[", "").replace(
+            "]", "").split(',')
+        return map(int, value_str)
+    else:
+        # TODO: check and support list of other data type.
+        raise ValueError("Do not support parsing list of non-int data type.")
+
+
 class BaseParamInfo(object):
     def __init__(self, name, type, value):
-        self.name = name
-        self.type = type
-        self.value = value
+        self.name = self._encode_item(name)
+        self.type = self._encode_item(type)
+        self.value = self._translate_value(self._encode_item(value))
 
-    def convert_params_to_str(self):
-        param = self.name + '--' + self.type + '| ' + self.value + '\n '
-        return param
+    def _encode_item(self, item):
+        return item.encode("utf-8") if isinstance(item, str) else item
+
+    def to_string(self):
+        return self.name + '--' + self.type + '| ' + str(self.value) + '\n '
+
+    def _translate_value(self, value):
+        if self.type in ["float", "float32", "float64"]:
+            return float(value)
+        elif self.type in ["int", "int32", "int64"]:
+            return int(value)
+        elif self.type == "bool":
+            return bool(value)
+        elif self.type == "string":
+            return None if value == "None" else value
+        elif self.type == "list":
+            return parse_list(value, sub_dtype="int")
 
 
-class VarParamInfo(object):
+class VarParamInfo(BaseParamInfo):
     def __init__(self, name, type, dtype, shape, lod_level=0):
-        self.name = name
-        self.type = type
-        self.dtype = dtype
-        self.shape = shape
-        self.lod_level = lod_level
+        self.name = self._encode_item(name)
+        self.type = self._encode_item(type)
+        self.dtype = self._encode_item(dtype)
+        if isinstance(shape, str):
+            self.shape = parse_list(self._encode_item(shape))
+        else:
+            assert isinstance(shape, list)
+            self.shape = shape
+        self.lod_level = self._encode_item(lod_level)
 
-    def convert_params_to_str(self):
-        param = self.name + '--' + self.type + '| ' + self.dtype + '| shape:' + self.shape + '\n '
-        return param
+    def to_string(self):
+        return self.name + '--' + self.type + '| ' + str(
+            self.dtype) + '| shape:' + str(self.shape) + '\n '
 
 
 class APIConfig(object):
@@ -47,6 +75,32 @@ class APIConfig(object):
         self.params_list = []
         self.backward = False
         self.feed_spec = None
+
+    def init_from_json(self, filename, config_id=0):
+        with open(filename, 'r') as f:
+            data = json.load(f)
+            self.name = data[config_id]["op"]
+            self.params = data[config_id]["param_info"]
+
+        self._parse_params()
+        for param in self.params_list:
+            setattr(self, param.name, param.value)
+        for var in self.variable_list:
+            setattr(self, var.name + '_shape', var.shape)
+            setattr(self, var.name + '_dtype', var.dtype)
+        return self
+
+    def to_tensorflow(self):
+        return self
+
+    def to_string(self):
+        self._parse_params()
+        params = ""
+        for info in self.variable_list:
+            params = params + info.to_string()
+        for info in self.params_list:
+            params = params + info.to_string()
+        return params
 
     def __str__(self):
         debug_str = ('API params of <%s> {\n') % (self.name)
@@ -59,82 +113,24 @@ class APIConfig(object):
         debug_str = debug_str + '}'
         return debug_str
 
-    def init_from_json(self, filename, config_id=0):
-        with open(filename, 'r') as f:
-            data = json.load(f)
-            self.name = data[config_id]["op"]
-            self.params = data[config_id]["param_info"]
-
-        self._parse_params()
-        for params in self.params_list:
-            self._translate_param(
-                name=params.name.encode('utf-8'),
-                type=params.type.encode('utf-8'),
-                value=params.value.encode('utf-8'))
-        for input_p in self.variable_list:
-            self._translate_variable(
-                name=input_p.name.encode('utf-8'),
-                dtype=input_p.dtype.encode('utf-8'),
-                shape=input_p.shape.encode('utf-8'),
-                lod_level=input_p.lod_level)
-        return self
-
-    def to_tensorflow(self):
-        return self
-
-    def _convert_params_to_str(self):
-        params = ""
-        for name, value in self.params.items():
-            if self._is_variable(value):
-                info = VarParamInfo(name, value["type"], value["dtype"],
-                                    value["shape"])
-            else:
-                info = BaseParamInfo(name, value["type"], value["value"])
-            params = params + info.convert_params_to_str()
-        return params
-
     def _parse_params(self):
         for name, value in self.params.items():
-            if self._is_variable(value):
+            assert value.get("type", None) is not None
+            if value["type"] == "Variable":
                 info = VarParamInfo(name, value["type"], value["dtype"],
                                     value["shape"])
+                self.variable_list.append(info)
+            elif value["type"] == "list<Variable>":
+                dtype_list = []
+                shape_list = []
+                for key, var in value.items():
+                    if key != "type":
+                        assert var["type"] == "Variable"
+                        dtype_list.append(var["dtype"])
+                        shape_list.append(parse_list(var["shape"]))
+                info = VarParamInfo(name, value["type"], dtype_list,
+                                    shape_list)
                 self.variable_list.append(info)
             else:
                 info = BaseParamInfo(name, value["type"], value["value"])
                 self.params_list.append(info)
-
-    def _parse_list(self, value_str, dtype):
-        value_str = value_str.replace("L", "").replace("[", "").replace(
-            "]", "").split(',')
-        # TODO: check and support list of other data type.
-        if dtype == "int":
-            return map(int, value_str)
-        else:
-            raise ValueError(
-                "Do not support parsing list of non-int data type.")
-
-    def _is_variable(self, value):
-        if value.get("type", None) is not None and value["type"] == "Variable":
-            return True
-        return False
-
-    def _translate_param(self, name, type, value):
-        value_t = None
-        if type in ["float", "float32", "float64"]:
-            value_t = float(value)
-        elif type in ["int", "int32", "int64"]:
-            value_t = int(value)
-        elif type == "bool":
-            value_t = bool(value)
-        elif type == "string":
-            if value == "None":
-                value_t = None
-            else:
-                value_t = value
-        elif type == "list":
-            value_t = self._parse_list(value, dtype="int")
-        setattr(self, name, value_t)
-
-    def _translate_variable(self, name, dtype, shape, lod_level):
-        setattr(self, name + '_shape', self._parse_list(shape, dtype="int"))
-        setattr(self, name + '_dtype', dtype)

--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -19,9 +19,14 @@ import abc, six
 import traceback
 import contextlib
 import numpy as np
-import paddle
-import paddle.fluid as fluid
 import utils
+
+try:
+    import paddle
+    import paddle.fluid as fluid
+except Exception as e:
+    sys.stderr.write(
+        "Cannot import paddle.fluid, maybe paddle is not installed.\n")
 
 
 @contextlib.contextmanager

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -14,15 +14,21 @@
 
 from __future__ import print_function
 
+import sys
 import json
 import time
 import abc, six
 import numpy as np
-import tensorflow as tf
-from tensorflow.python.profiler import model_analyzer
-from tensorflow.python.profiler import option_builder
-from tensorflow.python.client import timeline
 import utils
+
+try:
+    import tensorflow as tf
+    from tensorflow.python.profiler import model_analyzer
+    from tensorflow.python.profiler import option_builder
+    from tensorflow.python.client import timeline
+except Exception as e:
+    sys.stderr.write(
+        "Cannot import tensorflow, maybe tensorflow is not installed.\n")
 
 
 def convert_dtype(dtype, to_string=True):
@@ -85,12 +91,18 @@ def convert_dtype(dtype, to_string=True):
 class TensorflowAPIBenchmarkBase(object):
     def __init__(self):
         self.name = self.__class__.__name__
-        self.graph = tf.Graph()
         self.feed_list = None
         self.fetch_list = None
         self.allow_growth = True
-        if tf.__version__ > "1.15.0":
-            tf.compat.v1.disable_eager_execution()
+        try:
+            import tensorflow as tf
+            self.graph = tf.Graph()
+            if tf.__version__ > "1.15.0":
+                tf.compat.v1.disable_eager_execution()
+        except Exception as e:
+            sys.stderr.write(
+                "Cannot import tensorflow, maybe tensorflow is not installed.\n"
+            )
 
     @abc.abstractmethod
     def build_graph(self, config=None):

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -85,13 +85,42 @@ def convert_dtype(dtype, to_string=True):
 class TensorflowAPIBenchmarkBase(object):
     def __init__(self):
         self.name = self.__class__.__name__
+        self.graph = tf.Graph()
         self.feed_list = None
         self.fetch_list = None
-        self.allow_growth = False
+        self.allow_growth = True
+        if tf.__version__ > "1.15.0":
+            tf.compat.v1.disable_eager_execution()
 
     @abc.abstractmethod
     def build_graph(self, backward=False):
         pass
+
+    def placeholder(self, name, shape, dtype):
+        if isinstance(dtype, str):
+            all_supported_tf_dtypes = [tf.float16,
+                                       tf.float32,
+                                       tf.float64,
+                                       tf.int8,
+                                       tf.uint8,
+                                       tf.uint16,
+                                       tf.uint32,
+                                       tf.uint64,
+                                       tf.int16,
+                                       tf.int32,
+                                       tf.int64,
+                                       tf.bool]
+            for tf_dtype in all_supported_tf_dtypes:
+                if convert_dtype(tf_dtype) == dtype:
+                    break
+        else:
+            tf_dtype = dtype
+
+        if tf.__version__ >= "1.15.0":
+            var = tf.compat.v1.placeholder(name=name, shape=shape, dtype=tf_dtype)
+        else:
+            var = tf.placeholder(name=name, shape=shape, dtype=tf_dtype)
+        return var
 
     def append_gradients(self, targets, inputs):
         if isinstance(inputs, tf.Tensor):
@@ -108,22 +137,14 @@ class TensorflowAPIBenchmarkBase(object):
             self.fetch_list.append(gradients)
 
     def run(self, use_gpu, feed=None, repeat=1, log_level=0, check_output=False, profile=False):
-        config = self._set_config(use_gpu)
-        if tf.__version__ < "1.14.0":
-            sess = tf.Session(config=config)
-            sess.run(tf.global_variables_initializer())
-            sess.run(tf.local_variables_initializer())
-        else:
-            sess = tf.compat.v1.Session(config=config)
-            sess.run(tf.compat.v1.global_variables_initializer())
-            sess.run(tf.compat.v1.local_variables_initializer())
+        sess = self._init_session(use_gpu)
 
         if profile:
             profiler = model_analyzer.Profiler(graph=sess.graph)
             run_options = tf.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)
             run_metadata = tf.RunMetadata()
         else:
-            log_writer = None
+            profiler = None
             run_options = None
             run_metadata = None
         self.timeline_dict = None
@@ -134,7 +155,7 @@ class TensorflowAPIBenchmarkBase(object):
         runtimes = []
         fetches = []
         outputs = None
-        for i in xrange(repeat):
+        for i in range(repeat):
             begin = time.time()
             outputs = sess.run(fetches=self.fetch_list,
                                feed_dict=feed,
@@ -177,11 +198,11 @@ class TensorflowAPIBenchmarkBase(object):
         utils.print_stat(stats, log_level=log_level)
         return outputs
 
-    def _set_config(self, use_gpu):
-        if tf.__version__ < "1.14.0":
-            config = tf.ConfigProto()
-        else:
+    def _init_session(self, use_gpu):
+        if tf.__version__ >= "1.15.0":
             config = tf.compat.v1.ConfigProto()
+        else:
+            config = tf.ConfigProto()
 
 #        if use_gpu:
 #            if not self.allow_growth:
@@ -189,7 +210,17 @@ class TensorflowAPIBenchmarkBase(object):
 #            else:
 #                config.gpu_options.allow_growth = True
             #config.log_device_placement = True
-        return config
+
+        if tf.__version__ >= "1.15.0":
+            sess = tf.compat.v1.Session(config=config)
+            sess.run(tf.compat.v1.global_variables_initializer())
+            sess.run(tf.compat.v1.local_variables_initializer())
+        else:
+            sess = tf.Session(config=config)
+            sess.run(tf.global_variables_initializer())
+            sess.run(tf.local_variables_initializer())
+
+        return sess
 
     def _update_timeline(self, chrome_trace):
         # Codes from: https://github.com/ikhlestov/tensorflow_profiling/blob/master/03_merged_timeline_example.py

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -196,39 +196,15 @@ class TensorflowAPIBenchmarkBase(object):
     def _init_session(self, use_gpu):
         if tf.__version__ >= "1.15.0":
             config = tf.compat.v1.ConfigProto()
-        else:
-            config = tf.ConfigProto()
-
-#        if use_gpu:
-#            if not self.allow_growth:
-#                config.gpu_options.per_process_gpu_memory_fraction = 0.9
-#            else:
-#                config.gpu_options.allow_growth = True
-
-        if tf.__version__ >= "1.15.0":
             sess = tf.compat.v1.Session(config=config)
             sess.run(tf.compat.v1.global_variables_initializer())
             sess.run(tf.compat.v1.local_variables_initializer())
         else:
+            config = tf.ConfigProto()
             sess = tf.Session(config=config)
             sess.run(tf.global_variables_initializer())
             sess.run(tf.local_variables_initializer())
-
         return sess
-
-    def _update_timeline(self, chrome_trace):
-        # Codes from: https://github.com/ikhlestov/tensorflow_profiling/blob/master/03_merged_timeline_example.py
-        # Convert crome trace to python dict
-        chrome_trace_dict = json.loads(chrome_trace)
-        if self.timeline_dict is None:
-            # For first run store full trace
-            self.timeline_dict = chrome_trace_dict
-        else:
-            # For other - update only time consumption, not definitions
-            for event in chrome_trace_dict['traceEvents']:
-                # Events time consumption started with 'ts' prefix
-                if 'ts' in event:
-                    self.timeline_dict['traceEvents'].append(event)
 
     def _feed_random_data(self):
         print("feed random data")

--- a/api/tests/abs.py
+++ b/api/tests/abs.py
@@ -12,25 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
-from common import api_param
+from common_import import *
 
 
-class AbsConfig(api_param.APIConfig):
+class AbsConfig(APIConfig):
     def __init__(self):
         super(AbsConfig, self).__init__('abs')
         self.feed_spec = {"range": [-1, 1]}
 
 
-class PDAbs(paddle_api.PaddleAPIBenchmarkBase):
+class PDAbs(PaddleAPIBenchmarkBase):
     def build_program(self, config):
-        import paddle.fluid as fluid
-
         with fluid.program_guard(self.main_program, self.startup_program):
             data = fluid.data(
                 name='data',
@@ -46,10 +38,8 @@ class PDAbs(paddle_api.PaddleAPIBenchmarkBase):
                 self.append_gradients(result, [data])
 
 
-class TFAbs(tensorflow_api.TensorflowAPIBenchmarkBase):
+class TFAbs(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
-        import tensorflow as tf
-
         data = self.placeholder(
             name='data', shape=config.x_shape, dtype=config.x_dtype)
         result = tf.abs(x=data)

--- a/api/tests/abs.py
+++ b/api/tests/abs.py
@@ -51,9 +51,7 @@ class TFAbs(tensorflow_api.TensorflowAPIBenchmarkBase):
         import tensorflow as tf
 
         self.name = "abs"
-        self.allow_growth = True
-
-        data = tf.placeholder(name='data', shape=config.input_shape, dtype=tf.float32)
+        data = self.placeholder(name='data', shape=config.input_shape, dtype=tf.float32)
         result = tf.abs(x=data)
 
         self.feed_list = [data]

--- a/api/tests/common_import.py
+++ b/api/tests/common_import.py
@@ -1,0 +1,33 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from main import test_main
+
+import sys
+sys.path.append("..")
+from common.paddle_api_benchmark import PaddleAPIBenchmarkBase
+from common.tensorflow_api_benchmark import TensorflowAPIBenchmarkBase
+from common.api_param import APIConfig
+
+try:
+    import paddle.fluid as fluid
+except Exception as e:
+    sys.stderr.write(
+        "Cannot import paddle.fluid, maybe paddle is not installed.\n")
+
+try:
+    import tensorflow as tf
+except Exception as e:
+    sys.stderr.write(
+        "Cannot import tensorflow, maybe tensorflow is not installed.\n")

--- a/api/tests/concat.py
+++ b/api/tests/concat.py
@@ -12,52 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
+from common_import import *
 
 
-class PDConcat(paddle_api.PaddleAPIBenchmarkBase):
-    def build_program(self, backward=False, dtype=None):
-        import paddle.fluid as fluid
-
-        self.name = "concat"
+class PDConcat(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
         with fluid.program_guard(self.main_program, self.startup_program):
-            data1 = fluid.data(
-                name='data1', shape=[100, 200], dtype='float32', lod_level=0)
-            data2 = fluid.data(
-                name='data2', shape=[100, 200], dtype='float32', lod_level=0)
-            data1.stop_gradient = False
-            data2.stop_gradient = False
-            result = fluid.layers.concat([data1, data2], axis=0)
+            inputs = []
+            for i in range(len(config.input_shape)):
+                input_i = fluid.data(
+                    name='input_' + str(i),
+                    shape=config.input_shape[i],
+                    dtype=config.input_dtype[i],
+                    lod_level=0)
+                input_i.stop_gradient = False
+                inputs.append(input_i)
+            result = fluid.layers.concat(input=inputs, axis=config.axis)
 
-            self.feed_vars = [data1, data2]
+            self.feed_vars = inputs
             self.fetch_vars = [result]
-            if backward:
-                self.append_gradients(result, [data1, data2])
+            if config.backward:
+                self.append_gradients(result, inputs)
 
 
-class TFConcat(tensorflow_api.TensorflowAPIBenchmarkBase):
-    def build_graph(self, backward=False):
-        import tensorflow as tf
+class TFConcat(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        inputs = []
+        for i in range(len(config.input_shape)):
+            input_i = self.placeholder(
+                name='input_' + str(i),
+                shape=config.input_shape[i],
+                dtype=config.input_dtype[i])
+            inputs.append(input_i)
+        result = tf.concat(values=inputs, axis=config.axis)
 
-        self.name = "concat"
-        self.allow_growth = True
-
-        data1 = tf.placeholder(
-            name='data1', shape=[100, 200], dtype=tf.float32)
-        data2 = tf.placeholder(
-            name='data2', shape=[100, 200], dtype=tf.float32)
-        result = tf.concat([data1, data2], 0)
-
-        self.feed_list = [data1, data2]
+        self.feed_list = inputs
         self.fetch_list = [result]
-        if backward:
-            self.append_gradients(result, [data1, data2])
+        if config.backward:
+            self.append_gradients(result, inputs)
 
 
 if __name__ == '__main__':
-    test_main(PDConcat(), TFConcat(), feed_spec=None)
+    test_main(PDConcat(), TFConcat(), config=APIConfig("concat"))

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -12,30 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
+from common_import import *
 
 
-class Conv2dConfig(object):
-    def __init__(self,
-                 input_shape,
-                 num_filters,
-                 filter_size,
-                 stride=[1, 1],
-                 padding=[0, 0]):
-        self.input_shape = input_shape
-        self.num_filters = num_filters
-        self.filter_size = filter_size
-        self.stride = stride
-        self._padding = padding
-        self.dilation = [1, 1]
-        self.groups = 1
-        self.data_format = "NCHW"
-        self.use_cudnn = True
+class Conv2dConfig(APIConfig):
+    def __init__(self):
+        super(Conv2dConfig, self).__init__('conv2d')
         self.feed_spec = [
             {
                 "range": [0, 1]
@@ -45,35 +27,35 @@ class Conv2dConfig(object):
             }  # filters
         ]
 
-    def filter_shape(self, for_tensorflow=False):
+    def init_from_json(self, filename, config_id=0):
+        super(Conv2dConfig, self).init_from_json(filename, config_id)
         if self.data_format == "NCHW":
-            num_channels = self.input_shape[1]
+            self.num_channels = self.input_shape[1]
         elif self.data_format == "NHWC":
-            num_channels = self.input_shape[4]
-        if not for_tensorflow:
-            return [
-                self.num_filters, num_channels, self.filter_size[0],
-                self.filter_size[1]
-            ]
-        else:
-            return [
-                self.filter_size[0], self.filter_size[1], num_channels,
-                self.num_filters
-            ]
+            self.num_channels = self.input_shape[4]
+        self.filter_shape = [
+            self.num_filters, self.num_channels, self.filter_size[0],
+            self.filter_size[1]
+        ]
 
-    def padding(self, for_tensorflow=False):
-        if not for_tensorflow or isinstance(self._padding, str):
-            return self._padding
+    def to_tensorflow(self):
+        tf_config = self
+        tf_config.filter_shape = [
+            self.filter_size[0], self.filter_size[1], self.num_channels,
+            self.num_filters
+        ]
+        tf_config.padding = self._convert_padding(self.padding)
+        return tf_config
 
-        assert isinstance(self._padding, list)
-        pad_top = self._padding[0] if len(
-            self._padding) == 2 else self._padding[0]
-        pad_bottom = self._padding[0] if len(
-            self._padding) == 2 else self._padding[1]
-        pad_left = self._padding[1] if len(
-            self._padding) == 2 else self._padding[2]
-        pad_right = self._padding[1] if len(
-            self._padding) == 2 else self._padding[3]
+    def _convert_padding(self, padding):
+        if isinstance(padding, str):
+            return padding
+
+        assert isinstance(padding, list)
+        pad_top = padding[0] if len(padding) == 2 else padding[0]
+        pad_bottom = padding[0] if len(padding) == 2 else padding[1]
+        pad_left = padding[1] if len(padding) == 2 else padding[2]
+        pad_right = padding[1] if len(padding) == 2 else padding[3]
 
         if self.data_format == "NCHW":
             return [[0, 0], [0, 0], [pad_top, pad_bottom],
@@ -83,40 +65,25 @@ class Conv2dConfig(object):
                     [0, 0]]
 
 
-#config = Conv2dConfig(input_shape=[32, 3, 224, 224],
-#                      num_filters=64,
-#                      filter_size=[7, 7],
-#                      stride=[2, 2],
-#                      padding="SAME")
-
-config = Conv2dConfig(
-    input_shape=[1, 1, 80, 1008],
-    num_filters=1,
-    filter_size=[3, 32],
-    stride=[1, 16],
-    padding=[1, 8])
-
-
-class PDConv2d(paddle_api.PaddleAPIBenchmarkBase):
-    def build_program(self, backward=False, dtype=None):
-        import paddle.fluid as fluid
-
-        self.name = "conv2d"
+class PDConv2d(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
         with fluid.program_guard(self.main_program, self.startup_program):
             input = fluid.data(
                 name='input',
                 shape=config.input_shape,
-                dtype=dtype,
+                dtype=config.input_dtype,
                 lod_level=0)
             filter = fluid.layers.create_parameter(
-                name='filter', shape=config.filter_shape(), dtype=dtype)
+                name='filter',
+                shape=config.filter_shape,
+                dtype=config.input_dtype)
             input.stop_gradient = False
             result = fluid.layers.conv2d(
                 input=input,
                 num_filters=config.num_filters,
                 filter_size=config.filter_size,
                 stride=config.stride,
-                padding=config.padding(),
+                padding=config.padding,
                 dilation=config.dilation,
                 groups=config.groups,
                 param_attr='filter',
@@ -127,37 +94,39 @@ class PDConv2d(paddle_api.PaddleAPIBenchmarkBase):
 
             self.feed_vars = [input, filter]
             self.fetch_vars = [result]
-            if backward:
+            if config.backward:
                 self.append_gradients(result, [input])
 
 
-class TFConv2d(tensorflow_api.TensorflowAPIBenchmarkBase):
-    def build_graph(self, backward=False, dtype=None):
-        import tensorflow as tf
-
-        self.name = "conv2d"
-        self.allow_growth = True
-
-        input = tf.placeholder(
-            name='input', shape=config.input_shape, dtype=tf.float32)
-        filter = tf.placeholder(
-            name='filter',
-            shape=config.filter_shape(for_tensorflow=True),
-            dtype=tf.float32)
-        result = tf.nn.conv2d(
-            input=input,
-            filter=filter,
-            strides=config.stride,
-            padding=config.padding(for_tensorflow=True),
-            data_format=config.data_format,
-            dilations=config.dilation,
-            use_cudnn_on_gpu=config.use_cudnn)
+class TFConv2d(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        input = self.placeholder(
+            name='input', shape=config.input_shape, dtype=config.input_dtype)
+        filter = self.placeholder(
+            name='filter', shape=config.filter_shape, dtype=config.input_dtype)
+        if tf.__version__ <= "1.15.0":
+            result = tf.nn.conv2d(
+                input=input,
+                filters=filter,
+                strides=config.stride,
+                padding=config.padding,
+                data_format=config.data_format,
+                dilations=config.dilation,
+                use_cudnn_on_gpu=config.use_cudnn)
+        else:
+            result = tf.nn.conv2d(
+                input=input,
+                filters=filter,
+                strides=config.stride,
+                padding=config.padding,
+                data_format=config.data_format,
+                dilations=config.dilation)
 
         self.feed_list = [input, filter]
         self.fetch_list = [result]
-        if backward:
+        if config.backward:
             self.append_gradients(result, [input])
 
 
 if __name__ == '__main__':
-    test_main(PDConv2d(), TFConv2d(), feed_spec=config.feed_spec)
+    test_main(PDConv2d(), TFConv2d(), config=Conv2dConfig())

--- a/api/tests/examples/concat.json
+++ b/api/tests/examples/concat.json
@@ -1,0 +1,22 @@
+[{
+    "op": "concat",
+    "param_info": {
+        "input": {
+            "type": "list<Variable>",
+            "input_0": {
+                "type": "Variable",
+                "dtype": "float32",
+                "shape": "[16L, 2L, 4L, 5L]"
+            },
+            "input_1": {
+                "type": "Variable",
+                "dtype": "float32",
+                "shape": "[32L, 2L, 4L, 5L]"
+            }
+        },
+        "axis": {
+            "type": "int",
+            "value": "0"
+        }
+    }
+}]

--- a/api/tests/examples/conv2d.json
+++ b/api/tests/examples/conv2d.json
@@ -7,39 +7,39 @@
             "shape": "[32L, 3L, 224L, 224L]"
         },
         "num_filters": {
-            "dtype": "int",
+            "type": "int",
             "value": "64"
         },
         "filter_size": {
-            "dtype": "list",
+            "type": "list",
             "value": "[11, 11]"
         },
         "stride": {
-            "dtype": "list",
+            "type": "list",
             "value": "[4, 4]"
         },
         "padding": {
-            "dtype": "list",
+            "type": "list",
             "value": "[2, 2]"
         },
         "dilation": {
-            "dtype": "list",
+            "type": "list",
             "value": "[1, 1]"
         },
         "groups": {
-            "dtype": "int",
+            "type": "int",
             "value": "1"
         },
         "use_cudnn": {
-            "dtype": "bool",
+            "type": "bool",
             "value": "True"
         },
         "act": {
-            "dtype": "string",
+            "type": "string",
             "value": "None"
         },
         "data_format": {
-            "dtype": "string",
+            "type": "string",
             "value": "NCHW"
         }
     }
@@ -52,39 +52,39 @@
             "shape": "[1L, 1L, 80L, 1008L]"
         },
         "num_filters": {
-            "dtype": "int",
+            "type": "int",
             "value": "1"
         },
         "filter_size": {
-            "dtype": "list",
+            "type": "list",
             "value": "[3, 32]"
         },
         "stride": {
-            "dtype": "list",
+            "type": "list",
             "value": "[1, 16]"
         },
         "padding": {
-            "dtype": "list",
+            "type": "list",
             "value": "[1, 8]"
         },
         "dilation": {
-            "dtype": "list",
+            "type": "list",
             "value": "[1, 1]"
         },
         "groups": {
-            "dtype": "int",
+            "type": "int",
             "value": "1"
         },
         "use_cudnn": {
-            "dtype": "bool",
+            "type": "bool",
             "value": "True"
         },
         "act": {
-            "dtype": "string",
+            "type": "string",
             "value": "None"
         },
         "data_format": {
-            "dtype": "string",
+            "type": "string",
             "value": "NCHW"
         }
     }

--- a/api/tests/examples/conv2d.json
+++ b/api/tests/examples/conv2d.json
@@ -1,0 +1,91 @@
+[{
+    "op": "conv2d",
+    "param_info": {
+        "input": {
+            "type": "Variable",
+            "dtype": "float32",
+            "shape": "[32L, 3L, 224L, 224L]"
+        },
+        "num_filters": {
+            "dtype": "int",
+            "value": "64"
+        },
+        "filter_size": {
+            "dtype": "list",
+            "value": "[11, 11]"
+        },
+        "stride": {
+            "dtype": "list",
+            "value": "[4, 4]"
+        },
+        "padding": {
+            "dtype": "list",
+            "value": "[2, 2]"
+        },
+        "dilation": {
+            "dtype": "list",
+            "value": "[1, 1]"
+        },
+        "groups": {
+            "dtype": "int",
+            "value": "1"
+        },
+        "use_cudnn": {
+            "dtype": "bool",
+            "value": "True"
+        },
+        "act": {
+            "dtype": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "dtype": "string",
+            "value": "NCHW"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "input": {
+            "type": "Variable",
+            "dtype": "float32",
+            "shape": "[1L, 1L, 80L, 1008L]"
+        },
+        "num_filters": {
+            "dtype": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "dtype": "list",
+            "value": "[3, 32]"
+        },
+        "stride": {
+            "dtype": "list",
+            "value": "[1, 16]"
+        },
+        "padding": {
+            "dtype": "list",
+            "value": "[1, 8]"
+        },
+        "dilation": {
+            "dtype": "list",
+            "value": "[1, 1]"
+        },
+        "groups": {
+            "dtype": "int",
+            "value": "1"
+        },
+        "use_cudnn": {
+            "dtype": "bool",
+            "value": "True"
+        },
+        "act": {
+            "dtype": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "dtype": "string",
+            "value": "NCHW"
+        }
+    }
+}]

--- a/api/tests/examples/expand.json
+++ b/api/tests/examples/expand.json
@@ -7,7 +7,7 @@
             "shape": "[32L, 807L, 1L]"
         },
         "expand_times": {
-            "dtype": "list",
+            "type": "list",
             "value": "[4, 1, 807]"
         }
     }
@@ -20,7 +20,7 @@
             "shape": "[32L, 807L, 807L]"
         },
         "expand_times": {
-            "dtype": "list",
+            "type": "list",
             "value": "[4, 1, 1]"
         }
     }

--- a/api/tests/examples/fc.json
+++ b/api/tests/examples/fc.json
@@ -1,43 +1,43 @@
 [{
     "op": "fc",
     "param_info": {
-        "act": {
-            "dtype": "string",
-            "value": "relu"
-        },
         "input": {
             "type": "Variable",
             "dtype": "float32",
             "shape": "[16L, 256L, 6L, 6L]"
         },
+        "size": {
+            "type": "int",
+            "value": "4096"
+        },
         "num_flatten_dims": {
-            "dtype": "int",
+            "type": "int",
             "value": "1"
         },
-        "size": {
-            "dtype": "int",
-            "value": "4096"
+        "act": {
+            "type": "string",
+            "value": "relu"
         }
     }
 }, {
     "op": "fc",
     "param_info": {
-        "act": {
-            "dtype": "string",
-            "value": "None"
-        },
         "input": {
             "type": "Variable",
             "dtype": "float32",
             "shape": "[16L, 256L, 5L, 5L]"
         },
+        "size": {
+            "type": "int",
+            "value": "4096"
+        },
         "num_flatten_dims": {
-            "dtype": "int",
+            "type": "int",
             "value": "1"
         },
-        "size": {
-            "dtype": "int",
-            "value": "4096"
+        "act": {
+            "type": "string",
+            "value": "None"
         }
     }
 }]

--- a/api/tests/examples/fill_constant.json
+++ b/api/tests/examples/fill_constant.json
@@ -2,15 +2,15 @@
     "op": "fill_constant",
     "param_info": {
         "shape": {
-            "dtype": "list",
+            "type": "list",
             "value": "[16L, 10L, 100L, 100L]"
         },
         "dtype": {
-            "dtype": "string",
+            "type": "string",
             "value": "int64"
         },
         "value": {
-            "dtype": "int64",
+            "type": "int64",
             "value": "3"
         }
     }

--- a/api/tests/examples/reduce_mean.json
+++ b/api/tests/examples/reduce_mean.json
@@ -7,11 +7,11 @@
             "shape": "[32L, 128L]"
         },
         "dim": {
-            "dtype": "int",
+            "type": "int",
             "value": "0"
         },
         "keep_dim": {
-            "dtype": "bool",
+            "type": "bool",
             "value": "False"
         }
     }

--- a/api/tests/examples/scale.json
+++ b/api/tests/examples/scale.json
@@ -7,7 +7,7 @@
             "shape": "[32L, 128L]"
         },
         "scale": {
-            "dtype": "float",
+            "type": "float",
             "value": "2.0"
         }
     }

--- a/api/tests/examples/unsqueeze.json
+++ b/api/tests/examples/unsqueeze.json
@@ -7,7 +7,7 @@
             "shape": "[32L, 128L, 256L]"
         },
         "axes": {
-            "dtype": "int",
+            "type": "int",
             "value": "1"
         }
     }

--- a/api/tests/expand.py
+++ b/api/tests/expand.py
@@ -12,19 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
-from common import api_param
+from common_import import *
 
 
-class PDExpand(paddle_api.PaddleAPIBenchmarkBase):
+class PDExpand(PaddleAPIBenchmarkBase):
     def build_program(self, config):
-        import paddle.fluid as fluid
-
         with fluid.program_guard(self.main_program, self.startup_program):
             x = fluid.data(
                 name='x',
@@ -40,12 +32,10 @@ class PDExpand(paddle_api.PaddleAPIBenchmarkBase):
                 self.append_gradients(result, [x])
 
 
-class TFExpand(tensorflow_api.TensorflowAPIBenchmarkBase):
+class TFExpand(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
-        import tensorflow as tf
-
-        x = tf.placeholder(
-            name='x', shape=config.x_shape, dtype=tf.as_dtype(config.x_dtype))
+        x = self.placeholder(
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
         result = tf.tile(input=x, multiples=config.expand_times)
 
         self.feed_list = [x]
@@ -55,4 +45,4 @@ class TFExpand(tensorflow_api.TensorflowAPIBenchmarkBase):
 
 
 if __name__ == '__main__':
-    test_main(PDExpand(), TFExpand(), config=api_param.APIConfig("expand"))
+    test_main(PDExpand(), TFExpand(), config=APIConfig("expand"))

--- a/api/tests/fc.py
+++ b/api/tests/fc.py
@@ -79,16 +79,23 @@ class TFFC(tensorflow_api.TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
         import tensorflow as tf
 
-        input = tf.placeholder(
-            name="input",
-            shape=config.input_shape,
-            dtype=tf.as_dtype(config.input_dtype))
-        result = tf.contrib.layers.fully_connected(
-            inputs=input,
-            num_outputs=config.size,
-            weights_initializer=tf.constant_initializer(0.5),
-            biases_initializer=tf.constant_initializer(0.1),
-            activation_fn=config.act)
+        input = self.placeholder(
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
+        if tf.__version__ <= "1.15.0":
+            result = tf.contrib.layers.fully_connected(
+                inputs=input,
+                num_outputs=config.size,
+                weights_initializer=tf.constant_initializer(0.5),
+                biases_initializer=tf.constant_initializer(0.1),
+                activation_fn=config.act)
+        else:
+            result = tf.compat.v1.layers.dense(
+                inputs=input,
+                units=config.size,
+                activation=config.act,
+                use_bias=True,
+                kernel_initializer=tf.constant_initializer(0.5),
+                bias_initializer=tf.constant_initializer(0.1))
 
         self.feed_list = [input]
         self.fetch_list = [result]

--- a/api/tests/fc.py
+++ b/api/tests/fc.py
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
-from common import api_param
+from common_import import *
 
 
-class FCConfig(api_param.APIConfig):
+class FCConfig(APIConfig):
     def __init__(self):
         super(FCConfig, self).__init__('fc')
 
@@ -48,10 +42,8 @@ class FCConfig(api_param.APIConfig):
         return tf_config
 
 
-class PDFC(paddle_api.PaddleAPIBenchmarkBase):
+class PDFC(PaddleAPIBenchmarkBase):
     def build_program(self, config):
-        import paddle.fluid as fluid
-
         with fluid.program_guard(self.main_program, self.startup_program):
             input = fluid.data(
                 name="input",
@@ -75,10 +67,8 @@ class PDFC(paddle_api.PaddleAPIBenchmarkBase):
                 self.append_gradients(result, [input])
 
 
-class TFFC(tensorflow_api.TensorflowAPIBenchmarkBase):
+class TFFC(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
-        import tensorflow as tf
-
         input = self.placeholder(
             name="input", shape=config.input_shape, dtype=config.input_dtype)
         if tf.__version__ <= "1.15.0":

--- a/api/tests/fc.py
+++ b/api/tests/fc.py
@@ -35,7 +35,6 @@ class FCConfig(APIConfig):
         self.num_flatten_dims = -1
 
     def to_tensorflow(self):
-        import tensorflow as tf
         tf_config = self
         if self.act == "relu":
             tf_config.act = tf.nn.relu

--- a/api/tests/fill_constant.py
+++ b/api/tests/fill_constant.py
@@ -12,19 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
-from common import api_param
+from common_import import *
 
 
-class PDFillConstant(paddle_api.PaddleAPIBenchmarkBase):
+class PDFillConstant(PaddleAPIBenchmarkBase):
     def build_program(self, config):
-        import paddle.fluid as fluid
-
         with fluid.program_guard(self.main_program, self.startup_program):
             result = fluid.layers.fill_constant(
                 shape=config.shape, dtype=config.dtype, value=config.value)
@@ -33,10 +25,8 @@ class PDFillConstant(paddle_api.PaddleAPIBenchmarkBase):
             self.fetch_vars = [result]
 
 
-class TFFillConstant(tensorflow_api.TensorflowAPIBenchmarkBase):
+class TFFillConstant(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
-        import tensorflow as tf
-
         result = tf.constant(
             shape=config.shape,
             dtype=tf.as_dtype(config.dtype),
@@ -48,6 +38,4 @@ class TFFillConstant(tensorflow_api.TensorflowAPIBenchmarkBase):
 
 if __name__ == '__main__':
     test_main(
-        PDFillConstant(),
-        TFFillConstant(),
-        config=api_param.APIConfig("fill_constant"))
+        PDFillConstant(), TFFillConstant(), config=APIConfig("fill_constant"))

--- a/api/tests/reduce_mean.py
+++ b/api/tests/reduce_mean.py
@@ -12,20 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
-from common import api_param
+from common_import import *
 
 
-class PDReduceMean(paddle_api.PaddleAPIBenchmarkBase):
+class PDReduceMean(PaddleAPIBenchmarkBase):
     def build_program(self, config):
-        import paddle.fluid as fluid
-
-        self.name = "reduce_mean"
         with fluid.program_guard(self.main_program, self.startup_program):
             input = fluid.data(
                 name='input',
@@ -42,17 +33,10 @@ class PDReduceMean(paddle_api.PaddleAPIBenchmarkBase):
                 self.append_gradients(result, [input])
 
 
-class TFReduceMean(tensorflow_api.TensorflowAPIBenchmarkBase):
+class TFReduceMean(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
-        import tensorflow as tf
-
-        self.name = "reduce_mean"
-        self.allow_growth = True
-
-        input = tf.placeholder(
-            name='input',
-            shape=config.input_shape,
-            dtype=tf.as_dtype(config.input_dtype))
+        input = self.placeholder(
+            name='input', shape=config.input_shape, dtype=config.input_dtype)
         result = tf.reduce_mean(
             input_tensor=input, axis=config.dim, keepdims=config.keep_dim)
 
@@ -63,7 +47,4 @@ class TFReduceMean(tensorflow_api.TensorflowAPIBenchmarkBase):
 
 
 if __name__ == '__main__':
-    test_main(
-        PDReduceMean(),
-        TFReduceMean(),
-        config=api_param.APIConfig("reduce_mean", ""))
+    test_main(PDReduceMean(), TFReduceMean(), config=APIConfig("reduce_mean"))

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -5,13 +5,14 @@ export CUDA_VISIBLE_DEVICES="1"
 #export LD_LIBRARY_PATH=/work/cudnn/cudnn-7.6.5/lib64:${LD_LIBRARY_PATH}
 
 name=${1:-"abs"}
+config_id=${2:-"0"}
 filename="examples/${name}.json"
 
 python ${name}.py \
       --task "accuracy" \
       --framework "paddle" \
       --json_file ${filename} \
-      --config_id 0 \
+      --config_id ${config_id} \
       --run_with_executor True \
       --check_output False \
       --profiler "none" \

--- a/api/tests/scale.py
+++ b/api/tests/scale.py
@@ -12,19 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
-from common import api_param
+from common_import import *
 
 
-class PDScale(paddle_api.PaddleAPIBenchmarkBase):
+class PDScale(PaddleAPIBenchmarkBase):
     def build_program(self, config):
-        import paddle.fluid as fluid
-
         with fluid.program_guard(self.main_program, self.startup_program):
             x = fluid.data(
                 name='x',
@@ -43,12 +35,10 @@ class PDScale(paddle_api.PaddleAPIBenchmarkBase):
             self.fetch_vars = [result]
 
 
-class TFScale(tensorflow_api.TensorflowAPIBenchmarkBase):
+class TFScale(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
-        import tensorflow as tf
-
-        x = tf.placeholder(
-            name='x', shape=config.x_shape, dtype=tf.as_dtype(config.x_dtype))
+        x = self.placeholder(
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
         result = tf.scalar_mul(scalar=config.scale, x=x)
 
         self.feed_list = [x]
@@ -56,4 +46,4 @@ class TFScale(tensorflow_api.TensorflowAPIBenchmarkBase):
 
 
 if __name__ == '__main__':
-    test_main(PDScale(), TFScale(), config=api_param.APIConfig("scale"))
+    test_main(PDScale(), TFScale(), config=APIConfig("scale"))

--- a/api/tests/sigmoid.py
+++ b/api/tests/sigmoid.py
@@ -12,19 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
-from common import api_param
+from common_import import *
 
 
-class PDSigmoid(paddle_api.PaddleAPIBenchmarkBase):
+class PDSigmoid(PaddleAPIBenchmarkBase):
     def build_program(self, config):
-        import paddle.fluid as fluid
-
         with fluid.program_guard(self.main_program, self.startup_program):
             data = fluid.data(
                 name='data',
@@ -40,14 +32,10 @@ class PDSigmoid(paddle_api.PaddleAPIBenchmarkBase):
                 self.append_gradients(result, [data])
 
 
-class TFSigmoid(tensorflow_api.TensorflowAPIBenchmarkBase):
+class TFSigmoid(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
-        import tensorflow as tf
-
-        data = tf.placeholder(
-            name='data',
-            shape=config.x_shape,
-            dtype=tf.as_dtype(config.x_dtype))
+        data = self.placeholder(
+            name='data', shape=config.x_shape, dtype=config.x_dtype)
         result = tf.sigmoid(x=data)
 
         self.feed_list = [data]
@@ -57,4 +45,4 @@ class TFSigmoid(tensorflow_api.TensorflowAPIBenchmarkBase):
 
 
 if __name__ == '__main__':
-    test_main(PDSigmoid(), TFSigmoid(), config=api_param.APIConfig("sigmoid"))
+    test_main(PDSigmoid(), TFSigmoid(), config=APIConfig("sigmoid"))

--- a/api/tests/square.py
+++ b/api/tests/square.py
@@ -12,19 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
-from common import api_param
+from common_import import *
 
 
-class PDSquare(paddle_api.PaddleAPIBenchmarkBase):
+class PDSquare(PaddleAPIBenchmarkBase):
     def build_program(self, config):
-        import paddle.fluid as fluid
-
         with fluid.program_guard(self.main_program, self.startup_program):
             x = fluid.data(
                 name='x',
@@ -40,12 +32,10 @@ class PDSquare(paddle_api.PaddleAPIBenchmarkBase):
                 self.append_gradients(result, [x])
 
 
-class TFSquare(tensorflow_api.TensorflowAPIBenchmarkBase):
+class TFSquare(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
-        import tensorflow as tf
-
-        x = tf.placeholder(
-            name='x', shape=config.x_shape, dtype=tf.as_dtype(config.x_dtype))
+        x = self.placeholder(
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
         result = tf.square(x=x)
 
         self.feed_list = [x]
@@ -55,4 +45,4 @@ class TFSquare(tensorflow_api.TensorflowAPIBenchmarkBase):
 
 
 if __name__ == '__main__':
-    test_main(PDSquare(), TFSquare(), config=api_param.APIConfig("square"))
+    test_main(PDSquare(), TFSquare(), config=APIConfig("square"))

--- a/api/tests/unsqueeze.py
+++ b/api/tests/unsqueeze.py
@@ -12,19 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
-from common import api_param
+from common_import import *
 
 
-class PDUnsqueeze(paddle_api.PaddleAPIBenchmarkBase):
+class PDUnsqueeze(PaddleAPIBenchmarkBase):
     def build_program(self, config):
-        import paddle.fluid as fluid
-
         with fluid.program_guard(self.main_program, self.startup_program):
             input = fluid.data(
                 name='input',
@@ -40,14 +32,10 @@ class PDUnsqueeze(paddle_api.PaddleAPIBenchmarkBase):
                 self.append_gradients(result, [input])
 
 
-class TFUnsqueeze(tensorflow_api.TensorflowAPIBenchmarkBase):
+class TFUnsqueeze(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
-        import tensorflow as tf
-
-        input = tf.placeholder(
-            name='input',
-            shape=config.input_shape,
-            dtype=tf.as_dtype(config.input_dtype))
+        input = self.placeholder(
+            name='input', shape=config.input_shape, dtype=config.input_dtype)
         result = tf.expand_dims(input=input, axis=config.axes)
 
         self.feed_list = [input]
@@ -57,5 +45,4 @@ class TFUnsqueeze(tensorflow_api.TensorflowAPIBenchmarkBase):
 
 
 if __name__ == '__main__':
-    test_main(
-        PDUnsqueeze(), TFUnsqueeze(), config=api_param.APIConfig("unsqueeze"))
+    test_main(PDUnsqueeze(), TFUnsqueeze(), config=APIConfig("unsqueeze"))


### PR DESCRIPTION
- 支持tensorflow 2.0.0以上的版本。`TensorflowAPIBenchmarkBase`封装了一个`placeholder`函数，方便组网代码的编写。
- 简化`import`语句，将公共的部分抽取到一个`common_import.py`文件中。
- 更新了`conv2d`的测试脚本。**说明：`conv2d`没有支持所有不同类型的参数配置，比如padding支持的参数类型可以为int、list、str，后面需要强化**。
- 支持输入类型为`list of Variable`，更新`concat`的测试脚本