### PR TITLE
Integrate nvprof to parse the gpu time.

### DIFF
--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -39,10 +39,6 @@ def profile_context(name, use_gpu, profiler):
         with fluid.profiler.profiler(
                 profile_type, 'total', output_file, tracer_option=profiler):
             yield
-    elif profiler == "nvprof" and use_gpu:
-        output_file = name + ".nvprof"
-        with fluid.profiler.cuda_profiler(output_file, 'kvp'):
-            yield
     elif profiler == "pyprof":
         profiler_handle = cProfile.Profile()
         profiler_handle.enable()
@@ -167,8 +163,7 @@ class PaddleAPIBenchmarkBase(object):
         stats["version"] = paddle.__version__
         stats["name"] = self.name
         stats["device"] = "GPU" if use_gpu else "CPU"
-        utils.print_benchmark_result(stats, log_level=log_level)
-        return outputs
+        return outputs, stats
 
     def _init_feed_tensor(self, feed):
         for var in self.feed_vars:

--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -125,7 +125,6 @@ class PaddleAPIBenchmarkBase(object):
                           use_gpu,
                           feed=None,
                           repeat=1,
-                          log_level=0,
                           check_output=False,
                           profiler="none"):
         self.place = fluid.CUDAPlace(0) if use_gpu else fluid.CPUPlace()

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -259,8 +259,7 @@ class TensorflowAPIBenchmarkBase(object):
             "total": runtimes
         }
         stats["device"] = "GPU" if use_gpu else "CPU"
-        utils.print_benchmark_result(stats, log_level=log_level)
-        return outputs
+        return outputs, stats
 
     def _init_session(self, use_gpu):
         if tf.__version__ >= "1.15.0":

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -219,7 +219,6 @@ class TensorflowAPIBenchmarkBase(object):
             use_gpu,
             feed=None,
             repeat=1,
-            log_level=0,
             check_output=False,
             profiler="none"):
         sess = self._init_session(use_gpu)

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -170,5 +170,5 @@ def print_benchmark_result(result, log_level=0):
     status["speed"]["end"] = end
     status["speed"]["total"] = avg_runtime
     if gpu_time is not None:
-        status["speed"]["gpu_time"] = gpu_time / repeat
+        status["speed"]["gpu_time"] = gpu_time
     print(json.dumps(status))

