### PR TITLE
Correct the usage of several ops

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -211,12 +211,13 @@ class APIConfig(object):
                 setattr(self, name, None)
 
     def __str__(self):
-        debug_str = ('[%s] %s {\n') % (self.framework, self.name)
+        debug_str = ('[%s][%s] %s {\n') % (self.framework, self.name,
+                                           self.api_name)
         for name, value in vars(self).items():
             if name not in [
                     '_APIConfig__name', '_APIConfig__framework', 'params',
-                    'api_list', 'variable_list', 'params_list', 'backward',
-                    'feed_spec'
+                    'api_name', 'api_list', 'variable_list', 'params_list',
+                    'backward', 'feed_spec'
             ]:
                 if isinstance(value, np.ndarray):
                     debug_str = debug_str + (

--- a/api/common/feeder.py
+++ b/api/common/feeder.py
@@ -61,7 +61,12 @@ def generate_random_data(shape, dtype, range=None, value=None):
         assert len(range) == 2
 
     if value is not None:
-        assert isinstance(value, np.ndarray)
+        if isinstance(value, list):
+            value = np.array(value)
+        assert isinstance(
+            value, np.ndarray
+        ), "Expected value's type to be numpy.ndarray, but recieved {}.".format(
+            type(value))
         data = check_shape_and_dtype(shape, dtype, value)
     else:
         if dtype == "int64" or dtype == "int32":

--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -237,8 +237,6 @@ class PaddleAPIBenchmarkBase(object):
             return feeder_adapter
 
     def run(self, config, args, use_feed_fetch=True, feeder_adapter=None):
-        print(config)
-
         self.name = config.api_name
         feeder_adapter = self.generate_random_feeder(config, use_feed_fetch,
                                                      feeder_adapter)

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -341,8 +341,6 @@ class TensorflowAPIBenchmarkBase(object):
             return feeder_adapter
 
     def run(self, config, args, use_feed_fetch=True, feeder_adapter=None):
-        print(config)
-
         self.name = config.api_name
         feeder_adapter = self.generate_random_feeder(config, use_feed_fetch,
                                                      feeder_adapter)

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -94,13 +94,12 @@ def _check_type(output1, output2):
 def _check_shape(output1, output2, i):
     shape1 = list(output1.shape)
     shape2 = list(output2.shape)
-    if shape1 != shape2:
-        print("---- The %d-the output's shape is different, %s vs %s." %
-              (i, str(shape1), str(shape2)))
-        if shape1 == shape2 + [1]:
-            output2 = np.reshape(output2, output1.shape)
-        elif shape1 + [1] == shape2:
-            output1 = np.reshape(output1, output2.shape)
+    if shape1 == shape2 + [1]:
+        output2 = np.reshape(output2, output1.shape)
+    elif shape1 + [1] == shape2:
+        output1 = np.reshape(output1, output2.shape)
+    assert output1.shape == output2.shape, "The %d-the output's shape is different, %s vs %s." % (
+        i, str(output1.shape), str(output2.shape))
     return output1, output2
 
 

--- a/api/tests/common_import.py
+++ b/api/tests/common_import.py
@@ -13,24 +13,20 @@
 # limitations under the License.
 
 import sys
-import importlib
 import numpy as np
+
 sys.path.append("..")
-from numpy.linalg import matrix_rank
 from common.paddle_api_benchmark import PaddleAPIBenchmarkBase
 from common.tensorflow_api_benchmark import TensorflowAPIBenchmarkBase
 from common.api_param import APIConfig
 
 try:
     import paddle
-except ImportError:
-    sys.stderr.write("Cannot import paddle, maybe paddle is not installed.\n")
-
-try:
     import paddle.fluid as fluid
 except ImportError:
     sys.stderr.write(
-        "Cannot import paddle.fluid, maybe paddle is not installed.\n")
+        "Cannot import paddle or paddle.fluid, maybe paddle is not installed.\n"
+    )
 
 try:
     import tensorflow as tf

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -32,7 +32,7 @@ class Conv2dConfig(APIConfig):
         if self.data_format == "NCHW":
             self.num_channels = self.input_shape[1]
         elif self.data_format == "NHWC":
-            self.num_channels = self.input_shape[4]
+            self.num_channels = self.input_shape[3]
         if self.input_shape[0] == -1:
             self.input_shape[0] = 64
         if isinstance(self.filter_size, int):

