### PR TITLE
Add script file to benchmark cond

### DIFF
--- a/api/tests/cond.py
+++ b/api/tests/cond.py
@@ -1,0 +1,68 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDCond(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        with fluid.program_guard(self.main_program, self.startup_program):
+
+            def true_fn():
+                return fluid.layers.fill_constant(
+                    value=1, shape=config.shape, dtype=config.dtype)
+
+            def false_fn():
+                return fluid.layers.fill_constant(
+                    value=0, shape=config.shape, dtype=config.dtype)
+
+            ten_var = fluid.layers.fill_constant(
+                shape=config.x_shape, value=10, dtype=config.x_dtype)
+            input = fluid.data(
+                name='input', shape=config.x_shape, dtype=config.x_dtype)
+            input.stop_gradient = False
+
+            pred = fluid.layers.less_than(input, ten_var)
+
+            result = fluid.layers.cond(pred, true_fn, false_fn)
+
+            self.feed_vars = [input]
+            self.fetch_vars = [result]
+            if config.backward:
+                self.append_gradients(result, [input])
+
+
+class TFCond(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        def true_fn():
+            return tf.constant(1, shape=config.shape, dtype=config.dtype)
+
+        def false_fn():
+            return tf.constant(0, shape=config.shape, dtype=config.dtype)
+
+        ten_var = tf.constant(10, shape=config.x_shape, dtype=config.x_dtype)
+        input = self.placeholder(
+            name='input', shape=config.x_shape, dtype=config.x_dtype)
+
+        result = tf.cond(
+            tf.reshape(tf.less(input, ten_var), []), true_fn, false_fn)
+
+        self.feed_list = [input]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [input])
+
+
+if __name__ == '__main__':
+    test_main(PDCond(), TFCond(), config=APIConfig('cond'))

--- a/api/tests/examples/cond.json
+++ b/api/tests/examples/cond.json
@@ -1,18 +1,20 @@
 [{
     "op": "cond",
     "param_info": {
-        "x": {
+        "input": {
             "type": "Variable",
             "dtype": "float32",
             "shape": "[1L]"
         },
-        "shape": {
-            "type": "list",
-            "value": "[10L, 10L, 100L, 100L]"
+        "x": {
+            "type": "Variable",
+            "dtype": "float32",
+            "shape": "[16L, 256L, 6L, 6L]"
         },
-        "dtype": {
-            "type": "string",
-            "value": "float32"
+        "y": {
+            "type": "Variable",
+            "dtype": "float32",
+            "shape": "[16L, 256L, 6L, 6L]"
         }
     }
 }]

--- a/api/tests/examples/cond.json
+++ b/api/tests/examples/cond.json
@@ -1,0 +1,18 @@
+[{
+    "op": "cond",
+    "param_info": {
+        "x": {
+            "type": "Variable",
+            "dtype": "float32",
+            "shape": "[1L]"
+        },
+        "shape": {
+            "type": "list",
+            "value": "[10L, 10L, 100L, 100L]"
+        },
+        "dtype": {
+            "type": "string",
+            "value": "float32"
+        }
+    }
+}]


### PR DESCRIPTION
添加API:`fluid.layers.cond`的测试脚本，CPU的输出结如下：

```
---- Initialize APIConfig from examples/cond.json, config_id = 0.

API params of <cond> {
  dtype: float32
  x_dtype: float32
  shape: [10, 10, 100, 100]
  run_tf: True
  atol: 1e-06
  x_shape: [1]
}
/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:1093: UserWarning: There are no operators in the program to be executed. If you pass Program manually, please use fluid.program_guard to ensure the current Program is being used.
  warnings.warn(error_info)
{"framework": "paddle", "version": "1.8.0", "name": "cond", "device": "CPU", "speed": {"repeat": 1, "begin": 0, "end": 1, "total": 6.284236907958984}}
API params of <cond> {
  dtype: float32
  x_dtype: float32
  shape: [10, 10, 100, 100]
  run_tf: True
  atol: 1e-06
  x_shape: [1]
}
2020-05-18 09:25:47,676-WARNING: From ../common/tensorflow_api_benchmark.py:163: The name tf.placeholder is deprecated. Please use tf.compat.v1.placeholder instead.

2020-05-18 09:25:47,685-WARNING: From ../common/tensorflow_api_benchmark.py:240: The name tf.ConfigProto is deprecated. Please use tf.compat.v1.ConfigProto instead.

2020-05-18 09:25:47,685-WARNING: From ../common/tensorflow_api_benchmark.py:241: The name tf.Session is deprecated. Please use tf.compat.v1.Session instead.

2020-05-18 09:25:47.685596: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 AVX512F FMA
2020-05-18 09:25:47.691716: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 2399470000 Hz
2020-05-18 09:25:47.693203: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x63062b0 executing computations on platform Host. Devices:
2020-05-18 09:25:47.693253: I tensorflow/compiler/xla/service/service.cc:175]   StreamExecutor device (0): <undefined>, <undefined>
2020-05-18 09:25:47,694-WARNING: From ../common/tensorflow_api_benchmark.py:242: The name tf.global_variables_initializer is deprecated. Please use tf.compat.v1.global_variables_initializer instead.

2020-05-18 09:25:47.697072: W tensorflow/compiler/jit/mark_for_compilation_pass.cc:1412] (One-time warning): Not using XLA:CPU for cluster because envvar TF_XLA_FLAGS=--tf_xla_cpu_global_jit was not set.  If you want XLA:CPU, either set that envvar, or use experimental_jit_scope to enable XLA:CPU.  To confirm that XLA is active, pass --vmodule=xla_compilation_cache=1 (as a proper command-line flag, not via TF_XLA_FLAGS) or set the envvar XLA_FLAGS=--xla_hlo_profile.
2020-05-18 09:25:47,697-WARNING: From ../common/tensorflow_api_benchmark.py:243: The name tf.local_variables_initializer is deprecated. Please use tf.compat.v1.local_variables_initializer instead.

{"framework": "tensorflow", "version": "1.14.0", "name": "cond", "device": "CPU", "speed": {"repeat": 1, "begin": 0, "end": 1, "total": 0.9560585021972656}}
{"name": "cond", "consistent": true, "num_outputs": 1, "diff": 0.0}
```