### PR TITLE
Support parse of tuple and enhance the codes of testing all configs in a json file

### DIFF
--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -16,21 +16,26 @@ from __future__ import print_function
 
 import traceback
 import numpy as np
+import json
+import collections
 
 
-def compare(output1, output2):
+def compare(output1, output2, atol):
     if not isinstance(output1, np.ndarray) or not isinstance(output2,
                                                              np.ndarray):
         raise TypeError("input argument's type should be numpy.ndarray.")
 
     max_diff = -0.0
+    offset = -1
     try:
         assert len(output1) == len(output2)
-        max_diff = np.amax(np.absolute(output1 - output2))
-        assert np.allclose(output1, output2, rtol=1.e-6, atol=0)
+        diff = np.abs(output1 - output2)
+        max_diff = np.max(diff)
+        offset = np.argmax(diff)
+        assert np.allclose(output1, output2, atol=atol)
     except (AssertionError) as e:
-        print("Meet AssertError!!!")
-    return max_diff
+        pass
+    return max_diff, offset
 
 
 def check_outputs(list1, list2, name=None):
@@ -40,6 +45,7 @@ def check_outputs(list1, list2, name=None):
 
     consistent = True
     max_diff = 0.0
+    atol = 1e-6
 
     assert len(list1) == len(list2)
     num_outputs = len(list1)
@@ -47,17 +53,28 @@ def check_outputs(list1, list2, name=None):
         output1 = list1[i]
         output2 = list2[i]
 
-        diff = compare(output1, output2)
-        max_diff = diff if diff > max_diff else max_diff
-        if max_diff > 1.e-6:
+        max_diff_i, offset_i = compare(output1, output2, atol)
+        if max_diff_i > atol:
+            print(
+                "---- The %d-th output (shape: %s, data type: %s) has diff. The maximum diff is %e, offset is %d: %e vs %e."
+                % (i, str(output1.shape), str(output1.dtype), max_diff_i,
+                   offset_i, output1.flatten()[offset_i],
+                   output2.flatten()[offset_i]))
+
+        max_diff = max_diff_i if max_diff_i > max_diff else max_diff
+        if max_diff > atol:
             consistent = False
+
+    status = collections.OrderedDict()
     if name is not None:
-        print(
-            "{ name: \"%s\", consistent: \"%s\", num_outputs: %d, diff: %.5f }"
-            % (name, str(consistent), num_outputs, max_diff))
-    else:
-        print("{ consistent: \"%s\", num_outputs: %d, diff: %.5f }" %
-              (str(consistent), num_outputs, max_diff))
+        status["name"] = name
+    status["consistent"] = consistent
+    status["num_outputs"] = num_outputs
+    status["diff"] = max_diff.astype("float")
+    print(json.dumps(status))
+
+    if not consistent:
+        assert consistent == True, "The output is not consistent."
 
 
 def get_stat(stats, key):
@@ -128,7 +145,7 @@ def print_stat(stats, log_level=0):
         # print all times
         seg_0 = 0
         seg_1 = 0
-    for i in xrange(len(runtimes)):
+    for i in range(len(runtimes)):
         if i < seg_0 or i >= seg_1:
             print("Iter {0}, Runtime: {1}".format("%4d" % i, "%.5f ms" %
                                                   runtimes[i]))

--- a/api/common/white_list.py
+++ b/api/common/white_list.py
@@ -1,0 +1,15 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RANDOM_OP_LIST = ["dropout"]

