### PR TITLE
fix bug of selected shapes

### DIFF
--- a/api/json/run.sh
+++ b/api/json/run.sh
@@ -65,6 +65,6 @@ done
 for key in $(echo ${!SIMILAR_API[*]})
 do
     echo "processing API:" ${SIMILAR_API[${key}]}
-    python2 select_configs.py --input_json_file ${file} --output_json_file ${OUTPUT_DIR}/${key}.json --similar_api {SIMILAR_API[${key}]}
+    python2 select_configs.py --input_json_file ${INPUT_DIR} --output_json_file ${OUTPUT_DIR}/${key}.json --similar_api ${SIMILAR_API[${key}]}
     echo ""
 done

--- a/api/json/select_configs.py
+++ b/api/json/select_configs.py
@@ -131,7 +131,7 @@ def select_from_shape_groups(shape_groups, shapes):
         ids = shape_groups[label]['ids']
         ids = rearrange_ids(shape_groups[label]['sizes'], ids)
         if len(ids) <= 3:
-            selected_ids = ids
+            candidate_ids = ids
         else:
             candidate_ids = [ids[0], ids[int(len(ids) / 2)], ids[-1]]
         selected_shapes = []
@@ -274,7 +274,7 @@ def group_input_shapes(shapes, config_ids, input_type):
     Returns: A 2-D dict of shape groups.
     """
     shape_groups = dict()
-    if not shapes[0]:
+    if len(shapes) == 0:
         warnings.warn("Group configs regardless of input shape.")
         return shape_groups
     for index in config_ids:
@@ -299,7 +299,7 @@ def get_input_shapes_from_json(args, origin_configs):
         input_shapes = []
         var_shapes = []
         for name, value in config["param_info"].items():
-            if name in args.ignored_params:
+            if args.ignored_params is not None and name in args.ignored_params:
                 continue
             if value["type"] in ["Variable", "numpy.ndarray"]:
                 if value["type"] == "Variable":
@@ -325,8 +325,9 @@ def get_input_shapes_from_json(args, origin_configs):
                         input_shapes.append(shape)
                 del config_res["param_info"][name]
         configs_without_input.append(config_res)
-        all_shapes.append(input_shapes)
-        if len(input_shapes) == 0 and len(var_shapes) <= 2:
+        if len(input_shapes) != 0:
+            all_shapes.append(input_shapes)
+        elif len(var_shapes) != 0 and len(var_shapes) <= 2:
             all_shapes.append(var_shapes)
 
     return configs_without_input, all_shapes, input_type


### PR DESCRIPTION
**问题描述**：修复配置筛选脚本的几个bug
- shape不超过3个时，之前未进行去重，另外会导致打印信息不全。
![image](https://user-images.githubusercontent.com/26615455/83636928-558cd280-a5d9-11ea-96ce-9f4240e0a14c.png)

修改后的结果：
```
processing API: cast
ignored_params: [].
Total config of input json: 37
==============================config_groups==============================
config 0: dtype=bool , total: 1.
  shape 0: 2-D is_power_of_2=F, total: 1. Select 1 config_ids: [2]. The shapes are: [[16, 1785]]
config 1: dtype=int64 , total: 1.
  shape 0: 2-D is_power_of_2=T, total: 1. Select 1 config_ids: [6]. The shapes are: [[16, 1]]
config 2: dtype=float32 , total: 31.
  shape 0: 2-D is_power_of_2=T, total: 9. Select 3 config_ids: [20, 24, 35]. The shapes are: [[16, 1]] [[16, 1024]] [[4096, 1024]]
  shape 1: 3-D is_power_of_2=T, total: 1. Select 1 config_ids: [26]. The shapes are: [[16, 16, 1024]]
  shape 2: 4-D is_power_of_2=F, total: 1. Select 1 config_ids: [5]. The shapes are: [[16, 1, 513, 513]]
  shape 3: 1-D is_power_of_2=F, total: 3. Select 3 config_ids: [19, 14, 16]. The shapes are: [[3]] [[768]] [[3072]]
  shape 4: 2-D is_power_of_2=F, total: 12. Select 3 config_ids: [12, 13, 28]. The shapes are: [[2, 768]] [[768, 768]] [[30522, 1024]]
  shape 5: 3-D is_power_of_2=F, total: 1. Select 1 config_ids: [7]. The shapes are: [[16, 16, 768]]
  shape 6: 1-D is_power_of_2=T, total: 4. Select 3 config_ids: [3, 32, 34]. The shapes are: [[1]] [[1024]] [[4096]]
config 3: dtype=float16 , total: 3.
  shape 0: 3-D is_power_of_2=T, total: 2. Select 2 config_ids: [9, 27]. The shapes are: [[16, 16, 1]] [[16, 16, 1024]]
  shape 1: 3-D is_power_of_2=F, total: 1. Select 1 config_ids: [8]. The shapes are: [[16, 16, 768]]
config 4: dtype=int32 , total: 1.
  shape 0: 2-D is_power_of_2=T, total: 1. Select 1 config_ids: [4]. The shapes are: [[16, 1]]
```

- `--ignored_params`默认下为None，如果不设置，会报以下错误。修改后结果同第3条，当该参数为None时，不会报错。
![image](https://user-images.githubusercontent.com/26615455/83751344-44a39600-a699-11ea-85b9-0cadb1b426a7.png)

- run.sh脚本中，系列OP的执行命令有错误，总的待过滤配置数目不正确。修该后结果同第二条
![image](https://user-images.githubusercontent.com/26615455/83751447-76b4f800-a699-11ea-9f7f-8214cb6d1ce9.png)

修改后的结果：
```
processing API: cos floor square tanh sigmoid sqrt
ignored_params: None.
Total config of input json: 78
==============================config_groups==============================
config 0: , total: 78.
  shape 0: 2-D is_power_of_2=T, total: 11. Select 3 config_ids: [19, 18, 16]. The shapes are: [[2, 1024]] [[512, 1024]] [[4096, 1024]] 
  shape 1: 4-D is_power_of_2=F, total: 14. Select 3 config_ids: [57, 51, 77]. The shapes are: [[16, 14, 1, 1]] [[16, 14, 64, 1]] [[16, 3, 256, 256]] 
  shape 2: 1-D is_power_of_2=F, total: 6. Select 3 config_ids: [11, 32, 5]. The shapes are: [[3]] [[3072]] [[10000]] 
  shape 3: 2-D is_power_of_2=F, total: 27. Select 3 config_ids: [38, 21, 20]. The shapes are: [[2, 768]] [[16, 49152]] [[30522, 1024]] 
  shape 4: 4-D is_power_of_2=T, total: 12. Select 3 config_ids: [45, 47, 76]. The shapes are: [[16, 512, 8, 8]] [[16, 128, 32, 32]] [[16, 64, 64, 64]] 
  shape 5: 1-D is_power_of_2=T, total: 8. Select 3 config_ids: [0, 68, 13]. The shapes are: [[1]] [[16]] [[4096]] 

```
