### PR TITLE
Add script file to benchmark exp

### DIFF
--- a/api/tests/examples/exp.json
+++ b/api/tests/examples/exp.json
@@ -1,0 +1,10 @@
+[{
+    "op": "exp",
+    "param_info": {
+        "x": {
+            "type": "Variable",
+            "dtype": "float32",
+            "shape": "[16L, 10L, 100L, 100L]"
+        }
+    }
+}]

--- a/api/tests/exp.py
+++ b/api/tests/exp.py
@@ -1,0 +1,48 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDExp(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        with fluid.program_guard(self.main_program, self.startup_program):
+            data = fluid.data(
+                name='data',
+                shape=config.x_shape,
+                dtype=config.x_dtype,
+                lod_level=0)
+            data.stop_gradient = False
+            result = fluid.layers.exp(x=data)
+
+            self.feed_vars = [data]
+            self.fetch_vars = [result]
+            if config.backward:
+                self.append_gradients(result, [data])
+
+
+class TFExp(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        data = self.placeholder(
+            name='data', shape=config.x_shape, dtype=config.x_dtype)
+        result = tf.exp(x=data)
+
+        self.feed_list = [data]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [data])
+
+
+if __name__ == '__main__':
+    test_main(PDExp(), TFExp(), config=APIConfig("exp"))


### PR DESCRIPTION
Paddle和TensorFlow都使用eigen实现exp。

- paddle的nvprof结果
```
CUDA_VISIBLE_DEVICES is None, set to CUDA_VISIBLE_DEVICES=0
API params of <exp> {
  x_dtype: float32
  x_shape: [16, 10, 100, 100]
}
/usr/local/lib/python2.7/dist-packages/paddle/fluid/executor.py:1089: UserWarning: There are no operators in the program to be executed. If you pass Program manually, please use fluid.program_guard to ensure the current Program is being used.
  warnings.warn(error_info)
W0428 07:51:05.465719  2422 device_context.cc:263] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 10.0
W0428 07:51:05.470433  2422 device_context.cc:271] device: 0, cuDNN Version: 7.5.
{
  framework: "paddle",
  version: "0.0.0",
  name: "exp",
  device: "GPU",
  speed: { repeat: 100, start: 10, end: 90, total: 6.71273, feed: 0.00000, compute: 0.00000, fetch: 0.00000 }
}
==2422== Profiling application: python exp.py --run_with_executor True --check_output False --profiler none --backward false --use_gpu True --repeat 100 --log_level 0 --json_file examples/exp.json
==2422== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   50.06%  123.29ms       100  1.2329ms  1.1585ms  4.6144ms  [CUDA memcpy DtoH]
                   49.07%  120.84ms       103  1.1732ms  1.7280us  1.2678ms  [CUDA memcpy HtoD]
                    0.86%  2.1270ms       100  21.269us  20.672us  22.592us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_exp_op<float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                    0.00%  7.0390us         4  1.7590us  1.6000us  2.1440us  [CUDA memset]
      API calls:   46.79%  3.00555s         8  375.69ms  1.6110us  3.00518s  cudaStreamCreateWithFlags
                   26.13%  1.67851s         5  335.70ms  1.4520us  1.67850s  cudaStreamCreateWithPriority
                   12.68%  814.60ms       406  2.0064ms  4.9260us  68.450ms  cuModuleUnload
                    9.78%  628.19ms         4  157.05ms     552ns  628.19ms  cudaFree
                    4.38%  281.34ms       203  1.3859ms  16.933us  5.5996ms  cudaMemcpy
                    0.09%  5.9937ms       100  59.936us  54.844us  79.648us  cudaLaunchKernel
                    0.04%  2.3073ms         6  384.55us  377.00us  396.92us  cuDeviceTotalMem
                    0.03%  1.7753ms       564  3.1470us     125ns  137.34us  cuDeviceGetAttribute
                    0.02%  1.3795ms         1  1.3795ms  1.3795ms  1.3795ms  cudaHostAlloc
                    0.02%  1.3584ms        16  84.902us  5.0800us  413.70us  cudaMalloc
```
- tf的nvprof结果
```
{
  framework: "tensorflow",
  version: "1.15.0",
  name: "exp",
  device: "GPU",
  speed: { repeat: 100, start: 10, end: 90, total: 6.36468, feed: 0.00000, compute: 0.00000, fetch: 0.00000 }
}
==2518== Profiling application: python exp.py --run_with_executor True --check_output False --profiler none --backward false --use_gpu True --repeat 100 --log_level 0 --json_file examples/exp.json --framework tf
==2518== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   59.21%  128.77ms       100  1.2877ms  1.1117ms  2.7476ms  [CUDA memcpy HtoD]
                   40.25%  87.540ms       100  875.40us  845.40us  955.19us  [CUDA memcpy DtoH]
                    0.54%  1.1724ms       100  11.723us  11.008us  15.232us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_exp_op<float>, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, int>(float, int=1)
                    0.00%  2.5280us         1  2.5280us  2.5280us  2.5280us  [CUDA memset]
      API calls:   49.93%  1.82010s       400  4.5503ms  1.7220us  1.81507s  cudaPointerGetAttributes
                   25.73%  937.88ms         2  468.94ms  468.92ms  468.96ms  cuDevicePrimaryCtxRetain
                   15.91%  579.91ms       229  2.5324ms  11.257us  30.736ms  cuModuleUnload
                    3.90%  142.19ms       100  1.4219ms  1.1930ms  3.9898ms  cuMemcpyHtoDAsync
                    2.31%  84.238ms       102  825.87us  18.040us  950.14us  cuCtxSynchronize
                    0.66%  24.226ms         1  24.226ms  24.226ms  24.226ms  cuMemAlloc
                    0.33%  11.916ms         2  5.9578ms  5.3008ms  6.6148ms  cuMemHostAlloc
                    0.32%  11.638ms       808  14.403us     131ns  1.7317ms  cuDeviceGetAttribute
                    0.31%  11.393ms        18  632.97us  404.70us  1.3970ms  cuDeviceTotalMem
                    0.21%  7.6045ms       100  76.045us  57.102us  102.03us  cudaLaunchKernel
                    0.13%  4.6618ms      1664  2.8010us     614ns  58.366us  cuEventQuery
                    0.07%  2.6374ms         8  329.68us  271.64us  407.85us  cudaGetDeviceProperties
                    0.05%  1.9241ms       100  19.240us  12.182us  71.596us  cuMemcpyDtoHAsync
                    0.05%  1.7644ms       400  4.4110us     416ns  22.496us  cuEventRecord
                    0.03%  992.63us        20  49.631us  2.2580us  486.64us  cuStreamCreate
                    0.03%  918.13us        18  51.007us  23.033us  259.68us  cuDeviceGetName
```

- paddle使用32bitIndex优化后的结果，尽管有所提升，但依然比tf慢
```
==2727== Profiling application: python exp.py --run_with_executor True --check_output False --profiler none --backward false --use_gpu True --repeat 100 --log_level 0 --json_file examples/exp.json
==2727== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   51.78%  130.96ms       107  1.2239ms  1.6960us  1.6243ms  [CUDA memcpy HtoD]
                   47.56%  120.29ms       100  1.2029ms  1.0506ms  5.4673ms  [CUDA memcpy DtoH]
                    0.65%  1.6496ms       100  16.495us  15.616us  17.728us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_exp_op<float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, int>(float, int=1)
                    0.00%  7.0080us         4  1.7520us  1.6000us  2.1440us  [CUDA memset]
      API calls:   39.68%  3.74369s        11  340.34ms  2.4160us  3.74322s  cudaStreamCreateWithFlags
                   25.15%  2.37281s         5  474.56ms  2.1610us  2.37280s  cudaStreamCreateWithPriority
                   19.26%  1.81772s        10  181.77ms     726ns  934.83ms  cudaFree
                   12.54%  1.18335s       682  1.7351ms  5.2800us  73.342ms  cuModuleUnload
                    3.12%  294.66ms       207  1.4235ms  19.789us  6.6897ms  cudaMemcpy
                    0.07%  7.0321ms       100  70.320us  55.388us  99.586us  cudaLaunchKernel
                    0.05%  4.6632ms         8  582.90us  538.37us  628.58us  cuDeviceTotalMem
                    0.03%  2.9126ms       750  3.8830us     151ns  163.20us  cuDeviceGetAttribute
                    0.03%  2.5841ms        28  92.290us  6.9330us  621.38us  cudaMalloc
```