### PR TITLE
modify command for saving logs

### DIFF
--- a/api/json/select_configs.md
+++ b/api/json/select_configs.md
@@ -44,43 +44,41 @@ if (is_expand && data_dim == 2U) {
 
 - 需要将所有类型的kernel都考虑到，例如conv具有GemmKernel，CudnnKernel
 - 需要注意为前向、反向的计算都添加log
-- 需要将所有影响到分支选择的参数设置打印在一条log中，在log信息的开头，标明是前向op还是反向op，不同参数之间用空格分离
+- 需要将所有影响到分支选择的参数设置打印在一条log中，在log信息的末尾，标明是前向op还是反向op，不同参数之间用空格分离
 - log中内容：
-  -  `op`名，例如`op=conv` 或者`op=conv_grad`
+  - `op`名，例如`op=conv` 或者`op=conv_grad`
   - 影响到分支选择的参数
   - 影响到数学库算法选择的参数：例如filter_size，在conv op的CudnnKernel计算逻辑中，虽然没有直接影响分支选择，但该参数会影响到cudnn算法的选择。
   - 输入shape
 ```
-    VLOG(10) << "op=conv"
-             << " use_cudnn=true"
+    VLOG(10) << " use_cudnn=true"
              << " data_format=" << data_format << " groups=" << groups
              << " is_exhaustive_search=" << exhaustive_search
              << " is_sys_pad=" << is_sys_pad << " input_shape=["
              << input->dims() << "]"
-             << " filter_size=[" << filter_dims[2] << ", " << filter_dims[3]
-             << "]";
+             << " filter_size=[" << filter_dims[2] << ", " << filter_dims[3] << "]"
+             << " op=conv";
 ```
 
 ## 获取OP运行log
 在过滤之前，首先要获取到OP运行所有配置的log。执行下面的命令将OP运行所有配置时前向、反向的log保存到conv2d.log文件中：
 ```
-GLOG_v=10 python conv2d.py --json_file ./examples/conv2d.json --framework paddle --check_output False --use_gpu=True --backward True --config_id -1 | grep 'op=' > conv2d.log
+GLOG_v=10 python conv2d.py --json_file ./examples/conv2d.json --framework paddle --check_output False --use_gpu=True --backward True --config_id -1 2>&1 | grep 'op=' | awk '{for (i=5;i<=NF;i++){if (i>5) printf(" ");printf("%s", $i)};print ""}'> conv2d.log
 ```
 收集到的log如下，每两条log为一组，代表了同一个配置前、反向的log，例如`op=batch_norm`表示前向log、`op=batch_norm_grad`表示反向log：
 
 - conv
 ```
-I0508 08:40:36.164196 22388 conv_cudnn_op.cu:142] op=conv use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7]
-I0508 08:40:36.179255 22388 conv_cudnn_op.cu:442] op=conv_grad use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7]
-I0508 08:40:37.576503 22388 conv_cudnn_op.cu:142] op=conv use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1]
-I0508 08:40:37.579442 22388 conv_cudnn_op.cu:442] op=conv_grad use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1]  
+use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7] op=conv
+use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7] op=conv_grad
+use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1] op=conv
+use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1] op=conv_grad
 ```
 - batch_norm
 ```
-I0508 09:15:03.065099 22585 batch_norm_op.cu:80] op=batch_norm data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0 input_shape=[1, 2048]
-I0508 09:15:03.070510 22585 batch_norm_op.cu:576] op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 input_shape=[1, 2048]
-I0508 09:15:03.258034 22585 batch_norm_op.cu:80] op=batch_norm data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0 input_shape=[1, 32, 32, 128]
-I0508 09:15:03.263720 22585 batch_norm_op.cu:576] op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 input_shape=[1, 32, 32, 128]
+data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0 input_shape=[1, 2048] op=batch_norm
+data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 input_shape=[1, 2048] op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0 input_shape=[1, 32, 32, 128] op=batch_norm
+data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 input_shape=[1, 32, 32, 128] op=batch_norm_grad
 ```
 
 ## 根据log，对配置进行过滤
@@ -107,16 +105,7 @@ python select_configs.py \
 
 脚本的处理逻辑如下：
 
-1. 首先对每组前、反向的log信息处理，由脚本中的`get_logs`函数完成，只保留log中的有效内容，如：
-   ```
-   op=conv use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224]  filter_size=[7, 7]
-   op=conv_grad use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7]
-   ```
-   ```
-   op=batch_norm  data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0 input_shape=[1, 2048]
-   op=batch_norm_grad data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 input_shape=[1, 2048]
-   ```
-2. 去除OP名称和输入shape，若设置了`ignored_params`，会同时去除可忽略参数：由`remove_params`函数完成，该函数将从log信息中去除这些参数及其对应的值。这一步是为第一次分组做准备。处理后如下：
+1. 去除OP名称和输入shape，若设置了`ignored_params`，会同时去除可忽略参数：由`remove_params`函数完成，该函数将从log信息中去除这些参数及其对应的值。这一步是为第一次分组做准备。处理后如下：
 
 - conv前向、反向log：
   ```
@@ -128,21 +117,21 @@ python select_configs.py \
   data_layout=NHWC compute_format=NCHW use_global_stats=0 test_mode=0
   data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0
   ```
-3. 根据前向和反向的log，将相同的参数设置和独有的参数设置进行组合，作为分组的参考信息：由`combine_logs_with_key_params`函数完成，该函数实际上是求前向、反向log中参数设置的并集。这样每条配置最终都对应一条标识信息，这条标识信息组合了前向和反向的信息，如下：
+2. 根据前向和反向的log，将相同的参数设置和独有的参数设置进行组合，作为分组的参考信息：由`combine_logs_with_key_params`函数完成，该函数实际上是求前向、反向log中参数设置的并集。这样每条配置最终都对应一条标识信息，这条标识信息组合了前向和反向的信息，如下：
 
 - conv前向、反向信息组合后的内容：
   ```
-    data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 test_mode=0
+  data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 test_mode=0
   ```
 - batch_norm前向、反向信息组合后的内容：
   ```
   use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 filter_size=[7,7]
   ```
-4. 根据每条配置的标识信息和输入大小进行分组，由`grouping_configs`函数完成，分为两步：
+3. 根据每条配置的标识信息和输入大小进行分组，由`grouping_configs`函数完成，分为两步：
   - 第一次分组，根据每条配置的标识信息，将其id划分到相应的组中
   - 第二次分组，对每个标识信息对应的config按照输入shape再次分组。按照shape进行分组的规则有：输入的维数、输入大小是否是2的幂
 
-5. 从每组中分别选取测试配置：按照shape分组后，对每组中的配置按照输入shape从小到大排序，从中选取第一个、中间的一个、以及最后一个，得到小、中、大3种shape。
+4. 从每组中分别选取测试配置：按照shape分组后，对每组中的配置按照输入shape从小到大排序，从中选取第一个、中间的一个、以及最后一个，得到小、中、大3种shape。
 
 - conv的分组结果：config 0~5代表了6种标识信息，所有配置被分为了6个大组，每个组中根据shape细分，最终都只得到1组。配置数不足3个时，将被全部选择。否则从每个小组中选取3个配置。
 
@@ -164,10 +153,10 @@ python select_configs.py \
 - batch_norm的分组结果：config 0是第一次忽略输入大小进行分组得到的结果。按照输入shape再次进行分组后，该组又被分为了3个小组。最后从每个小组中选取了3种大小的shape。
    ```
    ==============================config_groups==============================
-  config 0: compute_format=NCHW use_global_stats=0 data_layout=NHWC is_inplace=0 test_mode=0, total: 64
-    shape 0: 2-D is_power_of_2=T, total: 5. Select 3 config_ids: [49, 48, 46]. The shapes are: [1, 256] [1, 2048] [1, 32768]
-    shape 1: 4-D is_power_of_2=F, total: 45. Select 3 config_ids: [44, 33, 11]. The shapes are: [1, 7, 7, 512] [1, 33, 33, 1536] [1, 16, 402, 2048]
-    shape 2: 4-D is_power_of_2=T, total: 14. Select 3 config_ids: [35, 51, 59]. The shapes are: [1, 1, 1, 256] [1, 32, 32, 128] [1, 256, 256, 32]
+   config 0: compute_format=NCHW use_global_stats=0 data_layout=NHWC is_inplace=0 test_mode=0, total: 64
+     shape 0: 2-D is_power_of_2=T, total: 5. Select 3 config_ids: [49, 48, 46]. The shapes are: [1, 256] [1, 2048] [1, 32768]
+     shape 1: 4-D is_power_of_2=F, total: 45. Select 3 config_ids: [44, 33, 11]. The shapes are: [1, 7, 7, 512] [1, 33, 33, 1536] [1, 16, 402, 2048]
+     shape 2: 4-D is_power_of_2=T, total: 14. Select 3 config_ids: [35, 51, 59]. The shapes are: [1, 1, 1, 256] [1, 32, 32, 128] [1, 256, 256, 32]
    ```
 
-6. 最终选取的配置，将会被自动保存到指定的输出文件中，用于API测试。
+5. 最终选取的配置，将会被自动保存到指定的输出文件中，用于API测试。

--- a/api/json/select_configs.py
+++ b/api/json/select_configs.py
@@ -247,8 +247,7 @@ def rearrange_ids(sizes, ids):
 
 def get_logs(op_name, log_file):
     """
-    Given the name of the OP and the path of the log, extract key information from forward and 
-    backward logs.
+    Given the name of the OP and the path of the log, split forward and backward logs.
 
     Args: 
         op_name(str): The OP's name that is used to extract key logs.
@@ -264,12 +263,10 @@ def get_logs(op_name, log_file):
         for line in f.readlines():
             line = line.strip()
             if backward_name in line:
-                index = line.index(backward_name)
-                line = line[index:].replace(', ', ',').split(' ')
+                line = line.replace(', ', ',').split(' ')
                 backward_logs.append(line)
             elif forward_name in line:
-                index = line.index(forward_name)
-                line = line[index:].replace(', ', ',').split(' ')
+                line = line.replace(', ', ',').split(' ')
                 forward_logs.append(line)
     if not forward_logs:
         raise ValueError("Could not find {0} in {1}.".format(forward_name,


### PR DESCRIPTION
修改获取运行log的命令：保存log时，去除log中无用信息。例如原始输出为：
```
I0508 08:40:36.164196 22388 conv_cudnn_op.cu:142] use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7] op=conv
I0508 08:40:36.179255 22388 conv_cudnn_op.cu:442] use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7] op=conv_grad
I0508 08:40:37.576503 22388 conv_cudnn_op.cu:142] use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1] op=conv
I0508 08:40:37.579442 22388 conv_cudnn_op.cu:442] use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1] op=conv_grad
```
修改后，log将直接保存为下面内容：
```
use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7] op=conv
use_cudnn=true data_format=NCHW groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 3, 224, 224] filter_size=[7, 7] op=conv_grad
use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1] op=conv
use_cudnn=true data_format=NHWC groups=1 is_exhaustive_search=0 is_sys_pad=1 input_shape=[64, 56, 56, 64] filter_size=[1, 1] op=conv_grad
```