### PR TITLE
fix config bug for conv2d

### DIFF
--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -33,8 +33,17 @@ class Conv2dConfig(APIConfig):
             self.num_channels = self.input_shape[1]
         elif self.data_format == "NHWC":
             self.num_channels = self.input_shape[4]
+        if self.input_shape[0] == -1:
+            self.input_shape[0] = 64 
+        if isinstance(self.filter_size, int):
+            self.filter_size = [self.filter_size, self.filter_size]
+        if self.num_channels % self.groups != 0:
+            raise ValueError(
+                "the channel of input must be divisible by groups,"
+                "received: the channel of input is {}, the shape of input is {}"
+                ", the groups is {}".format(self.num_channels, self.input_shape, self.groups))
         self.filter_shape = [
-            self.num_filters, self.num_channels, self.filter_size[0],
+            self.num_filters, self.num_channels // self.groups, self.filter_size[0],
             self.filter_size[1]
         ]
 
@@ -50,6 +59,8 @@ class Conv2dConfig(APIConfig):
     def _convert_padding(self, padding):
         if isinstance(padding, str):
             return padding
+        if isinstance(padding, int):
+            padding = [padding, padding]
 
         assert isinstance(padding, list)
         pad_top = padding[0] if len(padding) == 2 else padding[0]
@@ -116,7 +127,7 @@ class TFConv2d(TensorflowAPIBenchmarkBase):
         else:
             result = tf.nn.conv2d(
                 input=input,
-                filters=filter,
+                filter=filter,
                 strides=config.stride,
                 padding=config.padding,
                 data_format=config.data_format,


### PR DESCRIPTION
- [x] 支持filter_size和padding为int；tf的padding不支持int，必须时string或者list
- [x] 修复groups不为1时，filter_shape计算的bug
```
API params of <conv2d> {
  groups: 32
  act: relu
  filter_shape: [128, 128, 3, 3]
  data_format: NCHW
  input_shape: [64, 128, 56, 56]
  padding: 1
  use_cudnn: True
  input_dtype: float32
  dilation: 1
  stride: 1
  num_filters: 128
  filter_size: [3, 3]
  num_channels: 128
}
```
这种配置下，num_filter_channels = num_channels // groups = 128 // 32 = 4，但是原始的计算中直接取了num_channels=128。导致如下错误：
```
ValueError: Variable filter has been created before. the previous shape is (128L, 128L, 3L, 3L); the new shape is (128, 4, 3, 3). They are not matched.
```
- [x] tf在1.15之前的版本中，参数为filter不是fliters
