### PR TITLE
Polish codes of basic benchmark class and update tensorflow version to 2.0 in ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,11 @@ __MACOSX
 *~
 __pycache__
 log*
+*.log
 *.swp
 *.dot
 *.profile
 *.timeline
 *.npz
+*.tar
+*.tar.gz

--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -14,6 +14,7 @@
 
 import os
 import json
+import numpy as np
 
 
 def parse_list(value_str, sub_dtype="int"):
@@ -88,31 +89,54 @@ class APIConfig(object):
     def __init__(self, op_type, params=None):
         self.name = op_type
         self.params = params
-        self.variable_list = []
-        self.params_list = []
+        self.variable_list = None
+        self.params_list = None
         self.backward = False
         self.feed_spec = None
         self.atol = 1e-6
         self.run_tf = True
 
+    def alias_filename(self, filename):
+        """
+        Get the filename of alias config.
+        If self.name = a, self.alias_config.name = b, the filename should be "dir/a.json",
+        the filename of alias config will be "dir/b.json".
+        """
+        if hasattr(self, "alias_config"):
+            dirname = os.path.dirname(filename)
+            basename = os.path.basename(filename)
+            basename = basename.replace(self.name, self.alias_config.name)
+            return os.path.join(dirname, basename)
+        return filename
+
+    @property
+    def alias_name(self):
+        if hasattr(self, "alias_config"):
+            return self.alias_config.name
+        else:
+            return self.name
+
+    @property
+    def alias(self):
+        if hasattr(self, "alias_config"):
+            return self.alias_config
+        else:
+            return self
+
     def init_from_json(self, filename, config_id=0):
         if hasattr(self, "alias_config"):
-            json_file = filename
-            dir = os.path.dirname(json_file)
-            file_name = os.path.basename(json_file)
-            end = file_name.split('.')
-            filename = dir + '/' + self.alias_config.name + '.' + end[1]
-            self.alias_config.init_from_json(filename, config_id)
+            self.alias_config.init_from_json(
+                self.alias_filename(filename), config_id)
             return self
 
         print("---- Initialize APIConfig from %s, config_id = %d.\n" %
               (filename, config_id))
         with open(filename, 'r') as f:
             data = json.load(f)
-            assert data[config_id][
-                "op"] == self.name, "The op type (%s) in json file is different from the name (%s). " \
+            op = data[config_id]["op"]
+            assert op == self.name or op == self.alias_name, "The op type (%s) in json file is different from the name (%s) and the alias name (%s). " \
                 "The filename: %s, config_id: %d." % (
-                    data[config_id]["op"], self.name, filename, config_id)
+                    op, self.name, self.alias_name, filename, config_id)
             self.params = data[config_id]["param_info"]
             if data[config_id].get("atol", None) is not None:
                 if isinstance(data[config_id]["atol"], str):
@@ -154,6 +178,8 @@ class APIConfig(object):
         return debug_str
 
     def _parse_params(self):
+        self.variable_list = []
+        self.params_list = []
         for name, value in self.params.items():
             assert value.get("type", None) is not None
             if value["type"] == "Variable":

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -39,7 +39,7 @@ def compare(output1, output2, atol):
     return max_diff, offset
 
 
-def check_outputs(list1, list2, name=None, atol=1e-6):
+def check_outputs(list1, list2, name, atol=1e-6):
     if not isinstance(list1, list) or not isinstance(list2, list):
         raise TypeError(
             "input argument's type should be list of numpy.ndarray.")
@@ -66,8 +66,7 @@ def check_outputs(list1, list2, name=None, atol=1e-6):
             consistent = False
 
     status = collections.OrderedDict()
-    if name is not None:
-        status["name"] = name
+    status["name"] = name
     status["consistent"] = consistent
     status["num_outputs"] = num_outputs
     status["diff"] = max_diff.astype("float")
@@ -85,44 +84,16 @@ def check_outputs(list1, list2, name=None, atol=1e-6):
         print(json.dumps(status))
 
 
-def get_stat(stats, key):
-    if stats.get(key, None) is None:
-        value = None
-    else:
-        value = stats[key]
-    return value
+def print_benchmark_result(result, log_level=0):
+    if not isinstance(result, dict):
+        raise TypeError("Input result should be a dict.")
 
+    runtimes = result.get("total", None)
+    stable = result.get("stable", None)
+    diff = result.get("diff", None)
 
-def calc_avg_time(times, begin, end):
-    if times is not None:
-        if not isinstance(times, list):
-            raise TypeError("Input times should be a list.")
-        sorted_times = np.sort(times)
-        avg_time = np.average(sorted_times[begin:end])
-    else:
-        avg_time = 0.0
-    return avg_time
-
-
-def print_stat(stats, log_level=0):
-    if not isinstance(stats, dict):
-        raise TypeError("Input stats should be a dict.")
-
-    runtimes = stats["total"]
-    feed_times = get_stat(stats, "feed")
-    fetch_times = get_stat(stats, "fetch")
-    compute_times = get_stat(stats, "compute")
-    stable = get_stat(stats, "stable")
-    diff = get_stat(stats, "diff")
-
-    for i in xrange(len(runtimes)):
+    for i in range(len(runtimes)):
         runtimes[i] *= 1000
