### PR TITLE
select configs by parsing json

### DIFF
--- a/api/json/run.sh
+++ b/api/json/run.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+INPUT_DIR=$1
+OUTPUT_DIR=$2
+
+if [ ! -d ${OUTPUT_DIR} ]; then
+    mkdir -p ${OUTPUT_DIR}
+fi
+
+declare -A SPECIAL_DICTS
+# Set ignored params
+SPECIAL_DICTS=( \
+    ["conv2d"]="act num_filters" \
+    ["conv2d_transpose"]="act num_filters" \
+    ["depthwise_conv2d"]="act num_filters groups" \
+    ["fill_constant"]="value" \
+    ["anchor_generator"]="anchor_sizes" \
+    ["batch_norm"]="epsilon" \
+    ["fc"]="size" \
+    ["matmul"]="alpha" \
+    ["reshape"]="shape" \
+    ["roi_align"]="spatial_scale" \
+    ["scale"]="bias" \
+    ["transpose"]="perm" \
+)
+
+declare -A SIMILAR_API
+# Set similar APIs
+SIMILAR_API=( \
+    ["activation"]="cos floor square tanh sigmoid sqrt" \
+    ["elementwise"]="elementwise_add elementwise_div elementwise_max elementwise_min elementwise_mul elementwise_sub elementwise_sum" \
+)
+
+filenames=$(ls ${INPUT_DIR}/*.json)
+for file in ${filenames}
+do
+    op_name=$(basename ${file} .json)
+
+    skipped=0
+    for key in $(echo ${!SIMILAR_API[*]})
+    do
+        result=$(echo ${SIMILAR_API[${key}]} | grep -w "${op_name}")
+        if [[ ${result} != "" ]]; then
+            skipped=1
+            break
+        fi
+    done
+    if [[ ${skipped} -eq 1 ]]; then
+        continue
+    fi
+
+    append_params=''
+    for key in $(echo ${!SPECIAL_DICTS[*]})
+    do
+        if [[ ${key} = ${op_name} ]]; then
+            append_params=${SPECIAL_DICTS[${key}]}
+            break
+        fi
+    done
+    echo "processing API:" ${op_name}
+    python2 select_configs.py --input_json_file ${file} --output_json_file ${OUTPUT_DIR}/${op_name}.json --ignored_params ${append_params}
+    echo ""
+done
+
+for key in $(echo ${!SIMILAR_API[*]})
+do
+    echo "processing API:" ${SIMILAR_API[${key}]}
+    python2 select_configs.py --input_json_file ${file} --output_json_file ${OUTPUT_DIR}/${key}.json --similar_api {SIMILAR_API[${key}]}
+    echo ""
+done

--- a/api/json/select_configs.md
+++ b/api/json/select_configs.md
@@ -2,14 +2,20 @@
 
 对同一个Op而言，从模型中收集到的相似配置在去重后依然非常多。因此，需要有一种筛选配置的方法，保证OP在不同参数设置下的性能数据都能收集到，同时去除大部分冗余的配置。
 
+这里提供2种筛选配置的方法：
+- [方法1：通过解析运行log进行筛选](#方法1通过解析运行log进行筛选)
+- [方法2：通过解析json文件进行筛选](#方法2通过解析json文件进行筛选)
+
+## 方法1：通过解析运行log进行筛选
+通过解析运行log筛选测试配置的方式，筛选的结果会比较准确。
 - [第一步：在Paddle Repo中为C++ OP添加log](#第一步在paddle-repo中为c-op添加log)
 - [第二步：获取所有Json配置对应的OP运行log](#第二步获取所有json配置对应的op运行log)
 - [第三步：根据Op运行log，对所有Json配置进行过滤](#第三步根据op运行log对所有json配置进行过滤)
 - [过滤结果展示](#过滤结果展示)
 
-## 第一步：在Paddle Repo中为C++ OP添加log
+### 第一步：在Paddle Repo中为C++ OP添加log
 
-### 必要性说明
+#### 必要性说明
 在对OP进行性能优化时，需要分析不同参数配置下的计算开销。对于同一个OP，当API参数设置不同，计算的逻辑也可能不同，那么计算的开销就会有差异。为了准确地获取OP在执行某种参数配置时，计算逻辑落入了哪条分支，就需要为OP添加log。对于一些简单的OP，例如[dist_op](https://github.com/PaddlePaddle/Paddle/blob/7fedf26b8778c5e1da1facfb32bd17ac9ca9f0a0/paddle/fluid/operators/dist_op.h#L99-L121)，影响性能的因素，除了OP输入大小，只有参数`p`。从下面的计算逻辑来看，`p`有4种情况，在忽略输入大小的情况下，最小只需要设计4种不同`p`值的配置，就能保证每个分支的性能都被测试到。
 ```
 if (p == 0) {
@@ -48,7 +54,7 @@ if (is_expand && data_dim == 2U) {
   col2vol(dev_ctx, col, dilations, strides, paddings, &in_grad_slice);
 }
 ```
-### 添加log的示例介绍
+#### 添加log的示例介绍
 添加log的示例，可以参考[conv_op](https://github.com/PaddlePaddle/Paddle/pull/24362)。需要注意：
 
 - 需要将所有类型的kernel都考虑到，例如conv具有GemmKernel，CudnnKernel
@@ -69,7 +75,7 @@ if (is_expand && data_dim == 2U) {
              << " op=conv";
 ```
 
-## 第二步：获取所有Json配置对应的OP运行log
+### 第二步：获取所有Json配置对应的OP运行log
 在过滤之前，首先要获取到OP运行所有配置的log。执行下面的命令将OP运行所有配置时前向、反向的log保存到conv2d.log文件中：
 ```
 GLOG_v=10 python conv2d.py --json_file ./examples/conv2d.json --framework paddle --check_output False --use_gpu=True --backward True --config_id -1 2>&1 | grep 'op=' | awk '{for (i=5;i<=NF;i++){if (i>5) printf(" ");printf("%s", $i)};print ""}'> conv2d.log
@@ -90,9 +96,9 @@ data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 input_shape
 data_layout=NHWC compute_format=NCHW use_global_stats=0 is_inplace=0 input_shape=[1, 32, 32, 128] op=batch_norm_grad
 ```
 
-## 第三步：根据Op运行log，对所有Json配置进行过滤
+### 第三步：根据Op运行log，对所有Json配置进行过滤
 
-### 自动化脚本的使用方式
+#### 自动化脚本的使用方式
 
 过滤配置以及保存过滤后的结果都由`benchmark/api/json/select_configs.py`脚本自动完成。只用执行下面的示例命令：
 ```
@@ -101,6 +107,7 @@ python select_configs.py \
       --log_file conv2d.log \
       --input_json_file ../tests/examples/conv2d.json \
       --output_json_file ./conv2d.json
+      --parse_runtime_log
 ```
 参数说明：
 
@@ -108,6 +115,7 @@ python select_configs.py \
 - log_file：指定log文件的路径
 - input_json_file：指定待过滤的json文件路径，其中包含了该OP所有备选配置
 - output_json_file：指定输出的json文件路径，则过滤后的配置将被保存在该文件中
+- parse_runtime_log：指定过滤方法，设置该参数后，将会通过解析log来筛选配置
 - input_shape：可选，指定log中输入shape的名称。未指定时，将默认使用`input_shape`去提取输入的shape。
 - ignored_params：可选，不建议设置。如果有特殊需要，希望在过滤配置时，忽略log中的某个参数进行过滤，则设置该参数。
 
@@ -121,7 +129,7 @@ python select_configs.py \
 - 若在过滤配置时，只想根据log中的部分参数进行过滤，则可以在运行脚本时指定`--ignored_params param_name1 param_name2`，那么过滤时将忽略这些指定的参数，根据其他参数来过滤配置。
 - 该参数通常不需要指定，仅在有特殊需要时使用。例如log中打印了输入shape，其名字为`x_shape`，但是过滤配置时并不希望结合输入shape去过滤配置，那么可以设置`--ignored_params x_shape`。
 
-### 自动化脚本的处理逻辑
+#### 自动化脚本的处理逻辑
 
 脚本的处理逻辑如下：
 
@@ -162,9 +170,9 @@ python select_configs.py \
 
 5. 最终选取的配置，将会被自动保存到指定的输出文件中，用于API测试。
 
-## 过滤结果展示
+### 过滤结果展示
 以下是按照过滤规则对配置进行分组的结果示例。
-### 0输入的Op
+#### 0输入的Op
 
 - 当log中没有输入shape时，例如fill_constant，由于是0个输入，因此在log中将不会打印输入shape。可以构造以下测试log：
   ```
@@ -185,7 +193,7 @@ python select_configs.py \
   config 1: param1=1 param2=1, total: 1.
     Select 1 config_ids: [3].
   ```
-### 1输入的Op
+#### 1输入的Op
 - 当log中仅有1个输入shape时，可以参考conv和batch_norm的log，处理后会得到以下分组结果
   - conv的分组结果：config 0~5代表了6种标识信息，所有配置被分为了6个大组。每组再根据shape细分，最终都只得到1组，即shape 0，因为每个组中shape的标记都是`4-D is_power_of_2=F`，意味着输入都是4-D的，并且shape的大小不是2的幂。当配置数不足3个时，其配置id将被全部选择，如下面的config 0，3，4中的每个shape 0组，包含的id数都只有1个。当配置数超过3个时，从每组中选取最多3个配置，如config 1，2，5中的每个shape 0组，包含的id数都超过了3个。
 
@@ -212,7 +220,7 @@ python select_configs.py \
       shape 1: 4-D is_power_of_2=F, total: 45. Select 3 config_ids: [44, 33, 11]. The shapes are: [1, 7, 7, 512] [1, 33, 33, 1536] [1, 16, 402, 2048]
       shape 2: 4-D is_power_of_2=T, total: 14. Select 3 config_ids: [35, 51, 59]. The shapes are: [1, 1, 1, 256] [1, 32, 32, 128] [1, 256, 256, 32]
     ```
-### 2输入的Op
+#### 2输入的Op
 - 当log中有2个输入shape时，例如elementwise_add，它有x和y这2个输入，因此log中也会对应打印2个shape。构造以下的测试log模拟这种场景：
   ```
   param1=0 param2=1 x_shape=[16L, 256L, 6L, 6L] y_shape=[16L, 256L, 6L, 6L] op=op
@@ -241,3 +249,160 @@ python select_configs.py \
     shape 2: is_same_shape=T 4-D-4-D is_power_of_2=F, total: 1. Select 1 config_ids: [0]. The shapes are: [[16, 256, 6, 6], [16, 256, 6, 6]]
     shape 3: is_same_shape=F 4-D-4-D, total: 1. Select 1 config_ids: [2]. The shapes are: [[16, 32, 6, 6], [16, 256, 6, 6]]
   ```
+
+## 方法2：通过解析json文件进行筛选
+
+直接解析原始json配置，从中筛选出测试配置的方式，在用法上比较简单。使用该方法，只需要直接运行过滤脚本即可。其筛选的原理与方法1相似，不同之处在于参数值是通过读取json文件直接获得的。以conv2d.json文件中的一条配置为例，它是一个字典。
+```
+   {
+        "op": "conv2d",
+        "param_info": {
+            "act": {
+                "type": "string",
+                "value": "None"
+            },
+            "data_format": {
+                "type": "string",
+                "value": "NCHW"
+            },
+            "dilation": {
+                "type": "int",
+                "value": "1"
+            },
+            "filter_size": {
+                "type": "tuple",
+                "value": "(7, 1)"
+            },
+            "groups": {
+                "type": "string",
+                "value": "None"
+            },
+            "input": {
+                "dtype": "float32",
+                "shape": "[-1L, 1L, 512L, 402L]",
+                "type": "Variable"
+            },
+            "num_filters": {
+                "type": "int",
+                "value": "32"
+            },
+            "padding": {
+                "type": "tuple",
+                "value": "(3, 0)"
+            },
+            "stride": {
+                "type": "tuple",
+                "value": "(2, 1)"
+            },
+            "use_cudnn": {
+                "type": "bool",
+                "value": "True"
+            }
+        }
+    }
+```
+上面的字典会先被处理为下面这样一个字符串，与方法1中的log信息在形式上是统一的。所以脚本在对API配置进行分组和筛选时的逻辑也与方法1相同，下文不再赘述。
+```
+filter_size=(7, 1) act=None data_format=NCHW padding=(3, 0) use_cudnn=True groups=None num_filters=32 stride=(2, 1) dilation=1
+```
+
+下面介绍如何使用脚本完成配置筛选，主要介绍3种使用场景以及结果展示：
+- [单独过滤某个API的json配置](#单独过滤某个API的json配置)
+- [过滤某一类API的json配置](#过滤某一类API的json配置)
+- [批量处理所有API的json配置](#批量处理所有API的json配置)
+- [过滤结果展示](#过滤结果展示)
+
+### 单独过滤某个API的json配置
+
+如果需要单独过滤某个json文件中配置，可以参考下面的命令：
+```
+python select_configs.py \
+      --input_json_file input_json/conv2d.json \
+      --output_json_file output_json/conv2d.json \
+      --ignored_params act num_filters
+```
+
+参数说明：
+- input_json_file：指定待过滤的json文件路径，其中包含了该OP所有备选配置
+- output_json_file：指定输出的json文件路径，则过滤后的配置将被保存在该文件中
+- ignored_params：可选，通常不建议设置。如果设置了，那么过滤配置时，指定的这些参数将被忽略。指定的参数名必须是json文件中`param_info`里已有的。在以下场景中可以设置：某些参数在API测试脚本中没有使用到，或者参数的值不能穷举，或者已知参数的设置对性能无影响，则可以忽略掉。如conv2d，json文件中的`act`参数在API测试脚本中没有使用，`num_filters`参数实际中会有很多可能的取值，如果不忽略，那么将会得到较多冗余的配置。
+
+使用上面的命令，处理conv2d的json配置，会得到以下输出：
+
+### 过滤某一类API的json配置
+
+有些API属于同类API，例如cos、floor、square、tanh、sigmoid、sqrt等，它们同属于activation这一类，这类API通常会使用同一个测试脚本，那么它们的json配置也应该合并后，再从中进行筛选。可以参考下面的命令，过滤脚本将自动地将这些同类API的json配置合并为一个集合，这个集合中的所有配置作为备选配置，然后再从中筛选出这类API的测试配置。
+```
+python select_configs.py \
+      --input_json_file ./input_json \
+      --output_json_file ./activation.json \
+      --similar_api cos floor square tanh sigmoid sqrt
+```
+参数说明：
+
+similar_api：用于指定同类API的名称，名称需要与各自的json文件名对应。例如cos对应的是cos.json。
+
+### 批量处理所有API的json配置
+
+如果需要批量过滤所有API的json配置，可以使用`benchmark/api/json/run.sh`脚本。请按照以下几点执行：
+- 如果有API需要设置`ignored_params`，那么参考下面conv2d的示例，对`run.sh`脚本做适当修改。其中conv2d是与输入json文件名conv2d.json对应的，`act num_filters`是该API在过滤时需要忽略的参数。
+```
+# Set ignored params
+SPECIAL_DICTS=( \
+    ["conv2d"]="act num_filters" \
+)
+```
+- 如果有同类API需要合并它们的json配置后，再进行统一的筛选。那么参考下面activation和elementwise的示例，对`run.sh`脚本做适当修改。其中activation和elementwise分别是这两类API的类名，可以自由指定该名称，同时该名称也将作为输出的json文件名；每个类名都分别对应着一批同类API，这些同类API，例如`cos floor square tanh sigmoid sqrt`分别对应着cos.josn、floor.json、square.json等输入json文件。
+```
+SIMILAR_API=( \
+    ["activation"]="cos floor square tanh sigmoid sqrt" \
+    ["elementwise"]="elementwise_add elementwise_div elementwise_max elementwise_min elementwise_mul elementwise_sub elementwise_sum" \
+)
+```
+- 在修改好`run.sh`脚本后，可以执行如下示例命令，根据实际情况指定输入和输出目录，其中`input_json`为输入json的目录，`output_json`为输出json的目录。最终，所有API的json配置将被批量处理，并保存在输出目录。
+```
+./run.sh input_json output_json
+```
+
+### 过滤结果展示
+
+#### 单独过滤某个API的json配置
+
+下面展示的是conv2d的过滤结果，可以看到设置了`ignored_params: ['act', 'num_filters']`后依然产生了不少分组。可以检查过滤结果是否合理，手动地去调整`ignored_params`的设置，以避免留下太多冗余配置。
+```
+ignored_params: ['act', 'num_filters'].
+==============================config_groups==============================
+config 0: filter_size=1 data_format=NCHW padding=0 use_cudnn=True groups=1 stride=2 dilation=1 , total: 3.
+  shape 0: 4-D is_power_of_2=F, total: 3. Select 3 config_ids: [20, 14, 8]. The shapes are: [[16, 1024, 14, 14]] [[16, 512, 28, 28]] [[16, 256, 56, 56]]
+config 1: filter_size=1 data_format=NCHW padding=0 use_cudnn=True groups=1 stride=1 dilation=1 , total: 21.
+  shape 0: 4-D is_power_of_2=F, total: 21. Select 3 config_ids: [19, 17, 30]. The shapes are: [[16, 512, 7, 7]] [[16, 1024, 14, 14]] [[16, 256, 56, 56]]
+config 2: filter_size=5 data_format=NCHW padding=2 use_cudnn=True groups=1 stride=1 dilation=1 , total: 1.
+  shape 0: 4-D is_power_of_2=F, total: 1. Select 1 config_ids: [24]. The shapes are: [[16, 64, 27, 27]]
+config 3: filter_size=3 data_format=NCHW padding=1 use_cudnn=True groups=1 stride=1 dilation=1 , total: 7.
+  shape 0: 4-D is_power_of_2=F, total: 7. Select 3 config_ids: [22, 16, 2]. The shapes are: [[16, 512, 7, 7]] [[16, 256, 14, 14]] [[16, 64, 56, 56]]
+config 4: filter_size=3 data_format=NCHW padding=1 use_cudnn=True groups=1 stride=2 dilation=1 , total: 3.
+  shape 0: 4-D is_power_of_2=F, total: 3. Select 3 config_ids: [18, 12, 6]. The shapes are: [[16, 512, 14, 14]] [[16, 256, 28, 28]] [[16, 128, 56, 56]]
+config 5: filter_size=3 data_format=NCHW padding=1 use_cudnn=True groups=32 stride=1 dilation=1 , total: 3.
+  shape 0: 4-D is_power_of_2=F, total: 3. Select 3 config_ids: [42, 37, 33]. The shapes are: [[16, 1024, 7, 7]] [[16, 512, 14, 14]] [[16, 256, 28, 28]]
+config 6: filter_size=3 data_format=NCHW padding=1 use_cudnn=True groups=32 stride=2 dilation=1 , total: 3.
+  shape 0: 4-D is_power_of_2=F, total: 3. Select 3 config_ids: [39, 35, 31]. The shapes are: [[16, 1024, 14, 14]] [[16, 512, 28, 28]] [[16, 256, 56, 56]]
+config 7: filter_size=7 data_format=NCHW padding=3 use_cudnn=True groups=1 stride=2 dilation=1 , total: 1.
+  shape 0: 4-D is_power_of_2=F, total: 1. Select 1 config_ids: [0]. The shapes are: [[16, 3, 224, 224]]
+config 8: filter_size=11 data_format=NCHW padding=2 use_cudnn=True groups=1 stride=4 dilation=1 , total: 1.
+  shape 0: 4-D is_power_of_2=F, total: 1. Select 1 config_ids: [23]. The shapes are: [[16, 3, 224, 224]]
+```
+
+#### 过滤某一类API的json配置
+
+下面是对`cos floor square tanh sigmoid sqrt`这一批同类API处理的结果，脚本将它们的配置合并为一个集合，作为备选配置，然后从中筛选出测试配置。
+```
+ignored_params: None.
+==============================config_groups==============================
+config 0: , total: 68.
+  shape 0: 2-D is_power_of_2=T, total: 10. Select 3 config_ids: [19, 27, 16]. The shapes are: [[2, 1024]] [[1024, 512]] [[4096, 1024]]
+  shape 1: 4-D is_power_of_2=F, total: 11. Select 3 config_ids: [57, 52, 49]. The shapes are: [[16, 14, 1, 1]] [[16, 14, 32, 1]] [[16, 3, 256, 256]]
+  shape 2: 1-D is_power_of_2=F, total: 6. Select 3 config_ids: [11, 32, 5]. The shapes are: [[3]] [[3072]] [[10000]]
+  shape 3: 2-D is_power_of_2=F, total: 25. Select 3 config_ids: [38, 2, 20]. The shapes are: [[2, 768]] [[10000, 200]] [[30522, 1024]]
+  shape 4: 4-D is_power_of_2=T, total: 8. Select 3 config_ids: [45, 47, 65]. The shapes are: [[16, 512, 8, 8]] [[16, 128, 32, 32]] [[16, 64, 64, 64]]
+  shape 5: 1-D is_power_of_2=T, total: 8. Select 3 config_ids: [0, 67, 13]. The shapes are: [[1]] [[16]] [[4096]]
+```

--- a/api/json/select_configs.py
+++ b/api/json/select_configs.py
@@ -17,19 +17,26 @@ import os
 import json
 import warnings
 from operator import mul
+from functools import reduce
 import random
+import copy
 
 import sys
 sys.path.append("..")
 from common.api_param import parse_list
 
 
-def select_configs_by_json(args, all_configs, all_shapes, input_type):
+def select_configs_by_json(args, origin_configs, configs_without_input,
+                           all_shapes, input_type):
+    """
+    Select configs according to json config and save the selected
+    configs to the sepcified json file.
+    """
     ignored_params = []
     if args.ignored_params:
         ignored_params += args.ignored_params
     all_config_info = []
-    for config in all_configs:
+    for config in configs_without_input:
         config_info = ""
         for param in config["param_info"]:
             if param not in ignored_params:
@@ -37,26 +44,19 @@ def select_configs_by_json(args, all_configs, all_shapes, input_type):
                 config_info += param + "=" + value + " "
         all_config_info.append(config_info)
     config_groups = grouping_configs(all_config_info, all_shapes, input_type)
-    print("=" * 30 + "config_groups" + "=" * 30)
-    all_selected_ids = []
-    i = 0
-    for key in config_groups:
-        print("config {0}: {1}, total: {2}.".format(
-            i, key, len(config_groups[key]['ids'])))
-        shape_groups = config_groups[key]['shape_groups']
-        if not shape_groups:
-            selected_ids = random.sample(config_groups[key]['ids'], 1)
-            all_selected_ids.append(selected_ids)
-            select_ids_info = "  Select {0} config_ids: {1}.".format(
-                len(selected_ids), selected_ids)
-            print(select_ids_info)
-        else:
-            all_selected_ids += select_from_shape_groups(shape_groups,
-                                                         all_shapes)
-        i += 1
+    all_selected_ids = select_and_print_configs(config_groups, all_shapes)
+
+    out_dir = os.path.dirname(args.output_json_file)
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+    configs = []
+    for index in all_selected_ids:
+        configs.append(origin_configs[index])
+    with open(args.output_json_file, 'w') as f:
+        json.dump(configs, f, indent=4, sort_keys=True)
 
 
-def select_configs(args, forward_logs, backward_logs):
+def select_configs_by_log(args, forward_logs, backward_logs):
     """
     Select configs according to forward logs and backward logs and save the selected
     configs to the sepcified json file.
@@ -77,24 +77,7 @@ def select_configs(args, forward_logs, backward_logs):
     combined_logs = combine_logs_with_key_params(removed_params, forward_logs,
                                                  backward_logs)
     config_groups = grouping_configs(combined_logs, shapes_list)
-
-    print("=" * 30 + "config_groups" + "=" * 30)
-    all_selected_ids = []
-    i = 0
-    for key in config_groups:
-        print("config {0}: {1}, total: {2}.".format(
-            i, key, len(config_groups[key]['ids'])))
-        shape_groups = config_groups[key]['shape_groups']
-        if not shape_groups:
-            selected_ids = random.sample(config_groups[key]['ids'], 1)
-            all_selected_ids.append(selected_ids)
-            select_ids_info = "  Select {0} config_ids: {1}.".format(
-                len(selected_ids), selected_ids)
-            print(select_ids_info)
-        else:
-            all_selected_ids += select_from_shape_groups(shape_groups,
-                                                         shapes_list)
-        i += 1
+    all_selected_ids = select_and_print_configs(config_groups, shapes_list)
 
     with open(args.input_json_file, 'r') as f:
         all_configs = json.load(f)
@@ -106,6 +89,27 @@ def select_configs(args, forward_logs, backward_logs):
         configs.append(all_configs[index])
     with open(args.output_json_file, 'w') as f:
         json.dump(configs, f, indent=4, sort_keys=True)
+
+
+def select_and_print_configs(config_groups, shapes_list):
+    print("=" * 30 + "config_groups" + "=" * 30)
+    all_selected_ids = []
+    i = 0
+    for key in config_groups:
+        print("config {0}: {1}, total: {2}.".format(
+            i, key, len(config_groups[key]['ids'])))
+        shape_groups = config_groups[key]['shape_groups']
+        if not shape_groups:
+            selected_ids = random.sample(config_groups[key]['ids'], 1)
+            all_selected_ids.extend(selected_ids)
+            select_ids_info = "  Select {0} config_ids: {1}.".format(
+                len(selected_ids), selected_ids)
+            print(select_ids_info)
+        else:
+            all_selected_ids.extend(
+                select_from_shape_groups(shape_groups, shapes_list))
+        i += 1
+    return all_selected_ids
 
 
 def select_from_shape_groups(shape_groups, shapes):
@@ -248,7 +252,7 @@ def get_input_shapes(logs, input_shape):
             param_val = item.split("=")
             if param_val[0] in input_shape:
                 shape = parse_list(param_val[1])
-                shapes.append(shape)
+                shapes.append(list(shape))
         all_shapes.append(shapes)
 
     return all_shapes
@@ -278,6 +282,49 @@ def group_input_shapes(shapes, config_ids, input_type):
             shape_groups[label]['sizes'] += [size]
 
     return shape_groups
+
+
+def get_input_shapes_from_json(args, origin_configs):
+    configs_without_input = []
+    all_shapes = []
+    input_type = "Variable"
+    input_name = ["input", "x", "y"]
+    for config in origin_configs:
+        config_res = copy.deepcopy(config)
+        input_shapes = []
+        var_shapes = []
+        for name, value in config["param_info"].items():
+            if name in args.ignored_params:
+                continue
+            if value["type"] in ["Variable", "numpy.ndarray"]:
+                if value["type"] == "Variable":
+                    shape = list(parse_list(value["shape"]))
+                else:
+                    shape = list(parse_list(value["value"]))
+                for i in range(len(shape)):
+                    if shape[i] == -1:
+                        shape[i] = 16
+                if name in input_name:
+                    input_shapes.append(shape)
+                else:
+                    var_shapes.append(shape)
+                del config_res["param_info"][name]
+            elif value["type"] == "list<Variable>":
+                input_type = "list<Variable>"
+                for key, var in value.items():
+                    if key != "type":
+                        shape = list(parse_list(var["shape"]))
+                        for i in range(len(shape)):
+                            if shape[i] == -1:
+                                shape[i] = 16
+                        input_shapes.append(shape)
+                del config_res["param_info"][name]
+        configs_without_input.append(config_res)
+        all_shapes.append(input_shapes)
+        if len(input_shapes) == 0 and len(var_shapes) <= 2:
+            all_shapes.append(var_shapes)
+
+    return configs_without_input, all_shapes, input_type
 
 
 def label_shape(shape, input_type):
@@ -388,30 +435,33 @@ def get_logs(op_name, log_file):
     return forward_logs, backward_logs
 
 
-def parse_json_config(json_file):
-    if not os.path.exists(json_file):
+def parse_json_config(args):
+    if not os.path.exists(args.input_json_file):
         raise ValueError(
-            "The file {} is not found. Please check the path of json file.".
-            format(json_file))
-    with open(args.input_json_file, 'r') as f:
-        all_configs = json.load(f)
-        all_shapes = []
-        for config in all_configs:
-            if "input" in config["param_info"]:
-                shapes = []
-                value = config["param_info"]["input"]
-                if value["type"] == "Variable":
-                    input_type = "Variable"
-                    shape = parse_list(value["shape"])
-                    shapes.append(shape)
-                elif value["type"] == "list<Variable>":
-                    input_type = "list<Variable>"
-                    for key, var in value.items():
-                        if key != "type":
-                            shapes.append(parse_list(var["shape"]))
-                del config["param_info"]["input"]
-            all_shapes.append(shapes)
-    return all_configs, all_shapes, input_type
+            "The input_json_file {} is not found. Please check the path of json file.".
+            format(args.input_json_file))
+
+    origin_configs = []
+    if os.path.isdir(args.input_json_file):
+        if args.similar_api:
+            for api in args.similar_api:
+                json_path = os.path.join(args.input_json_file, api + '.json')
+                with open(json_path, 'r') as f:
+                    api_configs = json.load(f)
+                    origin_configs.extend(api_configs)
+        else:
+            raise ValueError(
+                "When input_json_file is a Directory, the args similar_api should be set."
+            )
+    elif os.path.isfile(args.input_json_file):
+        with open(args.input_json_file, 'r') as f:
+            origin_configs = json.load(f)
+
+    configs_without_input, all_shapes, input_type = get_input_shapes_from_json(
+        args, origin_configs)
+    print("Total config of input json: {}".format(len(origin_configs)))
+
+    return origin_configs, configs_without_input, all_shapes, input_type
 
 
 def parse_args():
@@ -450,6 +500,11 @@ def parse_args():
         action='store_true',
         help='Whether selecting configs by parsing runtime log. '
         'Default: False, selecting configs by parsing json config.')
+    parser.add_argument(
+        '--similar_api',
+        nargs='*',
+        help='Specify the similar APIs, the output config will be '
+        'selected from the json file of these APIs.')
     args = parser.parse_args()
     return args
 
@@ -459,8 +514,9 @@ if __name__ == '__main__':
     print("ignored_params: {0}.".format(args.ignored_params))
     if args.parse_runtime_log:
         forward_logs, backward_logs = get_logs(args.op_name, args.log_file)
-        select_configs(args, forward_logs, backward_logs)
+        select_configs_by_log(args, forward_logs, backward_logs)
     else:
-        all_configs, all_shapes, input_type = parse_json_config(
-            args.input_json_file)
-        select_configs_by_json(args, all_configs, all_shapes, input_type)
+        origin_configs, configs_without_input, all_shapes, input_type = parse_json_config(
+            args)
+        select_configs_by_json(args, origin_configs, configs_without_input,
+                               all_shapes, input_type)


### PR DESCRIPTION
增加过滤方案2：通过直接解析json中的配置进行筛选。目前该筛选脚本支持解析log或者解析json进行配置的筛选。待完善的功能：
- [x] 支持同类API的 json配置进行合并后筛选。例如exp、abs等这种属于同类API，它们的API测试脚本是同一个，因此可以将它们的原始配置合并后，再统一筛选。
- [x] 文档中添加过滤方法2的使用方式说明


Example：
- conv：`python select_configs.py       --input_json_file ./conv2d.json       --output_json_file ./conv2d.json --ignored_params act num_filters`
```
ignored_params: ['act', 'num_filters'].
==============================config_groups==============================
config 0: filter_size=1 data_format=NCHW padding=0 use_cudnn=True groups=1 stride=2 dilation=1 , total: 3.
  shape 0: 4-D is_power_of_2=F, total: 3. Select 3 config_ids: [20, 14, 8]. The shapes are: [[16, 1024, 14, 14]] [[16, 512, 28, 28]] [[16, 256, 56, 56]]
config 1: filter_size=1 data_format=NCHW padding=0 use_cudnn=True groups=1 stride=1 dilation=1 , total: 21.
  shape 0: 4-D is_power_of_2=F, total: 21. Select 3 config_ids: [19, 17, 30]. The shapes are: [[16, 512, 7, 7]] [[16, 1024, 14, 14]] [[16, 256, 56, 56]]
config 2: filter_size=5 data_format=NCHW padding=2 use_cudnn=True groups=1 stride=1 dilation=1 , total: 1.
  shape 0: 4-D is_power_of_2=F, total: 1. Select 1 config_ids: [24]. The shapes are: [[16, 64, 27, 27]]
config 3: filter_size=3 data_format=NCHW padding=1 use_cudnn=True groups=1 stride=1 dilation=1 , total: 7.
  shape 0: 4-D is_power_of_2=F, total: 7. Select 3 config_ids: [22, 16, 2]. The shapes are: [[16, 512, 7, 7]] [[16, 256, 14, 14]] [[16, 64, 56, 56]]
config 4: filter_size=3 data_format=NCHW padding=1 use_cudnn=True groups=1 stride=2 dilation=1 , total: 3.
  shape 0: 4-D is_power_of_2=F, total: 3. Select 3 config_ids: [18, 12, 6]. The shapes are: [[16, 512, 14, 14]] [[16, 256, 28, 28]] [[16, 128, 56, 56]]
config 5: filter_size=3 data_format=NCHW padding=1 use_cudnn=True groups=32 stride=1 dilation=1 , total: 3.
  shape 0: 4-D is_power_of_2=F, total: 3. Select 3 config_ids: [42, 37, 33]. The shapes are: [[16, 1024, 7, 7]] [[16, 512, 14, 14]] [[16, 256, 28, 28]]
config 6: filter_size=3 data_format=NCHW padding=1 use_cudnn=True groups=32 stride=2 dilation=1 , total: 3.
  shape 0: 4-D is_power_of_2=F, total: 3. Select 3 config_ids: [39, 35, 31]. The shapes are: [[16, 1024, 14, 14]] [[16, 512, 28, 28]] [[16, 256, 56, 56]]
config 7: filter_size=7 data_format=NCHW padding=3 use_cudnn=True groups=1 stride=2 dilation=1 , total: 1.
  shape 0: 4-D is_power_of_2=F, total: 1. Select 1 config_ids: [0]. The shapes are: [[16, 3, 224, 224]]
config 8: filter_size=11 data_format=NCHW padding=2 use_cudnn=True groups=1 stride=4 dilation=1 , total: 1.
  shape 0: 4-D is_power_of_2=F, total: 1. Select 1 config_ids: [23]. The shapes are: [[16, 3, 224, 224]]
```

- concat：`python select_configs.py       --input_json_file ./concat.json       --output_json_file ./concat.json`
```
ignored_params: None.
==============================config_groups==============================
config 0: axis=1 , total: 39.
  shape 0: is_same_shape=F, total: 21. Select 3 config_ids: [19, 20, 6]. The shapes are: [[16, 1024], [16, 512]] [[16, 256, 16, 16], [16, 512, 16, 16]] [[16, 256, 129, 129], [16, 48, 129, 129]]
  shape 1: is_same_shape=T, total: 18. Select 3 config_ids: [8, 26, 45]. The shapes are: [[16, 16, 1], [16, 16, 1], [16, 16, 1], [16, 16, 1], [16, 16, 1]] [[16, 256, 16, 16], [16, 256, 16, 16]] [[16, 64, 128, 128], [16, 64, 128, 128]]
config 1: axis=0 , total: 9.
  shape 0: is_same_shape=T, total: 9. Select 3 config_ids: [7, 15, 10]. The shapes are: [[1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1], [1]] [[1, 16, 200], [1, 16, 200]] [[16, 256, 14, 14], [16, 256, 14, 14], [16, 256, 14, 14], [16, 256, 14, 14]]
```
- 同类API（例如：cos floor square tanh sigmoid sqrt）的json配置会自动合并为一个备选集合后，再进行过滤：`python select_configs.py       --input_json_file ./input_json       --output_json_file ./activation.json       --similar_api cos floor square tanh sigmoid sqrt`
```

ignored_params: None.
There are 1 invalid configs in which the input shape contains more than one -1.
==============================config_groups==============================
config 0: , total: 68.
  shape 0: 2-D is_power_of_2=T, total: 10. Select 3 config_ids: [19, 27, 16]. The shapes are: [[2, 1024]] [[1024, 512]] [[4096, 1024]]
  shape 1: 4-D is_power_of_2=F, total: 11. Select 3 config_ids: [57, 52, 49]. The shapes are: [[16, 14, 1, 1]] [[16, 14, 32, 1]] [[16, 3, 256, 256]]
  shape 2: 1-D is_power_of_2=F, total: 6. Select 3 config_ids: [11, 32, 5]. The shapes are: [[3]] [[3072]] [[10000]]
  shape 3: 2-D is_power_of_2=F, total: 25. Select 3 config_ids: [38, 2, 20]. The shapes are: [[2, 768]] [[10000, 200]] [[30522, 1024]]
  shape 4: 4-D is_power_of_2=T, total: 8. Select 3 config_ids: [45, 47, 65]. The shapes are: [[16, 512, 8, 8]] [[16, 128, 32, 32]] [[16, 64, 64, 64]]
  shape 5: 1-D is_power_of_2=T, total: 8. Select 3 config_ids: [0, 67, 13]. The shapes are: [[1]] [[16]] [[4096]]
```