### PR TITLE
select configs from json

### DIFF
--- a/api/json/select_configs.md
+++ b/api/json/select_configs.md
@@ -1,0 +1,82 @@
+# API配置过滤
+
+## 获取OP运行log
+在过滤之前，首先要获取到OP运行所有配置的log：
+
+- 对于大部分OP可以用`GLOG_vmodule`输出log，这样的log冗余的信息比较少。
+```
+GLOG_vmodule=batch_norm_op=10 python batch_norm.py --json_file ./examples/batch_norm.json --framework paddle --check_output False --use_gpu=True --backward True --config_id -1 2>&1 | grep 'op=' > batch_norm.log
+```
+- 但对于有的OP，例如conv，存在`conv_op`，`conv_cudnn_op`，输出log时，可以用下面这种方式，确保运行不同kernel时的log都被收集到。
+```
+GLOG_v=10 python conv2d.py --json_file ./examples/conv2d.json --framework paddle --check_output False --use_gpu=True --backward True --config_id -1 | grep 'op=' > conv2d.log
+```
+收集到的log如下，每两条log为一组，代表了同一个配置前、反向的log，例如`op=batch_norm`表示前向log、`op=batch_norm_grad`表示反向log：
+
+- batch_norm
+```
+I0508 09:15:03.065099 22585 batch_norm_op.cu:80] op=batch_norm data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0
+I0508 09:15:03.070510 22585 batch_norm_op.cu:576] op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0
+I0508 09:15:03.258034 22585 batch_norm_op.cu:80] op=batch_norm data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0
+I0508 09:15:03.263720 22585 batch_norm_op.cu:576] op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0
+```
+- conv
+```
+I0508 08:40:36.164196 22388 conv_cudnn_op.cu:142] op=conv use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7]
+I0508 08:40:36.179255 22388 conv_cudnn_op.cu:442] op=conv_grad use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7]
+I0508 08:40:37.576503 22388 conv_cudnn_op.cu:142] op=conv use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1]
+I0508 08:40:37.579442 22388 conv_cudnn_op.cu:442] op=conv_grad use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1]
+```
+
+## 根据log，对配置进行过滤
+- 首先进一步对每组前、反向的log信息处理，只保留必要部分，如：
+```
+op=batch_norm data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0
+op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0
+```
+```
+op=conv use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224]  filter_size=[7, 7]
+op=conv_grad use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7]
+```
+- 去除可忽略的参数：对于batch_norm，`op`并不是影响分组的关键信息，对于conv，`op`和`input_shape`并不是影响分组的关键信息，先去掉。则前向和反向的log信息如下：
+  - 第一组为batch_norm前向、反向信息
+  - 第二组为conv前向、反向信息
+```
+data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0
+data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0
+```
+
+```
+use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7, 7]
+use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7, 7]
+```
+- 从前向和反向的log中，取关键参数进行组合，作为分组的参考信息：即求前向、反向log中参数设置的并集。这样每条配置最终都对应一条标识信息，这条标识信息组合了前向和反向的信息，如下：
+  - 第一条为上面batch_norm前向、反向信息组合后的内容
+  - 第二条为上面conv前向、反向信息组合后的内容
+```
+"data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 test_mode=0"
+```
+```
+"use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7,7]"
+```
+- 根据每条配置的标识信息进行分组
+
+- 从每组中分别随机选取测试配置：若未设置`num_configs`，则抽取的参考数目为组数，否则为设置的个数。假设未设置`num_configs`，则下面的例子中，`num_configs=6`。根据每组配置数占总配置数的比例随机抽取，以conv2d为例，json配置一共有43个：：
+  - 第一组共24个，需要抽取的个数为：max(1,  6*24/43) = 3
+  - 第二组只有1个，需要抽取的个数为：max(1,  6*1/43) = 1
+```
+ignored_params: ['input_shape'].
+==================config_groups===================
+config: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[1,1], total: 24
+Select 3 config_ids: [38, 8, 29].
+config: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[5,5], total: 1
+Select 1 config_ids: [24].
+config: use_cudnn=true data_format=NCHW groups=32 is_exhaustive_search=0 is_sys_pad=1 filter_size=[3,3], total: 6
+Select 1 config_ids: [33].
+config: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[11,11], total: 1
+Select 1 config_ids: [23].
+config: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[3,3], total: 10
+Select 1 config_ids: [18].
+config: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7,7], total: 1
+Select 1 config_ids: [0].
+```