--- a/api/tests/dropout.py
+++ b/api/tests/dropout.py
@@ -12,55 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main
-
-import sys
-sys.path.append("..")
-from common import paddle_api_benchmark as paddle_api
-from common import tensorflow_api_benchmark as tensorflow_api
+from common_import import *
 
 
-class PDDropout(paddle_api.PaddleAPIBenchmarkBase):
-    def build_program(self, backward=False, dtype=None):
-        import paddle.fluid as fluid
-
-        self.name = "dropout"
+class PDDropout(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
         with fluid.program_guard(self.main_program, self.startup_program):
-            data = fluid.data(
-                name='data',
-                shape=[10, 10, 100, 100],
-                dtype='float32',
+            x = fluid.data(
+                name='x',
+                shape=config.x_shape,
+                dtype=config.x_dtype,
                 lod_level=0)
-            data.stop_gradient = False
+            x.stop_gradient = False
             result = fluid.layers.dropout(
-                x=data,
-                dropout_prob=0.2,
+                x=x,
+                dropout_prob=config.dropout_prob,
                 seed=123,
-                dropout_implementation="upscale_in_train")
+                dropout_implementation=config.dropout_implementation)
 
-            self.feed_vars = [data]
+            self.feed_vars = [x]
             self.fetch_vars = [result]
-            if backward:
-                self.append_gradients(result, [data])
+            if config.backward:
+                self.append_gradients(result, [x])
 
 
-class TFDropout(tensorflow_api.TensorflowAPIBenchmarkBase):
-    def build_graph(self, backward=False, dtype=None):
-        import tensorflow as tf
+class TFDropout(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.placeholder(
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = tf.nn.dropout(
+            x=x, rate=config.dropout_prob, noise_shape=None, seed=123)
 
-        self.name = "dropout"
-        self.allow_growth = True
-
-        data = tf.placeholder(
-            name='data', shape=[10, 10, 100, 100], dtype=tf.float32)
-        result = tf.nn.dropout(x=data, rate=0.2, noise_shape=None, seed=123)
-
-        self.feed_list = [data]
+        self.feed_list = [x]
         self.fetch_list = [result]
-        if backward:
-            self.append_gradients(result, [data])
+        if config.backward:
+            self.append_gradients(result, [x])
 
 
 if __name__ == '__main__':
-    # Not consitent!!!
-    test_main(PDDropout(), TFDropout(), feed_spec=None)
+    test_main(PDDropout(), TFDropout(), config=APIConfig("dropout"))

--- a/api/tests/examples/conv2d.json
+++ b/api/tests/examples/conv2d.json
@@ -56,20 +56,20 @@
             "value": "1"
         },
         "filter_size": {
-            "type": "list",
-            "value": "[3, 32]"
+            "type": "tuple",
+            "value": "(3, 32)"
         },
         "stride": {
-            "type": "list",
-            "value": "[1, 16]"
+            "type": "tuple",
+            "value": "(1, 16)"
         },
         "padding": {
-            "type": "list",
-            "value": "[1, 8]"
+            "type": "tuple",
+            "value": "(1, 8)"
         },
         "dilation": {
-            "type": "list",
-            "value": "[1, 1]"
+            "type": "tuple",
+            "value": "(1, 1)"
         },
         "groups": {
             "type": "int",

--- a/api/tests/examples/dropout.json
+++ b/api/tests/examples/dropout.json
@@ -1,0 +1,22 @@
+[{
+    "op": "dropout",
+    "param_info": {
+        "x": {
+            "type": "Variable",
+            "dtype": "float32",
+            "shape": "[20L, 35L, 1500L]"
+        },
+        "dropout_prob": {
+            "type": "float",
+            "value": "0.65"
+        },
+        "dropout_implementation": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "is_test": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}]

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -163,7 +163,7 @@ def run_tensorflow(task, obj, args, feed_list=None):
 
 
 def copy_feed_spec(config=None):
-    if config is None:
+    if config is None or config.feed_spec is None:
         return None
     feed_spec = []
     for feed_item in config.feed_spec:

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -165,6 +165,9 @@ def run_tensorflow(task, obj, args, feed_list=None):
 def copy_feed_spec(config=None):
     if config is None or config.feed_spec is None:
         return None
+    if not isinstance(config.feed_spec, list):
+        config.feed_spec = [config.feed_spec]
+
     feed_spec = []
     for feed_item in config.feed_spec:
         item = {}

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ function run_api(){
         for api in ${HAS_MODIFIED_API_TEST[@]}
         do
             name=`echo $api |awk -F "/" '{print $NF}' |awk -F "." '{print $NR}'`
-            sh run.sh $name
+            sh run.sh $name -1
             if [ $? -ne 0 ]; then
                 fail_name[${#fail_name[@]}]="$name.py"
             fi

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -53,24 +53,36 @@ function run_api(){
     fetch_upstream_master_if_not_exist
     cd ${BENCHMARK_ROOT}/api/tests
     HAS_MODIFIED_API_TEST=`git diff --name-only upstream/$BRANCH | grep "api/tests" || true`
-    fail_name=()
+    API_NAMES=(abs fc)
     if [ "${HAS_MODIFIED_API_TEST}" != "" ] ; then
-        for api in ${HAS_MODIFIED_API_TEST[@]}
-        do
-            name=`echo $api |awk -F "/" '{print $NF}' |awk -F "." '{print $NR}'`
-            sh run.sh $name -1
-            if [ $? -ne 0 ]; then
-                fail_name[${#fail_name[@]}]="$name.py"
+        for api in ${HAS_MODIFIED_API_TEST[@]}; do
+            new_name=`echo $api |awk -F "/" '{print $NF}' |awk -F "." '{print $NR}'`
+            if [[ "$new_name" != "main" && "$new_name" != "feeder" && "$new_name" != "common_ops" ]]; then
+                need_append="yes"
+                for name in ${API_NAMES[@]}; do
+                    if [ "${name}" == "${new_name}" ]; then
+                        need_append="no"
+                        break
+                    fi
+                done
+                if [ "$need_append" == "yes" ]; then
+                    API_NAMES[${#API_NAMES[@]}]=${new_name}
+                fi
             fi
         done
-        len=${#fail_name[@]}
-        if [ $len -ne 0 ]; then
-            echo "Failed API TESTS: ${fail_name[@]}"
-            exit 1
+    fi
+
+    fail_name=()
+    for name in ${API_NAMES[@]}; do
+        sh run.sh $name -1
+        if [ $? -ne 0 ]; then
+            fail_name[${#fail_name[@]}]="$name.py"
         fi
-    else
-        echo "OP tests have no changed."
-        exit 0
+    done
+    len=${#fail_name[@]}
+    if [ $len -ne 0 ]; then
+        echo "Failed API TESTS: ${fail_name[@]}"
+        exit 1
     fi
 }
 


### PR DESCRIPTION
### op测试框架上的修改
- 支持参数类型是`tuple`
- 调整函数名：`test_main_without_json`支持不通过json配置进行测试，有一些op（比如控制流），不能通过json来配置，可以调用`test_main_without_json`
- 调整测试一个json文件中多个配置的代码。
- 精度检查失败时改成直接挂掉。
- 添加白名单功能，像dropout这种具有随机性的op，可以记录在白名单里面。

### CI脚本上的修改
- 即使没有修改op测试脚本，因为有可能修改了测试框架的代码，因此也需要测试abs、fc进行验证。
- 测试的op需要去重。
- api/tests目录下，main、feeder、common_ops三个文件不是op测试，需要排除
- 若op的json配置文件中存在多个配置时，则都需要测试 