### PR TITLE
fix batch_norm to support api benchmark

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -92,6 +92,7 @@ class APIConfig(object):
         self.backward = False
         self.feed_spec = None
         self.atol = 1e-6
+        self.run_tf = True
 
     def init_from_json(self, filename, config_id=0):
         print("---- Initialize APIConfig from %s, config_id = %d.\n" %

--- a/api/tests/examples/batch_norm.json
+++ b/api/tests/examples/batch_norm.json
@@ -1,0 +1,370 @@
+[{
+    "op": "batch_norm",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "relu"
+        },
+        "data_layout": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "do_model_average_for_mean_and_var": {
+            "type": "bool",
+            "value": "True"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "in_place": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 256L]",
+            "type": "Variable"
+        },
+        "is_test": {
+            "type": "bool",
+            "value": "False"
+        },
+        "momentum": {
+            "type": "float",
+            "value": "0.9"
+        },
+        "use_global_stats": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "batch_norm",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_layout": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "do_model_average_for_mean_and_var": {
+            "type": "bool",
+            "value": "True"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "in_place": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 2048L]",
+            "type": "Variable"
+        },
+        "is_test": {
+            "type": "bool",
+            "value": "False"
+        },
+        "momentum": {
+            "type": "float",
+            "value": "0.9"
+        },
+        "use_global_stats": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "batch_norm",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_layout": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "do_model_average_for_mean_and_var": {
+            "type": "bool",
+            "value": "True"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "in_place": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 32768L]",
+            "type": "Variable"
+        },
+        "is_test": {
+            "type": "bool",
+            "value": "False"
+        },
+        "momentum": {
+            "type": "float",
+            "value": "0.9"
+        },
+        "use_global_stats": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "batch_norm",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "relu"
+        },
+        "data_layout": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "do_model_average_for_mean_and_var": {
+            "type": "bool",
+            "value": "True"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "in_place": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 512L, 7L, 7L]",
+            "type": "Variable"
+        },
+        "is_test": {
+            "type": "bool",
+            "value": "False"
+        },
+        "momentum": {
+            "type": "float",
+            "value": "0.9"
+        },
+        "use_global_stats": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "batch_norm",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_layout": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "do_model_average_for_mean_and_var": {
+            "type": "bool",
+            "value": "True"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "0.001"
+        },
+        "in_place": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 1536L, 33L, 33L]",
+            "type": "Variable"
+        },
+        "is_test": {
+            "type": "bool",
+            "value": "False"
+        },
+        "momentum": {
+            "type": "float",
+            "value": "0.99"
+        },
+        "use_global_stats": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "batch_norm",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_layout": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "do_model_average_for_mean_and_var": {
+            "type": "bool",
+            "value": "True"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "in_place": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 2048L, 16L, 402L]",
+            "type": "Variable"
+        },
+        "is_test": {
+            "type": "bool",
+            "value": "False"
+        },
+        "momentum": {
+            "type": "float",
+            "value": "0.9"
+        },
+        "use_global_stats": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "batch_norm",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_layout": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "do_model_average_for_mean_and_var": {
+            "type": "bool",
+            "value": "True"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "in_place": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 256L, 1L, 1L]",
+            "type": "Variable"
+        },
+        "is_test": {
+            "type": "bool",
+            "value": "False"
+        },
+        "momentum": {
+            "type": "float",
+            "value": "0.99"
+        },
+        "use_global_stats": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "batch_norm",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_layout": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "do_model_average_for_mean_and_var": {
+            "type": "bool",
+            "value": "True"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "in_place": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 128L, 32L, 32L]",
+            "type": "Variable"
+        },
+        "is_test": {
+            "type": "bool",
+            "value": "False"
+        },
+        "momentum": {
+            "type": "float",
+            "value": "0.9"
+        },
+        "use_global_stats": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "batch_norm",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_layout": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "do_model_average_for_mean_and_var": {
+            "type": "bool",
+            "value": "True"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "in_place": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 32L, 256L, 256L]",
+            "type": "Variable"
+        },
+        "is_test": {
+            "type": "bool",
+            "value": "False"
+        },
+        "momentum": {
+            "type": "float",
+            "value": "0.9"
+        },
+        "use_global_stats": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}]

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -20,6 +20,8 @@ import feeder
 import json
 import sys
 import re
+import warnings
+
 sys.path.append("..")
 from common import utils
 from common import api_param
@@ -222,12 +224,17 @@ def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
             raise ValueError("TensorFlow object is None.")
         tf_config = config.to_tensorflow()
         print(tf_config)
-        tf_obj.name = tf_config.name
-        tf_obj.build_graph(config=tf_config)
-        feed_list = feeder.feed_tensorflow(
-            tf_obj, feed_list, feed_spec=feed_spec)
-        tf_outputs = run_tensorflow(args.task, tf_obj, args, feed_list)
+        warnings.simplefilter('always', UserWarning)
+        if tf_config.run_tf:
+            tf_obj.name = tf_config.name
+            tf_obj.build_graph(config=tf_config)
+            feed_list = feeder.feed_tensorflow(
+                tf_obj, feed_list, feed_spec=feed_spec)
+            tf_outputs = run_tensorflow(args.task, tf_obj, args, feed_list)
+        else:
+            warnings.warn("This config is not supported by TensorFlow.")
 
     if args.task == "accuracy":
-        utils.check_outputs(
-            pd_outputs, tf_outputs, name=pd_obj.name, atol=config.atol)
+        if tf_config.run_tf:
+            utils.check_outputs(
+                pd_outputs, tf_outputs, name=pd_obj.name, atol=config.atol)


### PR DESCRIPTION
batch_norm支持使用json配置初始化参数：
- tf的该API没有data_layout或者data_format参数，默认的计算格式为NHWC，因此若配置中的数据格式为NCHW，则通过设置`run_tf=False`，不运行TF的测试。同时会打出warning
```
---- Initialize APIConfig from ./examples/batch_norm.json, config_id = 0.

API params of <batch_norm> {
  data_layout: NCHW
  do_model_average_for_mean_and_var: True
  epsilon: 1e-05
  axes: [0]
  use_global_stats: True
  input_shape: [16, 256]
  is_test: True
  num_channels: 256
  input_dtype: float32
  momentum: 0.9
  run_tf: False
  atol: 1e-06
  act: relu
  in_place: True
}
/workspace/benchmark/api/tests/main.py:235: UserWarning: This config is not supported by TensorFlow.
  warnings.warn("This config is not supported by TensorFlow.")
```
- json文件中的很多param，在tf的API中并没有，因此组网中也未使用，例如：
  - `act `
  - `do_model_average_for_mean_and_var `
  - `in_place `：不影响结果对齐。尽管原始的json配置中in_place有True和False两种值，但是由于in_place策略受build_stratedy.enable_inplace控制，如果Paddle组网中设置了in_place，在执行反向时会报错。实际框架没有开启in_place策略，但是OP设置了in_palce=True，导致了以下检查报错。
![image](https://user-images.githubusercontent.com/26615455/81315179-8d792680-90bc-11ea-8222-2011b29d80cf.png)。因此也无法设置
  - `is_test `
  - `momentum `
  - `use_global_stats `
- 支持shape为[batch, depth]的2维输入
- 按照目前组网的参数设置，对json过滤后，选取出了9个配置用于测试，具体可见json文件。
