### PR TITLE
remove accuracy of tensorflow

### DIFF
--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -61,6 +61,9 @@ do
                         if [ ${direction[$m]} = "backward" ] && [ ${backward} = False ]; then
                             continue
                         fi
+                        if [ ${framwork[$k]} = "tensorflow" ] && [ ${feature[$n]} = "accuracy" ]; then
+                            continue
+                        fi
                         if [ "${device[$j]}" = "gpu" ]; then
                             repeat=1000
                         else


### PR DESCRIPTION
Paddle 和 tensorflow框架的accuracy的结果是一致的。可以只跑Paddle部分。