--- a/api/tests/launch.py
+++ b/api/tests/launch.py
@@ -1,0 +1,119 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import sys
+import argparse
+
+sys.path.append("..")
+from common import utils
+
+
+def nvprof(cmd):
+    return utils.run_command("nvprof {}".format(cmd))
+
+
+def parse_gpu_time(line):
+    print("nvprof result: %s" % line)
+    infos = line.strip().split()
+    percent = float(infos[2].replace("%", "")) * 0.01
+    gpu_time = infos[3]
+    if gpu_time.endswith("us"):
+        gpu_time = float(gpu_time.replace("us", "")) * 0.001
+    elif gpu_time.endswith("ms"):
+        gpu_time = float(gpu_time.replace("ms", ""))
+    elif gpu_time.endswith("s"):
+        gpu_time = float(gpu_time.replace("s", "")) * 1000
+    else:
+        raise ValueError("Invalid time: %s" % gpu_time)
+    calls = int(infos[4])
+    function = infos[8]
+    for i in range(9, len(infos)):
+        function = function + " " + infos[i]
+    print("percent: %.2f; gpu_time: %.4f ms; calls: %d; function: %s" %
+          (percent, gpu_time, calls, function))
+
+    total_gpu_time = gpu_time / percent
+    print("total gpu_time: %.4f ms" % total_gpu_time)
+    return total_gpu_time
+
+
+def launch(framework,
+           benchmark_script,
+           benchmark_script_args,
+           with_nvprof=False):
+    cmd = "{} {} {}".format(sys.executable, benchmark_script,
+                            " ".join(benchmark_script_args))
+    if with_nvprof:
+        stdout, exit_code = nvprof(cmd)
+        if exit_code == 0:
+            logs = stdout.split("\n")
+            tag = "GPU activities:"
+            gpu_time = 0
+            for line in logs:
+                if tag in line.encode("utf-8"):
+                    total_gpu_time = parse_gpu_time(line.encode("utf-8"))
+                    break
+            return total_gpu_time
+        else:
+            print("stdout: {}".format(stdout))
+    else:
+        stdout, exit_code = utils.run_command(cmd)
+        print(stdout)
+        if exit_code != 0:
+            raise RuntimeError("Run command (%s) error." % cmd)
+    return 0.0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='OP Benchmark of PaddlePaddle')
+
+    # positional
+    parser.add_argument(
+        "benchmark_script",
+        type=str,
+        help="The full path to operator's benchmark script file. If the task "
+        "the speed and GPU is used, nvprof will be used to get the GPU kernel time."
+    )
+
+    # rest from the operator benchmark program
+    parser.add_argument('benchmark_script_args', nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    task = "speed"
+    framework = "paddle"
+    use_gpu = False
+    for i in range(len(args.benchmark_script_args)):
+        if args.benchmark_script_args[i] == "--task":
+            task = args.benchmark_script_args[i + 1]
+        elif args.benchmark_script_args[i] == "--framework":
+            framework = args.benchmark_script_args[i + 1]
+        elif args.benchmark_script_args[i] == "--use_gpu":
+            use_gpu = utils.str2bool(args.benchmark_script_args[i + 1])
+
+    if use_gpu and task == "speed":
+        total_gpu_time = launch(
+            framework,
+            args.benchmark_script,
+            args.benchmark_script_args,
+            with_nvprof=True)
+        args.benchmark_script_args.append(" --gpu_time ")
+        args.benchmark_script_args.append(str(total_gpu_time))
+
+    launch(
+        framework,
+        args.benchmark_script,
+        args.benchmark_script_args,
+        with_nvprof=False)

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -111,7 +111,6 @@ def run_paddle(task, obj, args, feed_list=None):
             use_gpu=args.use_gpu,
             feed=feed,
             repeat=args.repeat,
-            log_level=args.log_level,
             check_output=args.check_output,
             profiler=args.profiler)
         return outputs, stats
@@ -136,7 +135,6 @@ def run_tensorflow(task, obj, args, feed_list=None):
         outputs, stats = obj.run(use_gpu=args.use_gpu,
                                  feed=feed,
                                  repeat=args.repeat,
-                                 log_level=args.log_level,
                                  check_output=args.check_output,
                                  profiler=args.profiler)
         return outputs, stats

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -27,15 +27,6 @@ from common import utils
 from common import api_param
 
 
-def str2bool(v):
-    if v.lower() in ('yes', 'true', 't', 'y', '1'):
-        return True
-    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
-        return False
-    else:
-        raise argparse.ArgumentTypeError('Unsupported value encountered.')
-
-
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -60,25 +51,30 @@ def parse_args():
     )
     parser.add_argument(
         '--check_output',
-        type=str2bool,
+        type=utils.str2bool,
         default=True,
         help='Whether checking the consistency of outputs [True|False]')
     parser.add_argument(
         '--profiler',
         type=str,
         default="none",
-        help='Choose which profiler to use [\"none\"|\"Default\"|\"OpDetail\"|\"AllOpDetail\"|\"nvprof\"|\"pyprof\"]'
+        help='Choose which profiler to use [\"none\"|\"Default\"|\"OpDetail\"|\"AllOpDetail\"|\"pyprof\"]'
     )
     parser.add_argument(
         '--backward',
-        type=str2bool,
+        type=utils.str2bool,
         default=False,
         help='Whether appending grad ops [True|False]')
     parser.add_argument(
         '--use_gpu',
-        type=str2bool,
+        type=utils.str2bool,
         default=False,
         help='Whether using gpu [True|False]')