--- a/api/json/select_configs.md
+++ b/api/json/select_configs.md
@@ -1,82 +1,169 @@
 # API配置过滤
 
-## 获取OP运行log
-在过滤之前，首先要获取到OP运行所有配置的log：
+对同一个Op而言，从模型中收集到的相似配置在去重后依然非常多。因此，需要有一种筛选配置的方法，保证OP在不同参数设置下的性能数据都能收集到，同时去除大部分冗余的配置。
+## 为OP添加log
+在对OP进行性能优化时，需要分析不同参数配置下的计算开销。对于同一个OP，当API参数设置不同，计算的逻辑也可能不同，那么计算的开销就会有差异。为了准确地获取OP在执行某种参数配置时，计算逻辑落入了哪条分支，就需要为OP添加log。对于一些简单的OP，例如dist_op，影响性能的因素，除了OP输入大小，只有参数`p`。从下面的计算逻辑来看，`p`有4种情况，在忽略输入大小的情况下，最小只需要设计4种不同`p`值的配置，就能保证每个分支的性能都被测试到。
+```
+if (p == 0) {
+    out_t.device(place) =
+        (x_t.broadcast(x_bcast_dims) != y_t.broadcast(y_bcast_dims))
+            .template cast<T>()
+            .sum();
+  } else if (p == INFINITY) {
+    out_t.device(place) =
+        (x_t.broadcast(x_bcast_dims) - y_t.broadcast(y_bcast_dims))
+            .abs()
+            .maximum();
+  } else if (p == -INFINITY) {
+    out_t.device(place) =
+        (x_t.broadcast(x_bcast_dims) - y_t.broadcast(y_bcast_dims))
+            .abs()
+            .minimum();
+  } else {
+    out_t.device(place) =
+        (x_t.broadcast(x_bcast_dims) - y_t.broadcast(y_bcast_dims))
+            .abs()
+            .pow(p)
+            .sum()
+            .pow(1.0 / p);
+  }
+```
+一些复杂的OP，例如conv_op，计算逻辑中的分支较多，有的分支并不能直接从参数配置中推算出来。例如下面的`is_expand`分支是根据其他参数计算出的结果，因此在代码中添加log，就能很清楚地了解到OP运行时的计算逻辑落入了哪个分支。
+```
+bool is_expand = IsExpand(filter_shape_vec, strides, paddings, dilations);
+...
+if (is_expand && data_dim == 2U) {
+  col2im(dev_ctx, col, dilations, strides,
+         std::vector<int>{paddings[0], paddings[2], paddings[1],
+                          paddings[3]}, &in_grad_slice);
+} else if (is_expand && data_dim == 3U) {
+  col2vol(dev_ctx, col, dilations, strides, paddings, &in_grad_slice);
+}
+```
+添加log的示例，可以参考[conv_op](https://github.com/PaddlePaddle/Paddle/pull/24362)。需要注意：
 
-- 对于大部分OP可以用`GLOG_vmodule`输出log，这样的log冗余的信息比较少。
+- 需要将所有类型的kernel都考虑到，例如conv具有GeemKernel，CudnnKernel
+- 需要注意为前向、反向的计算都添加log
+- 需要将所有影响到分支选择的参数设置打印在一条log中，在log信息的开头，标明是前向op还是反向op，不同参数之间用空格分离
+- log中内容：
+  -  `op`名，例如`op=conv` 或者`op=conv_grad`
+  - 影响到分支选择的参数
+  - 影响到数学库算法选择的参数：例如filter_size，在conv op的CudnnKernel计算逻辑中，虽然没有直接影响分支选择，但该参数会影响到cudnn算法的选择。
+  - 输入shape
 ```
-GLOG_vmodule=batch_norm_op=10 python batch_norm.py --json_file ./examples/batch_norm.json --framework paddle --check_output False --use_gpu=True --backward True --config_id -1 2>&1 | grep 'op=' > batch_norm.log
+    VLOG(10) "op=conv"
+             << " use_cudnn=true"
+             << " data_format=" << data_format << " groups=" << groups
+             << " is_exhaustive_search=" << exhaustive_search
+             << " is_sys_pad=" << is_sys_pad << " input_shape=["
+             << input->dims() << "]"
+             << " filter_size=[" << filter_dims[2] << ", " << filter_dims[3]
+             << "]";
 ```
-- 但对于有的OP，例如conv，存在`conv_op`，`conv_cudnn_op`，输出log时，可以用下面这种方式，确保运行不同kernel时的log都被收集到。
+
+## 获取OP运行log
+在过滤之前，首先要获取到OP运行所有配置的log。执行下面的命令将OP运行所有配置时前向、反向的log保存到conv2d.log文件中：
 ```
 GLOG_v=10 python conv2d.py --json_file ./examples/conv2d.json --framework paddle --check_output False --use_gpu=True --backward True --config_id -1 | grep 'op=' > conv2d.log
 ```
 收集到的log如下，每两条log为一组，代表了同一个配置前、反向的log，例如`op=batch_norm`表示前向log、`op=batch_norm_grad`表示反向log：
 
-- batch_norm
-```
-I0508 09:15:03.065099 22585 batch_norm_op.cu:80] op=batch_norm data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0
-I0508 09:15:03.070510 22585 batch_norm_op.cu:576] op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0
-I0508 09:15:03.258034 22585 batch_norm_op.cu:80] op=batch_norm data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0
-I0508 09:15:03.263720 22585 batch_norm_op.cu:576] op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0
-```
 - conv
 ```
 I0508 08:40:36.164196 22388 conv_cudnn_op.cu:142] op=conv use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7]
 I0508 08:40:36.179255 22388 conv_cudnn_op.cu:442] op=conv_grad use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7]
 I0508 08:40:37.576503 22388 conv_cudnn_op.cu:142] op=conv use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1]
-I0508 08:40:37.579442 22388 conv_cudnn_op.cu:442] op=conv_grad use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1]
+I0508 08:40:37.579442 22388 conv_cudnn_op.cu:442] op=conv_grad use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1]  
+```
+- batch_norm
+```
+I0508 09:15:03.065099 22585 batch_norm_op.cu:80] op=batch_norm data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0 input_shape=[1, 2048]
+I0508 09:15:03.070510 22585 batch_norm_op.cu:576] op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 input_shape=[1, 2048]
+I0508 09:15:03.258034 22585 batch_norm_op.cu:80] op=batch_norm data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0 input_shape=[1, 32, 32, 128]
+I0508 09:15:03.263720 22585 batch_norm_op.cu:576] op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 input_shape=[1, 32, 32, 128]
 ```
 
 ## 根据log，对配置进行过滤
-- 首先进一步对每组前、反向的log信息处理，只保留必要部分，如：
+以下的步骤，都由`benchmark/api/json/select_configs.py`脚本自动完成。只用执行下面的示例命令：
 ```
-op=batch_norm data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0
-op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0
+python select_configs.py \
+      --op_name conv \
+      --log_file conv2d.log \
+      --json_file ../tests/examples/conv2d.json \
+      --output_file ./conv2d.json
 ```
+参数说明：
+
+- op_name：指定log中前向OP名称，例如conv、batch_norm
+- log_file：指定log文件的路径
+- json_file：执行待过滤的json文件路径，其中包含了该OP所有备选配置
+- output_file：指定输出文件路径，则过滤后的配置将被保存在该文件中
+- input_shape：可选，指定log中输入shape的名称。未指定时，将默认使用`input_shape`去提取输入的shape。
+- ignored_params：可选，不建议设置。如果有特殊需要，希望在过滤配置时，忽略log中的某个参数进行过滤，则设置该参数。
+
+脚本的处理逻辑如下：
+
+- 首先对每组前、反向的log信息处理，由脚本中的`get_logs`函数完成，只保留log中的有效内容，如：
 ```
 op=conv use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224]  filter_size=[7, 7]
 op=conv_grad use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7]
 ```
-- 去除可忽略的参数：对于batch_norm，`op`并不是影响分组的关键信息，对于conv，`op`和`input_shape`并不是影响分组的关键信息，先去掉。则前向和反向的log信息如下：
-  - 第一组为batch_norm前向、反向信息
-  - 第二组为conv前向、反向信息
 ```
-data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0
-data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0
+op=batch_norm  data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0 input_shape=[1, 2048]
+op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 input_shape=[1, 2048]
 ```
+- 去除OP名称和输入shape，若设置了`ignored_params`，会同时去除可忽略参数：由`remove_params`函数完成，该函数将从log信息中去除这些参数及其对应的值。这一步是为第一次分组做准备。处理后如下：
 
-```
-use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7, 7]
-use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7, 7]
-```
-- 从前向和反向的log中，取关键参数进行组合，作为分组的参考信息：即求前向、反向log中参数设置的并集。这样每条配置最终都对应一条标识信息，这条标识信息组合了前向和反向的信息，如下：
-  - 第一条为上面batch_norm前向、反向信息组合后的内容
-  - 第二条为上面conv前向、反向信息组合后的内容
-```
-"data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 test_mode=0"
-```
-```
-"use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7,7]"
-```
-- 根据每条配置的标识信息进行分组
+  - conv前向、反向log：
+  ```
+  use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7, 7]
+  use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7, 7]
+  ```
+    - batch_norm前向、反向log：
+  ```
+  data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0
+  data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0
+  ```
+- 根据前向和反向的log，将相同的参数设置和独有的参数设置进行组合，作为分组的参考信息：由`combine_logs_with_key_params`函数完成，该函数实际上是求前向、反向log中参数设置的并集。这样每条配置最终都对应一条标识信息，这条标识信息组合了前向和反向的信息，如下：
 
-- 从每组中分别随机选取测试配置：若未设置`num_configs`，则抽取的参考数目为组数，否则为设置的个数。假设未设置`num_configs`，则下面的例子中，`num_configs=6`。根据每组配置数占总配置数的比例随机抽取，以conv2d为例，json配置一共有43个：：
-  - 第一组共24个，需要抽取的个数为：max(1,  6*24/43) = 3
-  - 第二组只有1个，需要抽取的个数为：max(1,  6*1/43) = 1
-```
-ignored_params: ['input_shape'].
-==================config_groups===================
-config: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[1,1], total: 24
-Select 3 config_ids: [38, 8, 29].
-config: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[5,5], total: 1
-Select 1 config_ids: [24].
-config: use_cudnn=true data_format=NCHW groups=32 is_exhaustive_search=0 is_sys_pad=1 filter_size=[3,3], total: 6
-Select 1 config_ids: [33].
-config: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[11,11], total: 1
-Select 1 config_ids: [23].
-config: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[3,3], total: 10
-Select 1 config_ids: [18].
-config: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7,7], total: 1
-Select 1 config_ids: [0].
-```
+  - conv前向、反向信息组合后的内容：
+  ```
+    data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 test_mode=0
+  ```
+  - batch_norm前向、反向信息组合后的内容：
+  ```
+  use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7,7]
+  ```
+- 根据每条配置的标识信息和输入大小进行分组，由`grouping_configs`函数完成，分为两步：
+  - 第一次分组，根据每条配置的标识信息，将其id划分到相应的组中
+  - 第二次分组，对每个标识信息对应的config按照输入shape再次分组。按照shape进行分组的规则有：输入的维数、输入大小是否是2的幂
+
+- 从每组中分别选取测试配置：按照shape分组后，对每组中的配置按照输入shape的大小排序，从中选取第一个、中间的一个、以及最后一个，得到小、中、大3种shape。
+
+  - conv的分组结果：config 0~5代表了6种标识信息，所有配置被分为了6个大组，每个组中根据shape细分，最终都只得到1组。配置数不足3个时，将被全部选择。否则从每个小组中选取3个配置。
+
+  ```
+  ==============================config_groups==============================
+  config 0: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[11,11], total: 1
+    shape 0: 4-D is_power_of_2=F, total: 1. Select 1 config_ids: [23]. The shapes are: [64, 3, 224, 224]
+  config 1: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[3,3], total: 10
+    shape 0: 4-D is_power_of_2=F, total: 10. Select 3 config_ids: [22, 10, 6]. The shapes are: [64, 512, 7, 7] [64, 128, 28, 28] [64, 128, 56, 56]
+  config 2: use_cudnn=true data_format=NCHW groups=32 is_exhaustive_search=0 is_sys_pad=1 filter_size=[3,3], total: 6
+    shape 0: 4-D is_power_of_2=F, total: 6. Select 3 config_ids: [42, 39, 31]. The shapes are: [64, 1024, 7, 7] [64, 1024, 14, 14] [64, 256, 56, 56]
+  config 3: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[5,5], total: 1
+    shape 0: 4-D is_power_of_2=F, total: 1. Select 1 config_ids: [24]. The shapes are: [64, 64, 27, 27]
+  config 4: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7,7], total: 1
+    shape 0: 4-D is_power_of_2=F, total: 1. Select 1 config_ids: [0]. The shapes are: [64, 3, 224, 224]
+  config 5: use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[1,1], total: 24
+    shape 0: 4-D is_power_of_2=F, total: 24. Select 3 config_ids: [19, 28, 30]. The shapes are: [64, 512, 7, 7] [64, 64, 56, 56] [64, 256, 56, 56]
+  ```
+  - batch_norm的分组结果：config 0是第一次忽略输入大小进行分组得到的结果。按照输入shape再次进行分组后，该组又被分为了3个小组。最后从每个小组中选取了3种大小的shape。
+   ```
+   ==============================config_groups==============================
+  config 0: compute_format=NCHW use_global_stats=0 data_layout=NHWC is_inplace=0 test_mode=0, total: 64
+    shape 0: 2-D is_power_of_2=T, total: 5. Select 3 config_ids: [49, 48, 46]. The shapes are: [1, 256] [1, 2048] [1, 32768]
+    shape 1: 4-D is_power_of_2=F, total: 45. Select 3 config_ids: [44, 33, 11]. The shapes are: [1, 7, 7, 512] [1, 33, 33, 1536] [1, 16, 402, 2048]
+    shape 2: 4-D is_power_of_2=T, total: 14. Select 3 config_ids: [35, 51, 59]. The shapes are: [1, 1, 1, 256] [1, 32, 32, 128] [1, 256, 256, 32]
+   ```
+
+- 最终选取的配置，将会被自动保存到指定的输出文件中，用于API测试。

--- a/api/json/select_configs.py
+++ b/api/json/select_configs.py
@@ -1,0 +1,155 @@
+import argparse
+import random
+import os
+import json
+import warnings
+
+
+def select_configs(args, forward_logs, backward_logs):
+    removed_params = ["op"]
+    if args.ignored_params:
+        removed_params += args.ignored_params
+    combined_logs = combine_logs_with_key_params(removed_params, forward_logs,
+                                                 backward_logs)
+    config_groups = grouping_configs(combined_logs)
+    print("==================config_groups===================")
+    num_configs = args.num_configs
+    if not num_configs:
+        num_configs = len(config_groups)
+    selected_config_ids = []
+    for key in config_groups:
+        print("config: {0}, total: {1}".format(key, len(config_groups[key])))
+        config_ids = config_groups[key]
+        number = max(1, num_configs * len(config_ids) / len(combined_logs))
+        ids = random.sample(config_ids, int(number))
+        print("Select {0} config_ids: {1}.".format(number, ids))
+        selected_config_ids += ids
+
+    with open(args.json_file, 'r') as f:
+        all_configs = json.load(f)
+    out_dir = os.path.dirname(args.output_file)
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+    configs = []
+    for index in selected_config_ids:
+        configs.append(all_configs[index])
+    with open(args.output_file, 'w') as f:
+        json.dump(configs, f, indent=4, sort_keys=True)
+
+
+def combine_logs_with_key_params(removed_params, forward_logs, backward_logs):
+    for logs in [forward_logs, backward_logs]:
+        for i in range(len(logs)):
+            logs[i] = remove_params(logs[i], removed_params)
+
+    combined_logs = forward_logs
+    for i in range(len(forward_logs)):
+        if forward_logs[i] != backward_logs[i]:
+            intersection = list(
+                set(forward_logs[i]).intersection(set(backward_logs[i])))
+            difference = list(
+                set(forward_logs[i]).symmetric_difference(
+                    set(backward_logs[i])))
+            combined_logs[i] = intersection + difference
+        combined_logs[i] = ' '.join(combined_logs[i])
+
+    return combined_logs
+
+
+def grouping_configs(logs):
+    config_groups = dict()
+    for i in range(len(logs)):
+        if logs[i] not in config_groups.keys():
+            config_groups[logs[i]] = [i]
+        else:
+            config_groups[logs[i]] += [i]
+    return config_groups
+
+
+def remove_params(log, removed_params):
+    result = list(log)
+    if removed_params:
+        for item in log:
+            param_val = item.split("=")
+            if param_val[0] in removed_params:
+                result.remove(item)
+
+    return result
+
+
+def get_logs(op_name, log_file):
+    forward_logs = []
+    backward_logs = []
+    forward_name = "op=" + op_name
+    backward_name = forward_name + '_grad'
+    with open(log_file, 'r') as f:
+        for line in f.readlines():
+            line = line.strip()
+            if backward_name in line:
+                index = line.index(backward_name)
+                line = line[index:].replace(', ', ',').split(' ')
+                backward_logs.append(line)
+            elif forward_name in line:
+                index = line.index(forward_name)
+                line = line[index:].replace(', ', ',').split(' ')
+                forward_logs.append(line)
+    if not forward_logs:
+        raise ValueError("Could not find {0} in {1}.".format(forward_name,
+                                                             log_file))
+    if not backward_logs:
+        warnings.warn("Only forward logs are used to select configs.")
+    else:
+        if len(forward_logs) != len(backward_logs):
+            raise ValueError(
+                "There are {0} logs containing {1}, but {2} logs containing {3}. They should be equal".
+                format(
+                    len(forward_logs), forward_name,
+                    len(backward_logs), backward_name))
+    return forward_logs, backward_logs
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--op_name',
+        type=str,
+        default=None,
+        required=True,
+        help='Specify the operator name.')
+    parser.add_argument(
+        '--log_file',
+        type=str,
+        default=None,
+        required=True,
+        help='Specify the path of log file.')
+    parser.add_argument(
+        '--json_file',
+        type=str,
+        default=None,
+        required=True,
+        help='Specify the path of json file.')
+    parser.add_argument(
+        '--output_file',
+        type=str,
+        default=None,
+        required=True,
+        help='Specify the path of json file.')
+    parser.add_argument(
+        '--ignored_params',
+        nargs='*',
+        help='Specify the ignored param list, the configs will be filtered according to the other params.'
+    )
+    parser.add_argument(
+        '--num_configs',
+        type=int,
+        default=None,
+        help='Specify the maximum number of selected configs.')
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    print("ignored_params: {0}.".format(args.ignored_params))
+    forward_logs, backward_logs = get_logs(args.op_name, args.log_file)
+    select_configs(args, forward_logs, backward_logs)

