### PR TITLE
Add script file to benchmark switch_case

### DIFF
--- a/api/tests/examples/switch_case.json
+++ b/api/tests/examples/switch_case.json
@@ -1,0 +1,20 @@
+[{
+    "op": "switch_case",
+    "param_info": {
+        "input": {
+            "type": "Variable",
+            "dtype": "int32",
+            "shape": "[1L]"
+        },
+        "x": {
+            "type": "Variable",
+            "dtype": "float32",
+            "shape": "[16L, 256L, 6L, 6L]"
+        },
+        "y": {
+            "type": "Variable",
+            "dtype": "float32",
+            "shape": "[16L, 256L, 6L, 6L]"
+        }
+    }
+}]

--- a/api/tests/switch_case.py
+++ b/api/tests/switch_case.py
@@ -1,0 +1,81 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDSwitchCase(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        with fluid.program_guard(self.main_program, self.startup_program):
+            x = fluid.data(
+                name='x', shape=config.x_shape, dtype=config.x_dtype)
+            y = fluid.data(
+                name='y', shape=config.y_shape, dtype=config.y_dtype)
+            input = fluid.data(
+                name='input',
+                shape=config.input_shape,
+                dtype=config.input_dtype)
+            x.stop_gradient = False
+            y.stop_gradient = False
+            input.stop_gradient = False
+
+            def f1():
+                return fluid.layers.elementwise_add(x=x, y=y)
+
+            def f2():
+                return fluid.layers.elementwise_sub(x=x, y=y)
+
+            def f3():
+                return fluid.layers.elementwise_mul(x=x, y=y)
+
+            result = fluid.layers.switch_case(
+                branch_index=input, branch_fns={0: f1,
+                                                1: f2}, default=f3)
+            self.feed_vars = [x, y, input]
+            self.fetch_vars = [result]
+            if config.backward:
+                self.append_gradients(result, [x, y, input])
+
+
+class TFSwitchCase(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.placeholder(
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.placeholder(
+            name='y', shape=config.y_shape, dtype=config.y_dtype)
+        input = self.placeholder(
+            name='input', shape=config.input_shape, dtype=config.input_dtype)
+
+        def f1():
+            return tf.add(x, y)
+
+        def f2():
+            return tf.subtract(x, y)
+
+        def f3():
+            return tf.multiply(x, y)
+
+        result = tf.switch_case(
+            branch_index=tf.reshape(input, []),
+            branch_fns={0: f1,
+                        1: f2},
+            default=f3)
+        self.feed_list = [x, y, input]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, y, input])
+
+
+if __name__ == '__main__':
+    test_main(PDSwitchCase(), TFSwitchCase(), config=APIConfig('switch_case'))


### PR DESCRIPTION
添加API:`fluid.layers.switch_case`的测试脚本，CPU的输出结如下：

```
---- Initialize APIConfig from examples/switch_case.json, config_id = 0.

API params of <switch_case> {
  y_dtype: float32
  y_shape: [16, 256, 6, 6]
  input_shape: [1]
  x_dtype: float32
  input_dtype: int32
  run_tf: True
  atol: 1e-06
  x_shape: [16, 256, 6, 6]
}
/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:1093: UserWarning: There are no operators in the program to be executed. If you pass Program manually, please use fluid.program_guard to ensure the current Program is being used.
  warnings.warn(error_info)
{"framework": "paddle", "version": "1.8.0", "name": "switch_case", "device": "CPU", "speed": {"repeat": 1, "begin": 0, "end": 1, "total": 1.2700557708740234}}
API params of <switch_case> {
  y_dtype: float32
  y_shape: [16, 256, 6, 6]
  input_shape: [1]
  x_dtype: float32
  input_dtype: int32
  run_tf: True
  atol: 1e-06
  x_shape: [16, 256, 6, 6]
}
2020-05-21 03:03:41,176-WARNING: From ../common/tensorflow_api_benchmark.py:163: The name tf.placeholder is deprecated. Please use tf.compat.v1.placeholder instead.

2020-05-21 03:03:41,197-WARNING: From ../common/tensorflow_api_benchmark.py:240: The name tf.ConfigProto is deprecated. Please use tf.compat.v1.ConfigProto instead.

2020-05-21 03:03:41,197-WARNING: From ../common/tensorflow_api_benchmark.py:241: The name tf.Session is deprecated. Please use tf.compat.v1.Session instead.

2020-05-21 03:03:41.197815: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 AVX512F FMA
2020-05-21 03:03:41.202784: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 2399470000 Hz
2020-05-21 03:03:41.204612: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x6ee2380 executing computations on platform Host. Devices:
2020-05-21 03:03:41.204659: I tensorflow/compiler/xla/service/service.cc:175]   StreamExecutor device (0): <undefined>, <undefined>
2020-05-21 03:03:41,206-WARNING: From ../common/tensorflow_api_benchmark.py:242: The name tf.global_variables_initializer is deprecated. Please use tf.compat.v1.global_variables_initializer instead.

2020-05-21 03:03:41.209092: W tensorflow/compiler/jit/mark_for_compilation_pass.cc:1412] (One-time warning): Not using XLA:CPU for cluster because envvar TF_XLA_FLAGS=--tf_xla_cpu_global_jit was not set.  If you want XLA:CPU, either set that envvar, or use experimental_jit_scope to enable XLA:CPU.  To confirm that XLA is active, pass --vmodule=xla_compilation_cache=1 (as a proper command-line flag, not via TF_XLA_FLAGS) or set the envvar XLA_FLAGS=--xla_hlo_profile.
2020-05-21 03:03:41,209-WARNING: From ../common/tensorflow_api_benchmark.py:243: The name tf.local_variables_initializer is deprecated. Please use tf.compat.v1.local_variables_initializer instead.

{"framework": "tensorflow", "version": "1.14.0", "name": "switch_case", "device": "CPU", "speed": {"repeat": 1, "begin": 0, "end": 1, "total": 0.6189346313476562}}
{"name": "switch_case", "consistent": true, "num_outputs": 1, "diff": 0.0}
```