### PR TITLE
Use inspect to check and remove params in json config.

### DIFF
--- a/api/common/no_need_args.py
+++ b/api/common/no_need_args.py
@@ -12,22 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from main import test_main, test_main_without_json
-
-import sys
-sys.path.append("..")
-from common.paddle_api_benchmark import PaddleAPIBenchmarkBase
-from common.tensorflow_api_benchmark import TensorflowAPIBenchmarkBase
-from common.api_param import APIConfig
-
-try:
-    import paddle.fluid as fluid
-except ImportError:
-    sys.stderr.write(
-        "Cannot import paddle.fluid, maybe paddle is not installed.\n")
-
-try:
-    import tensorflow as tf
-except ImportError:
-    sys.stderr.write(
-        "Cannot import tensorflow, maybe tensorflow is not installed.\n")
+NO_NEED_ARGS = {"batch_norm": ["moving_mean_name", "moving_variance_name"]}

--- a/api/json/clear_params.py
+++ b/api/json/clear_params.py
@@ -1,0 +1,83 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import json
+import inspect
+import importlib
+import paddle.fluid as fluid
+
+import sys
+sys.path.append("..")
+from common.no_need_args import *
+
+
+def import_module(api_name):
+    try:
+        if api_name in ["embedding", "ont_hot"]:
+            module_name = "paddle.fluid"
+        else:
+            module_name = "paddle.fluid.layers"
+        module = importlib.import_module(module_name)
+        return getattr(module, api_name)
+    except ImportError:
+        print("Cannot immport %s.%s." % (module_name, api_name))
+        return None
+
+
+def check_and_clear_params(api_name, params, print_detail=False):
+    func = import_module(api_name)
+    if func is not None:
+        argspec = inspect.getargspec(func)
+        if print_detail:
+            print("API:", api_name, ",", argspec)
+
+        no_need_args = []
+        if api_name in NO_NEED_ARGS.keys():
+            no_need_args = NO_NEED_ARGS[api_name]
+            print(no_need_args)
+            print(type(no_need_args))
+        no_need_args.append("name")
+
+        for arg_name in argspec.args:
+            if arg_name not in no_need_args and arg_name not in params.keys():
+                if print_detail:
+                    print("   Argument %s is not set." % (arg_name))
+
+        for name, content in params.items():
+            if name not in argspec.args or name in no_need_args:
+                if print_detail:
+                    print("   Remove %s (type: %s, value: %s)." %
+                          (name, content["dtype"], content["value"]))
+                params.pop(name)
+
+        no_need_args.remove("name")
+
+
+if __name__ == '__main__':
+    op = "conv2d"
+    filename = "results/" + op + ".json"
+    cleared_filename = "results_cleared/" + op + ".json"
+    with open(filename, 'r') as f:
+        data = json.load(f)
+        print("-- Processing %s: including %d configs." %
+              (filename, len(data)))
+        for i in range(0, len(data)):
+            check_and_clear_params(
+                data[i]["op"], data[i]["param_info"], print_detail=True)
+    print("-- Writing %d cleared configs back to %s." %
+          (len(data), cleared_filename))
+    with open(cleared_filename, 'w') as f:
+        f.write(json.dumps(data, sort_keys=True, indent=4))


### PR DESCRIPTION
使用inspect获取API的参数列表，检查json中是否缺少参数、移除json中多余的参数。
一些处理的log如下：
- conv2d，bias_attr代表是否有bias、act是否需要支持，需要确定下。
```
-- Processing results/conv2d.json: including 23 configs.
API: conv2d , ArgSpec(args=['input', 'num_filters', 'filter_size', 'stride', 'padding', 'dilation', 'groups', 'param_attr', 'bias_attr', 'use_cudnn', 'act', 'name', 'data_format'], varargs=None, keywords=None, defaults=(1, 0, 1, None, None, None, True, None, None, 'NCHW'))
   Argument param_attr is not set.
   Argument bias_attr is not set.
   Argument act is not set.
   Remove num_channels (type: long, value: 3).
   Remove l_type (type: string, value: conv2d).
   Remove channel_last (type: bool, value: False).
```

- batch_norm
```
-- Processing results/batch_norm.json: including 53 configs.
API: batch_norm , ArgSpec(args=['input', 'act', 'is_test', 'momentum', 'epsilon', 'param_attr', 'bias_attr', 'data_layout', 'in_place', 'name', 'moving_mean_name', 'moving_variance_name', 'do_model_average_for_mean_and_var', 'use_global_stats'], varargs=None, keywords=None, defaults=(None, False, 0.9, 1e-05, None, None, 'NCHW', False, None, None, None, True, False))
['moving_mean_name', 'moving_variance_name']
<type 'list'>
   Argument param_attr is not set.
   Argument bias_attr is not set.
   Remove moving_mean_name (type: string, value: bn_conv1_mean).
   Remove moving_variance_name (type: string, value: bn_conv1_variance).
```

- fc
```
-- Processing results/fc.json: including 1 configs.
API: fc , ArgSpec(args=['input', 'size', 'num_flatten_dims', 'param_attr', 'bias_attr', 'act', 'name'], varargs=None, keywords=None, defaults=(1, None, None, None, None))
   Argument param_attr is not set.
   Argument bias_attr is not set.
   Argument act is not set.
-- Writing 1 cleared configs back to results_cleared/fc.json.
```

- pool2d
```
-- Processing results/pool2d.json: including 2 configs.
API: pool2d , ArgSpec(args=['input', 'pool_size', 'pool_type', 'pool_stride', 'pool_padding', 'global_pooling', 'use_cudnn', 'ceil_mode', 'name', 'exclusive', 'data_format'], varargs=None, keywords=None, defaults=(-1, 'max', 1, 0, False, True, False, None, True, 'NCHW'))
   Remove padding_algorithm (type: string, value: EXPLICIT).
API: pool2d , ArgSpec(args=['input', 'pool_size', 'pool_type', 'pool_stride', 'pool_padding', 'global_pooling', 'use_cudnn', 'ceil_mode', 'name', 'exclusive', 'data_format'], varargs=None, keywords=None, defaults=(-1, 'max', 1, 0, False, True, False, None, True, 'NCHW'))
   Remove padding_algorithm (type: string, value: EXPLICIT).
-- Writing 2 cleared configs back to results_cleared/pool2d.json.
```