--- a/api/json/select_configs.py
+++ b/api/json/select_configs.py
@@ -74,15 +74,15 @@ def select_configs(args, forward_logs, backward_logs):
             j += 1
         i += 1
 
-    with open(args.json_file, 'r') as f:
+    with open(args.input_json_file, 'r') as f:
         all_configs = json.load(f)
-    out_dir = os.path.dirname(args.output_file)
+    out_dir = os.path.dirname(args.output_json_file)
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
     configs = []
     for index in all_selected_ids:
         configs.append(all_configs[index])
-    with open(args.output_file, 'w') as f:
+    with open(args.output_json_file, 'w') as f:
         json.dump(configs, f, indent=4, sort_keys=True)
 
 
@@ -301,17 +301,17 @@ def parse_args():
         required=True,
         help='Specify the path of log file.')
     parser.add_argument(
-        '--json_file',
+        '--input_json_file',
         type=str,
         default=None,
         required=True,
-        help='Specify the path of json file.')
+        help='Specify the path of input json file.')
     parser.add_argument(
-        '--output_file',
+        '--output_json_file',
         type=str,
         default=None,
         required=True,
-        help='Specify the path of json file.')
+        help='Specify the path of output json file.')
     parser.add_argument(
         '--input_shape',
         nargs='*',

--- a/api/json/select_configs.py
+++ b/api/json/select_configs.py
@@ -1,29 +1,78 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
-import random
 import os
 import json
 import warnings
+from operator import mul
+
+import sys
+sys.path.append("..")
+from common.api_param import parse_list
 
 
 def select_configs(args, forward_logs, backward_logs):
-    removed_params = ["op"]
+    """
+    Select configs according to forward logs and backward logs and save the selected
+    configs to the sepcified json file.
+
+    Args:
+        args(object): An object to take the attributes.
+        forward_logs(list): A list of forward logs.
+        backward_logs(list): A list of backward logs.
+    """
+    ignored_params = ["op"]
+    input_shape = ["input_shape"]
+    if args.input_shape:
+        input_shape = args.input_shape
     if args.ignored_params:
-        removed_params += args.ignored_params
+        ignored_params += args.ignored_params
+    shapes_list = get_input_shapes(forward_logs, input_shape)
+    removed_params = ignored_params + input_shape
     combined_logs = combine_logs_with_key_params(removed_params, forward_logs,
                                                  backward_logs)
-    config_groups = grouping_configs(combined_logs)
-    print("==================config_groups===================")
-    num_configs = args.num_configs
-    if not num_configs:
-        num_configs = len(config_groups)
-    selected_config_ids = []
+    config_groups = grouping_configs(combined_logs, shapes_list)
+
+    print("=" * 30 + "config_groups" + "=" * 30)
+    all_selected_ids = []
+    i = 0
     for key in config_groups:
-        print("config: {0}, total: {1}".format(key, len(config_groups[key])))
-        config_ids = config_groups[key]
-        number = max(1, num_configs * len(config_ids) / len(combined_logs))
-        ids = random.sample(config_ids, int(number))
-        print("Select {0} config_ids: {1}.".format(number, ids))
-        selected_config_ids += ids
+        print("config {0}: {1}, total: {2}".format(
+            i, key, len(config_groups[key]['ids'])))
+        shape_groups = config_groups[key]['shape_groups']
+        j = 0
+        for label in shape_groups:
+            selected_ids = []
+            ids = shape_groups[label]['ids']
+            ids = rearrange_ids(shape_groups[label]['sizes'], ids)
+            if len(ids) <= 3:
+                selected_ids = ids
+            else:
+                selected_ids = [ids[0], ids[int(len(ids) / 2)], ids[-1]]
+            all_selected_ids += selected_ids
+            selected_shapes = [shapes_list[idx] for idx in selected_ids]
+            selected_shapes_info = " The shapes are: "
+            for shape in selected_shapes:
+                selected_shapes_info += "{} ".format(shape)
+            shape_groups_info = " " * 2 + "shape {0}: {1}, total: {2}.".format(
+                j, label, len(ids))
+            select_ids_info = " Select {0} config_ids: {1}.".format(
+                len(selected_ids), selected_ids)
+            print(shape_groups_info + select_ids_info + selected_shapes_info)
+            j += 1
+        i += 1
 
     with open(args.json_file, 'r') as f:
         all_configs = json.load(f)
@@ -31,13 +80,25 @@ def select_configs(args, forward_logs, backward_logs):
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
     configs = []
-    for index in selected_config_ids:
+    for index in all_selected_ids:
         configs.append(all_configs[index])
     with open(args.output_file, 'w') as f:
         json.dump(configs, f, indent=4, sort_keys=True)
 
 
 def combine_logs_with_key_params(removed_params, forward_logs, backward_logs):
+    """
+    Combine each forward log with the corresponding backward log. First, some params in
+    forward and backward logs are removed. Second, the union of each forward and
+    corresponding backward log is computed.
+
+    Args:
+        removed_params(list): A list of removed params. It usually contains "op" and "input_shape".
+        forward_logs(list): A list of forward logs.
+        backward_logs(list): A list og backward logs.
+
+    Returns: A list of combined logs.
+    """
     for logs in [forward_logs, backward_logs]:
         for i in range(len(logs)):
             logs[i] = remove_params(logs[i], removed_params)
@@ -56,17 +117,49 @@ def combine_logs_with_key_params(removed_params, forward_logs, backward_logs):
     return combined_logs
 
 
-def grouping_configs(logs):
+def grouping_configs(logs, shapes):
+    """
+    Groups all configs according to the logs. First, all configs are grouped by key params
+    without input shape. Second, the results of first step are grouped by input shape.
+
+    Args:
+        logs(list): A list of logs in which each item combines forward and backward log.
+        shapes(list): A list of input shapes.
+
+    Returns: A 2-D dict of config groups.
+    """
     config_groups = dict()
+    # group all configs by key params without input shape.
     for i in range(len(logs)):
         if logs[i] not in config_groups.keys():
-            config_groups[logs[i]] = [i]
+            config_groups[logs[i]] = {'ids': [i]}
         else:
-            config_groups[logs[i]] += [i]
+            config_groups[logs[i]]['ids'] += [i]
+
+    # group config_groups by input shape.
+    for key in config_groups:
+        config_ids = config_groups[key]['ids']
+        shape_groups = group_input_shapes(shapes, config_ids)
+        config_groups[key]['shape_groups'] = shape_groups
+
     return config_groups
 
 
 def remove_params(log, removed_params):
+    """
+    Remove params from logs according to the names of removed params.
+
+    Args:
+        log(list): A list of logs in which each item is a string.
+        removed_params(list): The names of removed params.
+
+    Example:
+        los=['op=conv data_format=NCHW filter_size=[1, 1]']
+        removed_params=['op']
+        result=['data_format=NCHW filter_size=[1, 1]']
+
+    Returns: A list of logs.
+    """
     result = list(log)
     if removed_params:
         for item in log:
@@ -77,7 +170,92 @@ def remove_params(log, removed_params):
     return result
 
 
+def get_input_shapes(logs, input_shape):
+    """
+    Get input shapes from logs and parse them into lists.
+
+    Args:
+        logs(list): A list of forward logs or backward logs. It is used to extract
+            input shapes.
+        input_shape(list): The name of input shape in logs. For example, if input_shape=[10, 10]
+            or x_shape=[10, 10] in logs. Then the name of input shape is "input_shape" or "x_shape".
+
+    Returns: A list of input shapes and each input shape is also a list.
+    """
+
+    shapes = []
+    for log in logs:
+        for item in log:
+            param_val = item.split("=")
+            if param_val[0] in input_shape:
+                shape = parse_list(param_val[1])
+                shapes.append(shape)
+
+    return shapes
+
+
+def group_input_shapes(shapes, config_ids):
+    """
+    Group the input shapes according to the number of dimensions and whether the size
+    is a power of 2.
+
+    Args: 
+        shapes(list): A list of input shapes.
+        config_ids(list): A list of config ids in one group.
+
+    Returns: A 2-D dict of shape groups.
+    """
+    shape_groups = dict()
+    for index in config_ids:
+        shape = shapes[index]
+        num_dims = len(shape)
+        size = reduce(mul, shape)
+        is_power_of_2 = 'T' if size == 0 or size & (size - 1) == 0 else 'F'
+        label = str(num_dims) + '-D' + ' is_power_of_2=' + is_power_of_2
+        if label not in shape_groups.keys():
+            shape_groups[label] = {'ids': [index], 'sizes': [size]}
+        else:
+            shape_groups[label]['ids'] += [index]
+            shape_groups[label]['sizes'] += [size]
+
+    return shape_groups
+
+
+def rearrange_ids(sizes, ids):
+    """
+    This function will sort sizes by ascending order and use the index of sorted sizes
+    to rearrange ids. 
+
+    Example: 
+        sizes = [400, 256, 1000, 512]
+        ids = [0, 3, 16, 10]
+
+        sorted_sizes = [256, 400, 512, 1000]
+        sorted_ids = [1, 0, 3, 2]
+        return: [3, 0, 10, 16]
+
+    Args: 
+        sizes(list): A list of sizes to be sorted.
+        ids(list): A list of config ids to be rearrange by index of sorted sizes. 
+    
+    Returns: A list of rearranged ids.
+    """
+    sorted_nums = sorted(enumerate(sizes), key=lambda x: x[1])
+    sorted_ids = [i[0] for i in sorted_nums]
+    return [ids[idx] for idx in sorted_ids]
+
+
 def get_logs(op_name, log_file):
+    """
+    Given the name of the OP and the path of the log, extract key information from forward and 
+    backward logs.
+
+    Args: 
+        op_name(str): The OP's name that is used to extract key logs.
+        log_file(str): The path of Op's log.
+
+    Returns: Two lists of forward and backward logs.
+    """
     forward_logs = []
     backward_logs = []
     forward_name = "op=" + op_name
@@ -135,15 +313,15 @@ def parse_args():
         required=True,
         help='Specify the path of json file.')
     parser.add_argument(
+        '--input_shape',
+        nargs='*',
+        help='Specify the name of input shape. If None, ["input_shape"] will be used.'
+    )
+    parser.add_argument(
         '--ignored_params',
         nargs='*',
         help='Specify the ignored param list, the configs will be filtered according to the other params.'
     )
-    parser.add_argument(
-        '--num_configs',
-        type=int,
-        default=None,
-        help='Specify the maximum number of selected configs.')
     args = parser.parse_args()
     return args
 


### PR DESCRIPTION
通过运行Op的测试脚本，得到了json文件中所有配置运行后的log，该脚本根据前向、反向的log信息，对所有配置进行分组
- 用法示例： 
```
python select_configs.py \
      --op_name conv \
      --log_file conv2d.log \
      --json_file ../tests/examples/conv2d.json \
      --output_file ./conv2d.json
```