-        if feed_times is not None:
-            feed_times[i] *= 1000
-        if fetch_times is not None:
-            fetch_times[i] *= 1000
-        if compute_times is not None:
-            compute_times[i] *= 1000
 
     sorted_runtimes = np.sort(runtimes)
     if len(sorted_runtimes) <= 2:
@@ -139,10 +110,6 @@ def print_stat(stats, log_level=0):
         end = len(sorted_runtimes) - 10
     avg_runtime = np.average(sorted_runtimes[begin:end])
 
-    avg_feed_time = calc_avg_time(feed_times, begin, end)
-    avg_fetch_time = calc_avg_time(fetch_times, begin, end)
-    avg_compute_time = calc_avg_time(compute_times, begin, end)
-
     if log_level == 0:
         seg_0 = 0
         seg_1 = len(runtimes)
@@ -158,16 +125,18 @@ def print_stat(stats, log_level=0):
             print("Iter {0}, Runtime: {1}".format("%4d" % i, "%.5f ms" %
                                                   runtimes[i]))
 
-    print("{")
-    print("  framework: \"%s\"," % stats["framework"])
-    print("  version: \"%s\"," % stats["version"])
-    print("  name: \"%s\"," % stats["name"])
-    print("  device: \"%s\"," % stats["device"])
+    status = collections.OrderedDict()
+    status["framework"] = result["framework"]
+    status["version"] = result["version"]
+    status["name"] = result["name"]
+    status["device"] = result["device"]
     if stable is not None and diff is not None:
-        print("  precision: { stable: \"%s\", diff: %.5f }," %
-              (str(stable), diff))
-    print(
-        "  speed: { repeat: %d, start: %d, end: %d, total: %.5f, feed: %.5f, compute: %.5f, fetch: %.5f }"
-        % (len(sorted_runtimes), begin, end, avg_runtime, avg_feed_time,
-           avg_compute_time, avg_fetch_time))
-    print("}")
+        status["precision"] = collections.OrderedDict()
+        status["precision"]["stable"] = stable
+        status["precision"]["diff"] = diff
+    status["speed"] = collections.OrderedDict()
+    status["speed"]["repeat"] = len(sorted_runtimes)
+    status["speed"]["begin"] = begin
+    status["speed"]["end"] = end
+    status["speed"]["total"] = avg_runtime
+    print(json.dumps(status))

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -4,6 +4,12 @@ export CUDA_VISIBLE_DEVICES="1"
 #export GLOG_v=4
 #export LD_LIBRARY_PATH=/work/cudnn/cudnn-7.6.5/lib64:${LD_LIBRARY_PATH}
 
+NVCC=`which nvcc`
+if [ ${NVCC} != "" ]; then
+  NVCC_VERSION=`nvcc --version | tail -n 1 | grep "[0-9][0-9]*\.[0-9]" -o | uniq`
+  export LD_LIBRARY_PATH=/usr/local/cuda-${NVCC_VERSION}/extras/CUPTI/lib64:${LD_LIBRARY_PATH}
+fi
+
 name=${1:-"abs"}
 config_id=${2:-"0"}
 filename="examples/${name}.json"
@@ -13,7 +19,6 @@ python ${name}.py \
       --framework "paddle" \
       --json_file ${filename} \
       --config_id ${config_id} \
-      --run_with_executor True \
       --check_output False \
       --profiler "none" \
       --backward False \

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -28,7 +28,8 @@ BENCHMARK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 echo ${BENCHMARK_ROOT}
 
 function prepare_tf_env(){
-    pip install tensorflow-gpu==1.15 pre-commit==1.21 pylint==1.9.5 pytest==4.6.9
+    pip install tensorflow-gpu==2.0 pre-commit==1.21 pylint==1.9.5 pytest==4.6.9
+    python -c "import tensorflow as tf; print(tf.__version__)"
     apt-get update
     apt-get install -y git
 }
@@ -52,7 +53,7 @@ function fetch_upstream_master_if_not_exist() {
 function run_api(){
     fetch_upstream_master_if_not_exist
     cd ${BENCHMARK_ROOT}/api/tests
-    HAS_MODIFIED_API_TEST=`git diff --name-only upstream/$BRANCH | grep "api/tests" || true`
+    HAS_MODIFIED_API_TEST=`git diff --name-only upstream/$BRANCH | grep "api/tests.*.py$" || true`
     API_NAMES=(abs fc)
     if [ "${HAS_MODIFIED_API_TEST}" != "" ] ; then
         for api in ${HAS_MODIFIED_API_TEST[@]}; do


### PR DESCRIPTION
拆分自#308 ，将其中一些与计时方式修改无关的代码拆离出来，方便review。
这个PR主要包含以下工作：

- 清理benchmark基类实现，移除无用的代码
- 将性能测试的结果改成用`json.dumps`后输出，修改后输出如下：
```json
{"framework": "paddle", "version": "0.0.0", "name": "abs", "device": "GPU", "speed": {"repeat": 1, "begin": 0, "end": 1, "total": 7.61103630065918}}
```

- 更新CI上的tf版本，并修改了grep的匹配规则，只匹配`api/tests`目录下的`.py`文件。这个PR CI中匹配到的修改文件如下：
```
++ grep 'api/tests.*.py$'
+ HAS_MODIFIED_API_TEST=api/tests/main.py
```