--- a/api/tests/conv2d_transpose.py
+++ b/api/tests/conv2d_transpose.py
@@ -18,6 +18,7 @@ from common_import import *
 class Conv2dTransposeConfig(APIConfig):
     def __init__(self):
         super(Conv2dTransposeConfig, self).__init__('conv2d_transpose')
+        self.run_tf = False
 
     def init_from_json(self, filename, config_id=0):
         super(Conv2dTransposeConfig, self).init_from_json(filename, config_id)
@@ -64,7 +65,7 @@ class PDConv2dTranspose(PaddleAPIBenchmarkBase):
 
         self.feed_vars = [input, filter]
         self.fetch_vars = [result]
-        if backward:
+        if config.backward:
             self.append_gradients(result, [input])
 
 

--- a/api/tests/examples/conv2d_transpose.json
+++ b/api/tests/examples/conv2d_transpose.json
@@ -1,0 +1,50 @@
+[{
+    "op": "conv2d_transpose",
+    "param_info": {
+        "input": {
+            "type": "Variable",
+            "dtype": "float32",
+            "shape": "[1L, 1L, 80L, 63L]"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "1"
+        },
+        "output_size": {
+            "type": "string",
+            "value": "None"
+        },
+        "filter_size": {
+            "type": "list",
+            "value": "[3, 32]"
+        },
+        "padding": {
+            "type": "list",
+            "value": "[1, 8]"
+        },
+        "stride": {
+            "type": "list",
+            "value": "[1, 16]"
+        },
+        "dilation": {
+            "type": "list",
+            "value": "[1, 1]"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
+        },
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        }
+    }
+}]

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -161,6 +161,7 @@ def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
     if _is_tensorflow_enabled(args, config):
         assert tf_obj is not None, "TensorFlow object is None."
         tf_config = config.to_tensorflow()