+    parser.add_argument(
+        '--gpu_time',
+        type=float,
+        default=0,
+        help='Total GPU kernel time parsed from nvprof')
     parser.add_argument(
         '--repeat', type=int, default=1, help='Iterations of Repeat running')
     parser.add_argument(
@@ -111,20 +107,20 @@ def run_paddle(task, obj, args, feed_list=None):
             feed[obj.feed_vars[i].name] = feed_list[i]
 
     if task == "speed":
-        obj.run_with_executor(
+        outputs, stats = obj.run_with_executor(
             use_gpu=args.use_gpu,
             feed=feed,
             repeat=args.repeat,
             log_level=args.log_level,
             check_output=args.check_output,
             profiler=args.profiler)
-        return None
+        return outputs, stats
     elif task == "accuracy":
         if feed is None:
             raise ValueError("feed should not be None when checking accuracy.")
-        outputs = obj.run_with_executor(
+        outputs, stats = obj.run_with_executor(
             use_gpu=args.use_gpu, feed=feed, check_output=False)
-        return outputs
+        return outputs, stats
 
 
 def run_tensorflow(task, obj, args, feed_list=None):
@@ -137,18 +133,20 @@ def run_tensorflow(task, obj, args, feed_list=None):
             feed[obj.feed_list[i]] = feed_list[i]
 
     if task == "speed":
-        obj.run(use_gpu=args.use_gpu,
-                feed=feed,
-                repeat=args.repeat,
-                log_level=args.log_level,
-                check_output=args.check_output,
-                profiler=args.profiler)
-        return None
+        outputs, stats = obj.run(use_gpu=args.use_gpu,
+                                 feed=feed,
+                                 repeat=args.repeat,
+                                 log_level=args.log_level,
+                                 check_output=args.check_output,
+                                 profiler=args.profiler)
+        return outputs, stats
     elif task == "accuracy":
         if feed is None:
             raise ValueError("feed should not be None when checking accuracy.")
-        outputs = obj.run(use_gpu=args.use_gpu, feed=feed, check_output=False)
-        return outputs
+        outputs, stats = obj.run(use_gpu=args.use_gpu,
+                                 feed=feed,
+                                 check_output=False)
+        return outputs, stats
 
 
 def copy_feed_spec(config=None):
@@ -232,7 +230,10 @@ def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
         pd_obj.create_program()
         pd_obj.build_program(config=config)
         feed_list = feeder.feed_paddle(pd_obj, feed_spec=feed_spec)
-        pd_outputs = run_paddle(args.task, pd_obj, args, feed_list)
+        pd_outputs, pd_stats = run_paddle(args.task, pd_obj, args, feed_list)
+        if args.task == "speed":
+            pd_stats["gpu_time"] = args.gpu_time
+            utils.print_benchmark_result(pd_stats, log_level=args.log_level)
 
     if _is_tensorflow_enabled(args, config):
         assert tf_obj is not None, "TensorFlow object is None."
@@ -243,7 +244,11 @@ def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
         tf_obj.build_graph(config=tf_config)
         feed_list = feeder.feed_tensorflow(
             tf_obj, feed_list, feed_spec=feed_spec)
-        tf_outputs = run_tensorflow(args.task, tf_obj, args, feed_list)
+        tf_outputs, tf_stats = run_tensorflow(args.task, tf_obj, args,
+                                              feed_list)
+        if args.task == "speed":
+            tf_stats["gpu_time"] = args.gpu_time
+            utils.print_benchmark_result(tf_stats, log_level=args.log_level)
 
     if args.task == "accuracy":
         if tf_config.run_tf:

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -14,7 +14,7 @@ name=${1:-"abs"}
 config_id=${2:-"0"}
 filename="examples/${name}.json"
 
-python ${name}.py \
+python -m launch ${name}.py \
       --task "accuracy" \
       --framework "paddle" \
       --json_file ${filename} \

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -58,7 +58,7 @@ function run_api(){
     if [ "${HAS_MODIFIED_API_TEST}" != "" ] ; then
         for api in ${HAS_MODIFIED_API_TEST[@]}; do
             new_name=`echo $api |awk -F "/" '{print $NF}' |awk -F "." '{print $NR}'`
-            if [[ "$new_name" != "main" && "$new_name" != "feeder" && "$new_name" != "common_ops" ]]; then
+            if [[ "$new_name" != "main" && "$new_name" != "feeder" && "$new_name" != "common_ops" && "$new_name" != "launch" ]]; then
                 need_append="yes"
                 for name in ${API_NAMES[@]}; do
                     if [ "${name}" == "${new_name}" ]; then


### PR DESCRIPTION
### 功能介绍
实现统一的`launch.py`函数，作为OP测试的入口。执行流程如下
- 当use_gpu为True、task为speed、profiler为none时，op测试脚本会执行两遍：
    - 执行shell命令`nvprof python xxx.py ...`，使用nvprof来获取GPU kernel总的执行时间gpu_time。
    - 将gpu_time作为argument传递到下一次执行
    - 执行shell命令`python xxx.py ...`，获取运行总时间。
- 其他情况，则只执行shell命令`python xxx.py ...`，获取相关测试信息。

#### 启动方式
- 比如abs测试，可通过launch.py入口统一启动，这样speed任务便可获得相应的总执行时间和gpu时间。执行命令为：
```python
python -m launch abs.py \
      --task "speed" \
      --framework "paddle" \
      --json_file ${filename} \
      --config_id ${config_id} \
      --check_output False \
      --profiler "none" \
      --backward False \
      --use_gpu True \
      --repeat 1000 \
      --log_level 0`
```

- 依旧支持直接启动op的测试脚本，只是这种方式无法获得gpu执行时间。

#### 测试结果
- abs log如下
```
run command: nvprof /usr/local/python2.7.15/bin/python abs.py --task speed --framework paddle --json_file examples/abs.json --config_id 0 --check_output False --profiler none --backward False --use_gpu True --repeat 1000 --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   53.21%  1.40780s      1008  1.3966ms  1.8240us  1.9484ms  [CUDA memcpy HtoD]
                   46.19%  1.22208s      1001  1.2209ms  1.1751ms  5.9020ms  [CUDA memcpy DtoH]
                    0.59%  15.710ms      1001  15.694us  14.784us  16.800us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_abs_op<float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, int>(float, int=1)

nvprof result:  GPU activities:   53.21%  1.40780s      1008  1.3966ms  1.8240us  1.9484ms  [CUDA memcpy HtoD]
percent: 0.53; gpu_time: 1407.8000 ms; calls: 1008; function: [CUDA memcpy HtoD]
total gpu_time: 2645.7433 ms

run command: /usr/local/python2.7.15/bin/python abs.py --task speed --framework paddle --json_file examples/abs.json --config_id 0 --check_output False --profiler none --backward False --use_gpu True --repeat 1000 --log_level 0  --gpu_time  2.64574328134
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
2020-05-25 03:54:16.318146: W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'libnvinfer.so.6'; dlerror: libnvinfer.so.6: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda-10.1/extras/CUPTI/lib64:/usr/local/python2.7.15/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
2020-05-25 03:54:16.318272: W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'libnvinfer_plugin.so.6'; dlerror: libnvinfer_plugin.so.6: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda-10.1/extras/CUPTI/lib64:/usr/local/python2.7.15/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
2020-05-25 03:54:16.318284: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:30] Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.
/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py:1101: UserWarning: There are no operators in the program to be executed. If you pass Program manually, please use fluid.program_guard to ensure the current Program is being used.
  warnings.warn(error_info)
W0525 03:54:16.836982 15411 device_context.cc:265] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 10.1
W0525 03:54:16.842706 15411 device_context.cc:273] device: 0, cuDNN Version: 7.6.
---- Initialize APIConfig from examples/abs.json, config_id = 0.

API params of <abs> {
  x_dtype: float32
  run_tf: True
  atol: 1e-06
  x_shape: [16, 10, 100, 100]
}
{"framework": "paddle", "version": "0.0.0", "name": "abs", "device": "GPU", "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 6.0070665515199, "gpu_time": 2.64574328134}}
```

- fc log如下：
```
run command: nvprof /usr/local/python2.7.15/bin/python fc.py --task speed --framework paddle --json_file examples/fc.json --config_id 0 --check_output False --profiler none --backward False --use_gpu True --repeat 1000 --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   60.79%  204.75ms      1001  204.55us  196.61us  224.99us  volta_sgemm_128x32_sliced1x4_nn
                   29.20%  98.352ms      1008  97.571us  1.8240us  99.488us  [CUDA memcpy HtoD]
                    8.05%  27.129ms      1001  27.101us  26.560us  28.127us  [CUDA memcpy DtoH]
                    0.77%  2.6070ms      1001  2.6040us  2.2720us  3.7120us  void thrust::cuda_cub::core::_kernel_agent<thrust::cuda_cub::__parallel_for::ParallelForAgent<thrust::cuda_cub::__transform::binary_transform_f<thrust::device_ptr<float const >, paddle::operators::RowwiseTransformIterator<float, paddle::platform::CUDADeviceContext>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::AddFunctor<float, void>, thrust::cuda_cub::__transform::always_true_predicate>, long>, thrust::cuda_cub::__transform::binary_transform_f<thrust::device_ptr<float const >, paddle::operators::RowwiseTransformIterator<float, paddle::platform::CUDADeviceContext>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::AddFunctor<float, void>, thrust::cuda_cub::__transform::always_true_predicate>, long>(thrust::device_ptr<float const >, float)
                    0.59%  1.9727ms      1001  1.9700us  1.7920us  2.6240us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_max_op<float const , float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const , Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const > const , Eigen::GpuDevice>, int>(float, int=1)
                    0.53%  1.7998ms      1005  1.7900us  1.6960us  2.5920us  [CUDA memset]

percent: 0.61; gpu_time: 204.7500 ms; calls: 1001; function: volta_sgemm_128x32_sliced1x4_nn
total gpu_time: 336.8153 ms

run command: /usr/local/python2.7.15/bin/python fc.py --task speed --framework paddle --json_file examples/fc.json --config_id 0 --check_output False --profiler none --backward False --use_gpu True --repeat 1000 --log_level 0  --gpu_time  0.336815265669
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
2020-05-25 03:58:43.819571: W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'libnvinfer.so.6'; dlerror: libnvinfer.so.6: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda-10.1/extras/CUPTI/lib64:/usr/local/python2.7.15/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
2020-05-25 03:58:43.819680: W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'libnvinfer_plugin.so.6'; dlerror: libnvinfer_plugin.so.6: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda-10.1/extras/CUPTI/lib64:/usr/local/python2.7.15/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
2020-05-25 03:58:43.819692: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:30] Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.
W0525 03:58:44.278899 15748 device_context.cc:265] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 10.1
W0525 03:58:44.284858 15748 device_context.cc:273] device: 0, cuDNN Version: 7.6.
---- Initialize APIConfig from examples/fc.json, config_id = 0.

API params of <fc> {
  size: 4096
  input_shape: [16, 9216]
  input_dtype: float32
  run_tf: True
  atol: 1e-06
  act: relu
  num_flatten_dims: -1
}
{"framework": "paddle", "version": "0.0.0", "name": "fc", "device": "GPU", "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.7758804730006627, "gpu_time": 0.336815265669}}
```