### PR TITLE
fix test code of conv2d for tf

### DIFF
--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -127,7 +127,7 @@ class TFConv2d(TensorflowAPIBenchmarkBase):
         else:
             result = tf.nn.conv2d(
                 input=input,
-                filter=filter,
+                filters=filter,
                 strides=config.stride,
                 padding=config.padding,
                 data_format=config.data_format,


### PR DESCRIPTION
- [x] 在#378 中修改tf的build_graph时改反了，此PR纠正修改。由于tf1.15版本中，支持filter和filters两种写法。故统一用filters
- [x] 使用该脚本，测试tf出现下面错误。需要cudnn7.6版本。
```
Traceback (most recent call last):
  File "conv2d.py", line 143, in <module>
    test_main(PDConv2d(), TFConv2d(), config=Conv2dConfig())
  File "/workspace/new-benchmark/benchmark/api/tests/main.py", line 188, in test_main
    test_main_without_json(pd_obj, tf_obj, config)
  File "/workspace/new-benchmark/benchmark/api/tests/main.py", line 229, in test_main_without_json
    tf_outputs = run_tensorflow(args.task, tf_obj, args, feed_list)
  File "/workspace/new-benchmark/benchmark/api/tests/main.py", line 156, in run_tensorflow
    profile=profile)
  File "../common/tensorflow_api_benchmark.py", line 165, in run
    run_metadata=run_metadata)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/client/session.py", line 956, in run
    run_metadata_ptr)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/client/session.py", line 1180, in _run
    feed_dict_tensor, options, run_metadata)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/client/session.py", line 1359, in _do_run
    run_metadata)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/client/session.py", line 1384, in _do_call
    raise type(e)(node_def, op, message)
tensorflow.python.framework.errors_impl.UnknownError: 2 root error(s) found.
  (0) Unknown: Failed to get convolution algorithm. This is probably because cuDNN failed to initialize, so try looking to see if a warning log message was printed above.
	 [[node Conv2D (defined at /usr/local/lib/python2.7/dist-packages/tensorflow_core/python/framework/ops.py:1751) ]]
  (1) Unknown: Failed to get convolution algorithm. This is probably because cuDNN failed to initialize, so try looking to see if a warning log message was printed above.
	 [[node Conv2D (defined at /usr/local/lib/python2.7/dist-packages/tensorflow_core/python/framework/ops.py:1751) ]]
	 [[Conv2D/_5]]
0 successful operations.
0 derived errors ignored.

Original stack trace for u'Conv2D':
  File "conv2d.py", line 143, in <module>
    test_main(PDConv2d(), TFConv2d(), config=Conv2dConfig())
  File "/workspace/new-benchmark/benchmark/api/tests/main.py", line 188, in test_main
    test_main_without_json(pd_obj, tf_obj, config)
  File "/workspace/new-benchmark/benchmark/api/tests/main.py", line 226, in test_main_without_json
    tf_obj.build_graph(config=tf_config)
  File "conv2d.py", line 134, in build_graph
    dilations=config.dilation)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/ops/nn_ops.py", line 1913, in conv2d_v2
    name=name)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/ops/nn_ops.py", line 2010, in conv2d
    name=name)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/ops/gen_nn_ops.py", line 1071, in conv2d
    data_format=data_format, dilations=dilations, name=name)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/framework/op_def_library.py", line 793, in _apply_op_helper
    op_def=op_def)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/util/deprecation.py", line 507, in new_func
    return func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/framework/ops.py", line 3360, in create_op
    attrs, op_def, compute_device)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/framework/ops.py", line 3429, in _create_op_internal
    op_def=op_def)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow_core/python/framework/ops.py", line 1751, in __init__
    self._traceback = tf_stack.extract_stack()
```