### PR TITLE
Support running op test in different directory.

### DIFF
--- a/api/common/__init__.py
+++ b/api/common/__init__.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -1,0 +1,13 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/api/tests/common_import.py
+++ b/api/tests/common_import.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import os, sys
 import numpy as np
 
-sys.path.append("..")
+package_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(package_path)
+
 from common.paddle_api_benchmark import PaddleAPIBenchmarkBase
 from common.tensorflow_api_benchmark import TensorflowAPIBenchmarkBase
 from common.api_param import APIConfig

--- a/api/tests/launch.py
+++ b/api/tests/launch.py
@@ -14,10 +14,12 @@
 
 from __future__ import print_function
 
-import sys
+import os, sys
 import argparse
 
-sys.path.append("..")
+package_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(package_path)
+
 from common import utils
 
 

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -10,11 +10,14 @@ if [ ${NVCC} != "" ]; then
   export LD_LIBRARY_PATH=/usr/local/cuda-${NVCC_VERSION}/extras/CUPTI/lib64:${LD_LIBRARY_PATH}
 fi
 
+OP_BENCHMARK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/../" && pwd )"
+export PYTHONPATH=${OP_BENCHMARK_ROOT}:${PYTHONPATH}
+
 name=${1:-"abs"}
 config_id=${2:-"0"}
-filename="examples/${name}.json"
+filename="${OP_BENCHMARK_ROOT}/tests/examples/${name}.json"
 
-python -m launch ${name}.py \
+python -m tests.launch ${OP_BENCHMARK_ROOT}/tests/${name}.py \
       --task "accuracy" \
       --framework "paddle" \
       --json_file ${filename} \

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -52,7 +52,6 @@ function fetch_upstream_master_if_not_exist() {
 
 function run_api(){
     fetch_upstream_master_if_not_exist
-    cd ${BENCHMARK_ROOT}/api/tests
     HAS_MODIFIED_API_TEST=`git diff --name-status upstream/$BRANCH | awk '$1!="D" {print $2}' | grep "api/tests.*.py$" || true`
     API_NAMES=(abs activation elementwise fc)
     if [ "${HAS_MODIFIED_API_TEST}" != "" ] ; then
@@ -75,7 +74,7 @@ function run_api(){
 
     fail_name=()
     for name in ${API_NAMES[@]}; do
-        sh run.sh $name -1
+        bash ${BENCHMARK_ROOT}/api/tests/run.sh $name -1
         if [ $? -ne 0 ]; then
             fail_name[${#fail_name[@]}]="$name.py"
         fi


### PR DESCRIPTION
master分支代码，若在`benchmark/api/tests/deploy`目录下面命令`python ../launch.py ../abs.py ...`，会出现如下错误：
```
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
Traceback (most recent call last):
  File "../launch.py", line 21, in <module>
    from common import utils
ImportError: No module named common
```

为了支持在不同的目录执行op测试，这个PR做了以下3个工作：
1. common目录下新增`__init__.py`文件
2. common_import.py和launch.py里面引入common目录模块时，将相对路径`..`改成绝对路径
3. 支持在别的目录直接运行tests目录下的run.sh，比如在`benchmark/api`目录下直接执行命令`./tests/run.sh`