+        print(tf_config)
         feeder_adapter = tf_obj.generate_random_feeder(tf_config,
                                                        use_feed_fetch)
         tf_outputs, tf_stats = tf_obj.run(tf_config, args, use_feed_fetch,
@@ -171,6 +172,7 @@ def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
 
     if _is_paddle_enabled(args, config):
         assert pd_obj is not None, "Paddle object is None."
+        print(config)
         pd_outputs, pd_stats = pd_obj.run(config, args, use_feed_fetch,
                                           feeder_adapter)
         if args.task == "speed":

--- a/api/tests/slice.py
+++ b/api/tests/slice.py
@@ -18,7 +18,6 @@ from common_import import *
 class SliceConfig(APIConfig):
     def __init__(self):
         super(SliceConfig, self).__init__('slice')
-        self.run_tf = False
 
     def to_tensorflow(self):
         tf_config = super(SliceConfig, self).to_tensorflow()
@@ -57,14 +56,22 @@ class TFSlice(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
         input = self.variable(
             name='input', shape=config.input_shape, dtype=config.input_dtype)
-        begin = self.variable(name='begin', shape=config.starts, dtype="int32")
-        size = self.variable(name='size', shape=config.ends, dtype="int32")
+        begin = self.variable(
+            name='begin',
+            shape=[len(config.starts)],
+            dtype="int32",
+            value=config.starts)
+        size = self.variable(
+            name='size',
+            shape=[len(config.ends)],
+            dtype="int32",
+            value=config.ends)
         result = tf.slice(input_=input, begin=begin, size=size)
 
-        self.feed_list = [input, begin, size]
+        self.feed_list = [input]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, [input, begin, size])
+            self.append_gradients(result, [input])
 
 
 if __name__ == '__main__':

--- a/api/tests/slice.py
+++ b/api/tests/slice.py
@@ -22,17 +22,17 @@ class SliceConfig(APIConfig):
     def to_tensorflow(self):
         tf_config = super(SliceConfig, self).to_tensorflow()
         if len(self.starts) < len(self.input_shape):
-            tf_config.starts = []
-            tf_config.ends = []
+            tf_config.begin = []
+            tf_config.size = []
             for i in range(len(self.input_shape)):
-                tf_config.starts.append(0)
-                tf_config.ends.append(self.input_shape[i])
+                tf_config.begin.append(0)
+                tf_config.size.append(self.input_shape[i])
             for i in self.axes:
-                tf_config.starts[i] = self.starts[i]
-                tf_config.ends[i] = self.ends[i] - self.starts[i]
+                tf_config.begin[i] = self.starts[i]
+                tf_config.size[i] = self.ends[i] - self.starts[i]
         else:
             for j in range(len(self.starts)):
-                tf_config.ends[j] = self.ends[j] - self.starts[j]
+                tf_config.size[j] = self.ends[j] - self.starts[j]
         return tf_config
 
 
@@ -56,17 +56,7 @@ class TFSlice(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
         input = self.variable(
             name='input', shape=config.input_shape, dtype=config.input_dtype)
-        begin = self.variable(
-            name='begin',
-            shape=[len(config.starts)],
-            dtype="int32",
-            value=config.starts)
-        size = self.variable(
-            name='size',
-            shape=[len(config.ends)],
-            dtype="int32",
-            value=config.ends)
-        result = tf.slice(input_=input, begin=begin, size=size)
+        result = tf.slice(input_=input, begin=config.begin, size=config.size)
 
         self.feed_list = [input]
         self.fetch_list = [result]

--- a/api/tests/softmax_with_cross_entropy.py
+++ b/api/tests/softmax_with_cross_entropy.py
@@ -38,7 +38,8 @@ class SoftmaxWithCrossEntropyConfig(APIConfig):
     def to_tensorflow(self):
         tf_config = super(FCConfig, self).to_tensorflow()
         label_rank = len(tf_config.label_shape)
-        tf_config.label_shape = tf_config.label_shape[0:label_rank - 2]
+        if tf_config.label_shape[label_rank - 1] == 1:
+            tf_config.label_shape = tf_config.label_shape[0:label_rank - 1]
         return tf_config
 
 

--- a/api/tests/softmax_with_cross_entropy.py
+++ b/api/tests/softmax_with_cross_entropy.py
@@ -19,7 +19,6 @@ class SoftmaxWithCrossEntropyConfig(APIConfig):
     def __init__(self):
         super(SoftmaxWithCrossEntropyConfig,
               self).__init__("softmax_with_cross_entropy")
-        self.run_tf = False
 
     def init_from_json(self, filename, config_id=0):
         super(SoftmaxWithCrossEntropyConfig, self).init_from_json(filename,
@@ -36,7 +35,7 @@ class SoftmaxWithCrossEntropyConfig(APIConfig):
         ]
 
     def to_tensorflow(self):
-        tf_config = super(FCConfig, self).to_tensorflow()
+        tf_config = super(SoftmaxWithCrossEntropyConfig, self).to_tensorflow()
         label_rank = len(tf_config.label_shape)
         if tf_config.label_shape[label_rank - 1] == 1:
             tf_config.label_shape = tf_config.label_shape[0:label_rank - 1]
@@ -68,12 +67,12 @@ class TFSoftmaxWithCrossEntropy(TensorflowAPIBenchmarkBase):
         label = self.variable(
             name='label', shape=config.label_shape, dtype=config.label_dtype)
         onehot_label = tf.one_hot(indices=label, depth=config.num_classes)
-        result = tf.losses.softmax_cross_entropy(
-            logits=input, onehot_labels=onehot_label)
+        result = tf.compat.v1.losses.softmax_cross_entropy(
+            logits=input, onehot_labels=onehot_label, reduction='none')
 
         self.feed_list = [input, label]
         self.fetch_list = [result]
-        if backward:
+        if config.backward:
             self.append_gradients(result, [input])
 
 


### PR DESCRIPTION
对齐了以下几个op的计算：

- accuracy，tf的label要求是one-hot tensor，因此可以先调用`tf.one_hot`对label进行转换，计算结果可对齐，但时间不好对比。
- conv2d_transpose，tf的conv2d_transpose要求必须设置output_size，但依据paddle的输出shape设置了output_size之后，运行还是出错。待下个PR解决。
- pad2d，paddle的pad2d输入是4-D的，实际只padding 2个维度，即在H、W这两个维度上进行padding；tf的pad可支持任意维度的输入，输入是4-D时，paddings的形状应为[4, 2]，不padding的维度上值应设置为0。且`tf.pad`的`paddings`参数，必须用`tf.constant`定义。
- slice，使用方式不对，config中的begin和size，是tf对应参数的值（不是shape）。
- softmax_with_cross_entropy，同accuracy，且必须设置`reduction='none'`。
