### PR TITLE
Enable profiling using cProfile.

### DIFF
--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -20,6 +20,7 @@ import traceback
 import contextlib
 import importlib
 import numpy as np
+import cProfile, pstats, StringIO
 import utils
 
 try:
@@ -42,6 +43,16 @@ def profile_context(name, use_gpu, profiler):
         output_file = name + ".nvprof"
         with fluid.profiler.cuda_profiler(output_file, 'kvp'):
             yield
+    elif profiler == "pyprof":
+        profiler_handle = cProfile.Profile()
+        profiler_handle.enable()
+        yield
+        profiler_handle.disable()
+        # profiler_handle.dump_stats("./outputs/" + name + ".pyprof")
+        s = StringIO.StringIO()
+        ps = pstats.Stats(profiler_handle, stream=s).sort_stats("cumulative")
+        ps.print_stats()
+        print(s.getvalue())
     else:
         yield
 

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -67,7 +67,7 @@ def parse_args():
         '--profiler',
         type=str,
         default="none",
-        help='Choose which profiler to use [\"none\"|\"Default\"|\"OpDetail\"|\"AllOpDetail\"|\"nvprof\"]'
+        help='Choose which profiler to use [\"none\"|\"Default\"|\"OpDetail\"|\"AllOpDetail\"|\"nvprof\"|\"pyprof\"]'
     )
     parser.add_argument(
         '--backward',
@@ -137,13 +137,12 @@ def run_tensorflow(task, obj, args, feed_list=None):
             feed[obj.feed_list[i]] = feed_list[i]
 
     if task == "speed":
-        profile = True if args.profiler != "none" else False
         obj.run(use_gpu=args.use_gpu,
                 feed=feed,
                 repeat=args.repeat,
                 log_level=args.log_level,
                 check_output=args.check_output,
-                profile=profile)
+                profiler=args.profiler)
         return None
     elif task == "accuracy":
         if feed is None:


### PR DESCRIPTION
主要工作：通过配置`--profiler "pyprof"`，可使用cProfile进行分析，结果直接输出。

### abs
- paddle
```
W0522 02:48:49.505357  2429 device_context.cc:265] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 10.1
W0522 02:48:49.511164  2429 device_context.cc:273] device: 0, cuDNN Version: 7.6.
         1180004 function calls (1170004 primitive calls) in 56.462 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.055    0.000   56.444    0.006 ../common/paddle_api_benchmark.py:139(_run_main_iter)
    10000    0.034    0.000   56.389    0.006 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:890(run)
    10000    0.285    0.000   56.355    0.006 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:1081(_run_impl)
    10000    0.224    0.000   55.878    0.006 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:1177(_run_program)
20000/10000    0.131    0.000   27.708    0.003 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:110(as_numpy)
    10000   26.946    0.003   27.502    0.003 {numpy.array}
    10000   14.337    0.001   14.337    0.001 {built-in method run_prepared_ctx}
    10000    0.225    0.000   13.120    0.001 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:636(_feed_data)
    10000    0.088    0.000   12.255    0.001 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:393(_as_lodtensor)
    10000   12.161    0.001   12.161    0.001 {built-in method set}
...
{"framework": "paddle", "version": "0.0.0", "name": "abs", "device": "GPU", "speed": {"repeat": 10000, "begin": 10, "end": 9990, "total": 5.640008478222008}}
```

- tensorflow
```
2020-05-22 02:51:44.876651: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1241] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:0 with 15023 MB memory) -> physical GPU (device: 0, name: Tesla V100-SXM2-16GB, pci bus id: 0000:00:0b.0, compute capability: 7.0)
         4410003 function calls (4280003 primitive calls) in 48.911 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.032    0.000   48.883    0.005 ../common/tensorflow_api_benchmark.py:229(_run_main_iter)
    10000    0.062    0.000   48.852    0.005 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:850(run)
    10000    0.476    0.000   48.790    0.005 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:1094(_run)
    10000    0.080    0.000   43.406    0.004 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:1320(_do_run)
    10000    0.021    0.000   43.280    0.004 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:1365(_do_call)
    10000    0.037    0.000   43.259    0.004 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:1348(_run_fn)
    10000    0.034    0.000   42.833    0.004 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:1441(_call_tf_sessionrun)
    10000   42.799    0.004   42.799    0.004 {_pywrap_tensorflow_internal.TF_SessionRun_wrapper}
...
{"framework": "tensorflow", "version": "2.1.0", "name": "abs", "device": "GPU", "speed": {"repeat": 10000, "begin": 10, "end": 9990, "total": 4.887826409273014}}
```

### fc
- paddle
```
W0522 02:50:37.248828  2487 device_context.cc:265] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 10.1
W0522 02:50:37.254078  2487 device_context.cc:273] device: 0, cuDNN Version: 7.6.
         1180004 function calls (1170004 primitive calls) in 8.303 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.027    0.000    8.291    0.001 ../common/paddle_api_benchmark.py:139(_run_main_iter)
    10000    0.019    0.000    8.264    0.001 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:890(run)
    10000    0.142    0.000    8.246    0.001 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:1081(_run_impl)
    10000    0.135    0.000    7.979    0.001 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:1177(_run_program)
    10000    4.152    0.000    4.152    0.000 {built-in method run_prepared_ctx}
    10000    0.139    0.000    2.035    0.000 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:636(_feed_data)
    10000    0.054    0.000    1.520    0.000 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:393(_as_lodtensor)
    10000    1.460    0.000    1.460    0.000 {built-in method set}
20000/10000    0.084    0.000    1.345    0.000 /usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:110(as_numpy)
    10000    0.818    0.000    1.203    0.000 {numpy.array}
...
{"framework": "paddle", "version": "0.0.0", "name": "fc", "device": "GPU", "speed": {"repeat": 10000, "begin": 10, "end": 9990, "total": 0.8314800883581739}}
```

- tensorflow
```
2020-05-22 02:53:44.008184: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1241] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:0 with 15023 MB memory) -> physical GPU (device: 0, name: Tesla V100-SXM2-16GB, pci bus id: 0000:00:0b.0, compute capability: 7.0)
2020-05-22 02:53:45.977477: I tensorflow/stream_executor/platform/default/dso_loader.cc:44] Successfully opened dynamic library libcublas.so.10
         4230003 function calls (4100003 primitive calls) in 13.623 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.018    0.000   13.604    0.001 ../common/tensorflow_api_benchmark.py:229(_run_main_iter)
    10000    0.044    0.000   13.585    0.001 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:850(run)
    10000    0.300    0.000   13.542    0.001 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:1094(_run)
    10000    0.063    0.000    9.433    0.001 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:1320(_do_run)
    10000    0.012    0.000    9.336    0.001 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:1365(_do_call)
    10000    0.019    0.000    9.324    0.001 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:1348(_run_fn)
    10000    0.016    0.000    9.015    0.001 /usr/local/python2.7.15/lib/python2.7/site-packages/tensorflow_core/python/client/session.py:1441(_call_tf_sessionrun)
    10000    8.999    0.001    8.999    0.001 {_pywrap_tensorflow_internal.TF_SessionRun_wrapper}
...
{"framework": "tensorflow", "version": "2.1.0", "name": "fc", "device": "GPU", "speed": {"repeat": 10000, "begin": 10, "end": 9990, "total": 1.3577786619534233}}
```

### TODO：后续考虑是否要使用该工具收集op运行时间，并直接抽取出有效的时间数据。