### PR TITLE
Append a config with opposite value for use_cudnn in op's configs.

### DIFF
--- a/api/json/clear_params.py
+++ b/api/json/clear_params.py
@@ -121,8 +121,8 @@ def get_json_filenames(config_path):
 
 
 if __name__ == '__main__':
-    config_path = "results_all"
-    output_dir = os.path.abspath("results_all_cleared")
+    config_path = "results"
+    output_dir = os.path.abspath("results_cleared")
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 

--- a/api/json/unify_optional_params.py
+++ b/api/json/unify_optional_params.py
@@ -1,0 +1,119 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import os
+import json
+import copy
+
+import clear_params
+
+
+def trans_to_params_list(configs):
+    op = None
+    params_list = []
+    for item in configs:
+        if not op:
+            op = item["op"]
+        else:
+            assert op == item["op"]
+        params = item["param_info"]
+        if params not in params_list:
+            params_list.append(params)
+    return op, params_list
+
+
+def unify_use_cudnn(configs):
+    op, params_list = trans_to_params_list(configs)
+
+    unified_params_list = []
+    has_use_cudnn_argument = True
+    for params in params_list:
+        if params not in unified_params_list:
+            unified_params_list.append(params)
+
+        # Change the use_cudnn's value to the opposite value.
+        if params.get("use_cudnn", None):
+            unified_params = copy.deepcopy(params)
+            cudnn_param = unified_params["use_cudnn"]
+            assert cudnn_param[
+                "type"] == "bool", "The type of use_cudnn must be bool, but get %s." % cudnn_param[
+                    "type"]
+            if cudnn_param["value"] == "True":
+                cudnn_param["value"] = "False"
+            else:
+                cudnn_param["value"] = "True"
+            if unified_params not in unified_params_list:
+                unified_params_list.append(unified_params)
+        else:
+            print("-- Operator %s does not have use_cudnn argument. Skipped." %
+                  op)
+            has_use_cudnn_argument = False
+            break
+
+    if has_use_cudnn_argument:
+        unified_configs = []
+        for params in unified_params_list:
+            config = {"op": op, "param_info": params}
+            unified_configs.append(config)
+        return unified_configs
+    else:
+        return configs
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--json_path',
+        type=str,
+        default="results",
+        help='Specify the path of input json. It can be a file path or a directory'
+    )
+    parser.add_argument(
+        '--param_name',
+        type=str,
+        default="use_cudnn",
+        help='Specify the parameter name.')
+    parser.add_argument(
+        '--output_dir',
+        type=str,
+        default="results_unified",
+        help='Specify the output directory.')
+    args = parser.parse_args()
+
+    output_dir = os.path.abspath(args.output_dir)
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    filenames = clear_params.get_json_filenames(args.json_path)
+    for filename in sorted(filenames):
+        try:
+            configs = []
+            with open(filename, 'r') as f:
+                configs = json.load(f)
+                print("-- Processing %s: including %d configs." %
+                      (filename, len(configs)))
+            unified_configs = unify_use_cudnn(configs)
+
+            unified_filename = os.path.join(output_dir,
+                                            os.path.basename(filename))
+            print("-- Writing %d unified configs back to %s.\n" %
+                  (len(unified_configs), unified_filename))
+            with open(unified_filename, 'w') as f:
+                f.write(json.dumps(unified_configs, sort_keys=True, indent=4))
+        except ValueError:
+            print("Cannot decode as JSON object in %s." % filename)
+            break

--- a/api/tests/configs/argsort.json
+++ b/api/tests/configs/argsort.json
@@ -18,11 +18,6 @@
 }, {
     "op": "argsort",
     "param_info": {
-        "input": {
-            "type": "Variable",
-            "dtype": "float32",
-            "shape": "[1700971L, 1L]"
-        },
         "axis": {
             "type": "int",
             "value": "0"
@@ -30,6 +25,11 @@
         "descending": {
             "type": "bool",
             "value": "True"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[1700971L, 1L]",
+            "type": "Variable"
         }
     }
 }]

--- a/api/tests/configs/case.json
+++ b/api/tests/configs/case.json
@@ -2,19 +2,19 @@
     "op": "case",
     "param_info": {
         "input": {
-            "type": "Variable",
             "dtype": "float32",
-            "shape": "[1L]"
+            "shape": "[1L]",
+            "type": "Variable"
         },
         "x": {
-            "type": "Variable",
             "dtype": "float32",
-            "shape": "[16L, 256L, 6L, 6L]"
+            "shape": "[16L, 256L, 6L, 6L]",
+            "type": "Variable"
         },
         "y": {
-            "type": "Variable",
             "dtype": "float32",
-            "shape": "[16L, 256L, 6L, 6L]"
+            "shape": "[16L, 256L, 6L, 6L]",
+            "type": "Variable"
         }
     }
 }]

--- a/api/tests/configs/cond.json
+++ b/api/tests/configs/cond.json
@@ -2,19 +2,19 @@
     "op": "cond",
     "param_info": {
         "input": {
-            "type": "Variable",
             "dtype": "float32",
-            "shape": "[1L]"
+            "shape": "[1L]",
+            "type": "Variable"
         },
         "x": {
-            "type": "Variable",
             "dtype": "float32",
-            "shape": "[16L, 256L, 6L, 6L]"
+            "shape": "[16L, 256L, 6L, 6L]",
+            "type": "Variable"
         },
         "y": {
-            "type": "Variable",
             "dtype": "float32",
-            "shape": "[16L, 256L, 6L, 6L]"
+            "shape": "[16L, 256L, 6L, 6L]",
+            "type": "Variable"
         }
     }
 }]

--- a/api/tests/configs/conv2d.json
+++ b/api/tests/configs/conv2d.json
@@ -60,6 +60,51 @@
         },
         "filter_size": {
             "type": "int",
+            "value": "3"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 512L, 7L, 7L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "512"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
             "value": "2"
         },
         "groups": {
@@ -82,6 +127,96 @@
         "stride": {
             "type": "int",
             "value": "1"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "2"
+        },
+        "groups": {
+            "type": "string",
+            "value": "None"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 2048L, 2L, 2L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "5"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "string",
+            "value": "None"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 512L, 64L, 402L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "1024"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "tuple",
+            "value": "(2, 1)"
         },
         "use_cudnn": {
             "type": "bool",
@@ -130,7 +265,7 @@
         },
         "use_cudnn": {
             "type": "bool",
-            "value": "True"
+            "value": "False"
         }
     }
 }, {
@@ -203,6 +338,51 @@
         },
         "input": {
             "dtype": "float32",
+            "shape": "[-1L, 128L, 257L, 257L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "128"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "input": {
+            "dtype": "float32",
             "shape": "[-1L, 2048L, 1L, 1L]",
             "type": "Variable"
         },
@@ -221,6 +401,51 @@
         "use_cudnn": {
             "type": "bool",
             "value": "True"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 2048L, 1L, 1L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "256"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
         }
     }
 }, {
@@ -285,6 +510,51 @@
         },
         "filter_size": {
             "type": "int",
+            "value": "4"
+        },
+        "groups": {
+            "type": "string",
+            "value": "None"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 3L, 128L, 128L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "64"
+        },
+        "padding": {
+            "type": "list",
+            "value": "[1, 1]"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
             "value": "3"
         },
         "groups": {
@@ -307,6 +577,96 @@
         "stride": {
             "type": "int",
             "value": "2"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "3"
+        },
+        "groups": {
+            "type": "string",
+            "value": "None"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 3L, 513L, 513L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "32"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "tuple",
+            "value": "(7, 1)"
+        },
+        "groups": {
+            "type": "string",
+            "value": "None"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 1L, 512L, 402L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "32"
+        },
+        "padding": {
+            "type": "tuple",
+            "value": "(3, 0)"
+        },
+        "stride": {
+            "type": "tuple",
+            "value": "(2, 1)"
         },
         "use_cudnn": {
             "type": "bool",
@@ -355,7 +715,7 @@
         },
         "use_cudnn": {
             "type": "bool",
-            "value": "True"
+            "value": "False"
         }
     }
 }, {
@@ -423,6 +783,51 @@
             "value": "3"
         },
         "groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 256L, 56L, 56L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "256"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "3"
+        },
+        "groups": {
             "type": "string",
             "value": "None"
         },
@@ -451,39 +856,6 @@
 }, {
     "op": "conv2d",
     "param_info": {
-        "input": {
-            "type": "Variable",
-            "dtype": "float16",
-            "shape": "[1L, 1L, 80L, 1008L]"
-        },
-        "num_filters": {
-            "type": "int",
-            "value": "1"
-        },
-        "filter_size": {
-            "type": "tuple",
-            "value": "(3, 32)"
-        },
-        "stride": {
-            "type": "tuple",
-            "value": "(1, 16)"
-        },
-        "padding": {
-            "type": "tuple",
-            "value": "(1, 8)"
-        },
-        "dilation": {
-            "type": "tuple",
-            "value": "(1, 1)"
-        },
-        "groups": {
-            "type": "int",
-            "value": "1"
-        },
-        "use_cudnn": {
-            "type": "bool",
-            "value": "True"
-        },
         "act": {
             "type": "string",
             "value": "None"
@@ -491,6 +863,129 @@
         "data_format": {
             "type": "string",
             "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "3"
+        },
+        "groups": {
+            "type": "string",
+            "value": "None"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 1024L, 8L, 8L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "512"
+        },
+        "padding": {
+            "type": "list",
+            "value": "[1, 1]"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "tuple",
+            "value": "(1, 1)"
+        },
+        "filter_size": {
+            "type": "tuple",
+            "value": "(3, 32)"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "input": {
+            "dtype": "float16",
+            "shape": "[1L, 1L, 80L, 1008L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "1"
+        },
+        "padding": {
+            "type": "tuple",
+            "value": "(1, 8)"
+        },
+        "stride": {
+            "type": "tuple",
+            "value": "(1, 16)"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "tuple",
+            "value": "(1, 1)"
+        },
+        "filter_size": {
+            "type": "tuple",
+            "value": "(3, 32)"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "input": {
+            "dtype": "float16",
+            "shape": "[1L, 1L, 80L, 1008L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "1"
+        },
+        "padding": {
+            "type": "tuple",
+            "value": "(1, 8)"
+        },
+        "stride": {
+            "type": "tuple",
+            "value": "(1, 16)"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
         }
     }
 }]

--- a/api/tests/configs/conv2d_transpose.json
+++ b/api/tests/configs/conv2d_transpose.json
@@ -64,6 +64,55 @@
         },
         "filter_size": {
             "type": "int",
+            "value": "4"
+        },
+        "groups": {
+            "type": "string",
+            "value": "None"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 1549L, 8L, 8L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "512"
+        },
+        "output_size": {
+            "type": "string",
+            "value": "None"
+        },
+        "padding": {
+            "type": "list",
+            "value": "[1, 1]"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "conv2d_transpose",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
             "value": "3"
         },
         "groups": {
@@ -94,6 +143,55 @@
         "use_cudnn": {
             "type": "bool",
             "value": "True"
+        }
+    }
+}, {
+    "op": "conv2d_transpose",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "3"
+        },
+        "groups": {
+            "type": "string",
+            "value": "None"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 128L, 64L, 64L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "64"
+        },
+        "output_size": {
+            "type": "string",
+            "value": "None"
+        },
+        "padding": {
+            "type": "list",
+            "value": "[1, 1]"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
         }
     }
 }, {
@@ -150,6 +248,55 @@
     "param_info": {
         "act": {
             "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "4"
+        },
+        "groups": {
+            "type": "string",
+            "value": "None"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 512L, 1L, 1L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "512"
+        },
+        "output_size": {
+            "type": "string",
+            "value": "None"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "conv2d_transpose",
+    "param_info": {
+        "act": {
+            "type": "string",
             "value": "relu"
         },
         "data_format": {
@@ -197,10 +344,79 @@
 }, {
     "op": "conv2d_transpose",
     "param_info": {
+        "act": {
+            "type": "string",
+            "value": "relu"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "2"
+        },
+        "groups": {
+            "type": "string",
+            "value": "None"
+        },
         "input": {
-            "type": "Variable",
             "dtype": "float32",
-            "shape": "[1L, 1L, 80L, 63L]"
+            "shape": "[-1L, 256L, 14L, 14L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "256"
+        },
+        "output_size": {
+            "type": "string",
+            "value": "None"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "conv2d_transpose",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "list",
+            "value": "[1, 1]"
+        },
+        "filter_size": {
+            "type": "list",
+            "value": "[3, 32]"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[1L, 1L, 80L, 63L]",
+            "type": "Variable"
         },
         "num_filters": {
             "type": "int",
@@ -210,9 +426,54 @@
             "type": "string",
             "value": "None"
         },
+        "padding": {
+            "type": "list",
+            "value": "[1, 8]"
+        },
+        "stride": {
+            "type": "list",
+            "value": "[1, 16]"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+}, {
+    "op": "conv2d_transpose",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "list",
+            "value": "[1, 1]"
+        },
         "filter_size": {
             "type": "list",
             "value": "[3, 32]"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[1L, 1L, 80L, 63L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "1"
+        },
+        "output_size": {
+            "type": "string",
+            "value": "None"
         },
         "padding": {
             "type": "list",
@@ -222,25 +483,9 @@
             "type": "list",
             "value": "[1, 16]"
         },
-        "dilation": {
-            "type": "list",
-            "value": "[1, 1]"
-        },
-        "groups": {
-            "type": "int",
-            "value": "1"
-        },
         "use_cudnn": {
             "type": "bool",
-            "value": "True"
-        },
-        "act": {
-            "type": "string",
-            "value": "None"
-        },
-        "data_format": {
-            "type": "string",
-            "value": "NCHW"
+            "value": "False"
         }
     }
 }]

--- a/api/tests/configs/cumsum.json
+++ b/api/tests/configs/cumsum.json
@@ -1,11 +1,7 @@
 [{
+    "atol": 0.05,
     "op": "cumsum",
     "param_info": {
-        "x": {
-            "type": "Variable",
-            "dtype": "float32",
-            "shape": "[1700971L, 1L]"
-        },
         "axis": {
             "type": "int",
             "value": "0"
@@ -17,7 +13,11 @@
         "reverse": {
             "type": "bool",
             "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1700971L, 1L]",
+            "type": "Variable"
         }
-    },
-    "atol": 0.05
+    }
 }]

--- a/api/tests/configs/depthwise_conv2d.json
+++ b/api/tests/configs/depthwise_conv2d.json
@@ -56,6 +56,51 @@
         },
         "dilation": {
             "type": "int",
+            "value": "18"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "3"
+        },
+        "groups": {
+            "type": "long",
+            "value": "2048"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 2048L, 33L, 33L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "long",
+            "value": "2048"
+        },
+        "padding": {
+            "type": "int",
+            "value": "18"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+}, {
+    "op": "depthwise_conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
             "value": "1"
         },
         "filter_size": {
@@ -109,6 +154,51 @@
         },
         "groups": {
             "type": "long",
+            "value": "728"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 728L, 65L, 65L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "long",
+            "value": "728"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+}, {
+    "op": "depthwise_conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "3"
+        },
+        "groups": {
+            "type": "long",
             "value": "128"
         },
         "input": {
@@ -131,6 +221,51 @@
         "use_cudnn": {
             "type": "bool",
             "value": "False"
+        }
+    }
+}, {
+    "op": "depthwise_conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "filter_size": {
+            "type": "int",
+            "value": "3"
+        },
+        "groups": {
+            "type": "long",
+            "value": "128"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 128L, 257L, 257L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "long",
+            "value": "128"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
         }
     }
 }]

--- a/api/tests/configs/elementwise.json
+++ b/api/tests/configs/elementwise.json
@@ -1,45 +1,45 @@
 [{
     "op": "elementwise",
     "param_info": {
-        "x": {
-            "type": "Variable",
-            "dtype": "float32",
-            "shape": "[50L, 128L, 1000L]"
-        },
-        "y": {
-            "type": "Variable",
-            "dtype": "float32",
-            "shape": "[128L, 1000L]"
+        "act": {
+            "type": "string",
+            "value": "None"
         },
         "axis": {
             "type": "int",
             "value": "-1"
         },
-        "act": {
-            "type": "string",
-            "value": "None"
+        "x": {
+            "dtype": "float32",
+            "shape": "[50L, 128L, 1000L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[128L, 1000L]",
+            "type": "Variable"
         }
     }
 }, {
     "op": "elementwise",
     "param_info": {
-        "x": {
-            "type": "Variable",
-            "dtype": "float32",
-            "shape": "[50L, 128L, 1000L]"
-        },
-        "y": {
-            "type": "Variable",
-            "dtype": "float32",
-            "shape": "[1L, 128L, 1000L]"
+        "act": {
+            "type": "string",
+            "value": "None"
         },
         "axis": {
             "type": "int",
             "value": "0"
         },
-        "act": {
-            "type": "string",
-            "value": "None"
+        "x": {
+            "dtype": "float32",
+            "shape": "[50L, 128L, 1000L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[1L, 128L, 1000L]",
+            "type": "Variable"
         }
     }
 }, {

--- a/api/tests/configs/expand.json
+++ b/api/tests/configs/expand.json
@@ -27,14 +27,14 @@
 }, {
     "op": "expand",
     "param_info": {
-        "x": {
-            "type": "Variable",
-            "dtype": "float32",
-            "shape": "[32L, 807L, 1L]"
-        },
         "expand_times": {
             "type": "list",
             "value": "[4, 1, 807]"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 807L, 1L]",
+            "type": "Variable"
         }
     }
 }]

--- a/api/tests/configs/pool2d.json
+++ b/api/tests/configs/pool2d.json
@@ -60,6 +60,51 @@
         },
         "global_pooling": {
             "type": "bool",
+            "value": "True"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 2048L, 7L, 7L]",
+            "type": "Variable"
+        },
+        "pool_padding": {
+            "type": "list",
+            "value": "[0, 0]"
+        },
+        "pool_size": {
+            "type": "list",
+            "value": "[-1, -1]"
+        },
+        "pool_stride": {
+            "type": "list",
+            "value": "[1, 1]"
+        },
+        "pool_type": {
+            "type": "string",
+            "value": "avg"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+}, {
+    "op": "pool2d",
+    "param_info": {
+        "ceil_mode": {
+            "type": "bool",
+            "value": "False"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "exclusive": {
+            "type": "bool",
+            "value": "True"
+        },
+        "global_pooling": {
+            "type": "bool",
             "value": "False"
         },
         "input": {
@@ -86,6 +131,51 @@
         "use_cudnn": {
             "type": "bool",
             "value": "False"
+        }
+    }
+}, {
+    "op": "pool2d",
+    "param_info": {
+        "ceil_mode": {
+            "type": "bool",
+            "value": "False"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "exclusive": {
+            "type": "bool",
+            "value": "True"
+        },
+        "global_pooling": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 64L, 112L, 112L]",
+            "type": "Variable"
+        },
+        "pool_padding": {
+            "type": "list",
+            "value": "[1, 1]"
+        },
+        "pool_size": {
+            "type": "list",
+            "value": "[3, 3]"
+        },
+        "pool_stride": {
+            "type": "list",
+            "value": "[2, 2]"
+        },
+        "pool_type": {
+            "type": "string",
+            "value": "max"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
         }
     }
 }, {
@@ -154,6 +244,51 @@
         },
         "input": {
             "dtype": "float32",
+            "shape": "[-1L, 256L, -1L, -1L]",
+            "type": "Variable"
+        },
+        "pool_padding": {
+            "type": "list",
+            "value": "[0, 0]"
+        },
+        "pool_size": {
+            "type": "list",
+            "value": "[2, 2]"
+        },
+        "pool_stride": {
+            "type": "list",
+            "value": "[2, 2]"
+        },
+        "pool_type": {
+            "type": "string",
+            "value": "avg"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "pool2d",
+    "param_info": {
+        "ceil_mode": {
+            "type": "bool",
+            "value": "True"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "exclusive": {
+            "type": "bool",
+            "value": "True"
+        },
+        "global_pooling": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
             "shape": "[-1L, 1024L, -1L, -1L]",
             "type": "Variable"
         },
@@ -176,6 +311,51 @@
         "use_cudnn": {
             "type": "bool",
             "value": "True"
+        }
+    }
+}, {
+    "op": "pool2d",
+    "param_info": {
+        "ceil_mode": {
+            "type": "bool",
+            "value": "True"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "exclusive": {
+            "type": "bool",
+            "value": "True"
+        },
+        "global_pooling": {
+            "type": "bool",
+            "value": "False"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 1024L, -1L, -1L]",
+            "type": "Variable"
+        },
+        "pool_padding": {
+            "type": "list",
+            "value": "[0, 0]"
+        },
+        "pool_size": {
+            "type": "list",
+            "value": "[2, 2]"
+        },
+        "pool_stride": {
+            "type": "list",
+            "value": "[2, 2]"
+        },
+        "pool_type": {
+            "type": "string",
+            "value": "avg"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
         }
     }
 }]

--- a/api/tests/configs/softmax.json
+++ b/api/tests/configs/softmax.json
@@ -24,6 +24,23 @@
         },
         "input": {
             "dtype": "float32",
+            "shape": "[-1L, 1000L]",
+            "type": "Variable"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+}, {
+    "op": "softmax",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "input": {
+            "dtype": "float32",
             "shape": "[-1L, 16L, -1L, -1L]",
             "type": "Variable"
         },
@@ -35,18 +52,52 @@
 }, {
     "op": "softmax",
     "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 16L, -1L, -1L]",
+            "type": "Variable"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+}, {
+    "op": "softmax",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "0"
+        },
         "input": {
             "dtype": "float32",
             "shape": "[128L, 128L, 16L, 16L]",
             "type": "Variable"
         },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}, {
+    "op": "softmax",
+    "param_info": {
         "axis": {
             "type": "int",
             "value": "0"
         },
+        "input": {
+            "dtype": "float32",
+            "shape": "[128L, 128L, 16L, 16L]",
+            "type": "Variable"
+        },
         "use_cudnn": {
             "type": "bool",
-            "value": "False"
+            "value": "True"
         }
     }
 }]

--- a/api/tests/configs/switch_case.json
+++ b/api/tests/configs/switch_case.json
@@ -2,19 +2,19 @@
     "op": "switch_case",
     "param_info": {
         "input": {
-            "type": "Variable",
             "dtype": "int32",
-            "shape": "[1L]"
+            "shape": "[1L]",
+            "type": "Variable"
         },
         "x": {
-            "type": "Variable",
             "dtype": "float32",
-            "shape": "[16L, 256L, 6L, 6L]"
+            "shape": "[16L, 256L, 6L, 6L]",
+            "type": "Variable"
         },
         "y": {
-            "type": "Variable",
             "dtype": "float32",
-            "shape": "[16L, 256L, 6L, 6L]"
+            "shape": "[16L, 256L, 6L, 6L]",
+            "type": "Variable"
         }
     }
 }]


### PR DESCRIPTION
paddle里面，有一些op有use_cudnn熟悉，可以配置是否调用cudnn。cudnn大部分情况下都有很好的性能，但也有些情况下，性能比paddle原生的CUDA实现性能差。op benchmark希望能系统地测试和比较paddle原生CUDA实现与cudnn实现的性能。

这个PR实现一个脚本，可以遍历所有op的json配置，当发现op有use_cudnn参数时，自动在json配置中插入一个与当前use_cudnn值相反的配置。

```
$  python unify_optional_params.py --json_path=./results --output_dir=./results_unified/
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
There are 56 configs under /work/benchmark/api/json/results.
-- Processing /work/benchmark/api/json/results/accuracy.json: including 2 configs.
-- Operator accuracy does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/accuracy.json.

-- Processing /work/benchmark/api/json/results/activation.json: including 2 configs.
-- Operator activation does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/activation.json.

-- Processing /work/benchmark/api/json/results/affine_channel.json: including 3 configs.
-- Operator affine_channel does not have use_cudnn argument. Skipped.
-- Writing 3 unified configs back to /work/benchmark/api/json/results_unified/affine_channel.json.

-- Processing /work/benchmark/api/json/results/arg.json: including 1 configs.
-- Operator arg does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/arg.json.

-- Processing /work/benchmark/api/json/results/argsort.json: including 2 configs.
-- Operator argsort does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/argsort.json.

-- Processing /work/benchmark/api/json/results/assign.json: including 3 configs.
-- Operator assign does not have use_cudnn argument. Skipped.
-- Writing 3 unified configs back to /work/benchmark/api/json/results_unified/assign.json.

-- Processing /work/benchmark/api/json/results/batch_norm.json: including 5 configs.
-- Operator batch_norm does not have use_cudnn argument. Skipped.
-- Writing 5 unified configs back to /work/benchmark/api/json/results_unified/batch_norm.json.

-- Processing /work/benchmark/api/json/results/case.json: including 1 configs.
-- Operator case does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/case.json.

-- Processing /work/benchmark/api/json/results/cast.json: including 7 configs.
-- Operator cast does not have use_cudnn argument. Skipped.
-- Writing 7 unified configs back to /work/benchmark/api/json/results_unified/cast.json.

-- Processing /work/benchmark/api/json/results/compare.json: including 2 configs.
-- Operator compare does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/compare.json.

-- Processing /work/benchmark/api/json/results/concat.json: including 5 configs.
-- Operator concat does not have use_cudnn argument. Skipped.
-- Writing 5 unified configs back to /work/benchmark/api/json/results_unified/concat.json.

-- Processing /work/benchmark/api/json/results/cond.json: including 1 configs.
-- Operator cond does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/cond.json.

-- Processing /work/benchmark/api/json/results/conv2d.json: including 11 configs.
-- Writing 22 unified configs back to /work/benchmark/api/json/results_unified/conv2d.json.

-- Processing /work/benchmark/api/json/results/conv2d_transpose.json: including 5 configs.
-- Writing 10 unified configs back to /work/benchmark/api/json/results_unified/conv2d_transpose.json.

-- Processing /work/benchmark/api/json/results/cos_sim.json: including 1 configs.
-- Operator cos_sim does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/cos_sim.json.

-- Processing /work/benchmark/api/json/results/cross_entropy.json: including 1 configs.
-- Operator cross_entropy does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/cross_entropy.json.

-- Processing /work/benchmark/api/json/results/cumsum.json: including 1 configs.
-- Operator cumsum does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/cumsum.json.

-- Processing /work/benchmark/api/json/results/depthwise_conv2d.json: including 3 configs.
-- Writing 6 unified configs back to /work/benchmark/api/json/results_unified/depthwise_conv2d.json.

-- Processing /work/benchmark/api/json/results/dropout.json: including 4 configs.
-- Operator dropout does not have use_cudnn argument. Skipped.
-- Writing 4 unified configs back to /work/benchmark/api/json/results_unified/dropout.json.

-- Processing /work/benchmark/api/json/results/elementwise.json: including 5 configs.
-- Operator elementwise does not have use_cudnn argument. Skipped.
-- Writing 5 unified configs back to /work/benchmark/api/json/results_unified/elementwise.json.

-- Processing /work/benchmark/api/json/results/elementwise_sum.json: including 3 configs.
-- Operator elementwise_sum does not have use_cudnn argument. Skipped.
-- Writing 3 unified configs back to /work/benchmark/api/json/results_unified/elementwise_sum.json.

-- Processing /work/benchmark/api/json/results/embedding.json: including 4 configs.
-- Operator embedding does not have use_cudnn argument. Skipped.
-- Writing 4 unified configs back to /work/benchmark/api/json/results_unified/embedding.json.

-- Processing /work/benchmark/api/json/results/expand.json: including 3 configs.
-- Operator expand does not have use_cudnn argument. Skipped.
-- Writing 3 unified configs back to /work/benchmark/api/json/results_unified/expand.json.

-- Processing /work/benchmark/api/json/results/fc.json: including 4 configs.
-- Operator fc does not have use_cudnn argument. Skipped.
-- Writing 4 unified configs back to /work/benchmark/api/json/results_unified/fc.json.

-- Processing /work/benchmark/api/json/results/fill_constant.json: including 2 configs.
-- Operator fill_constant does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/fill_constant.json.

-- Processing /work/benchmark/api/json/results/gather.json: including 2 configs.
-- Operator gather does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/gather.json.

-- Processing /work/benchmark/api/json/results/increment.json: including 1 configs.
-- Operator increment does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/increment.json.

-- Processing /work/benchmark/api/json/results/instance_norm.json: including 1 configs.
-- Operator instance_norm does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/instance_norm.json.

-- Processing /work/benchmark/api/json/results/isfinite.json: including 1 configs.
-- Operator isfinite does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/isfinite.json.

-- Processing /work/benchmark/api/json/results/l2_normalize.json: including 1 configs.
-- Operator l2_normalize does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/l2_normalize.json.

-- Processing /work/benchmark/api/json/results/layer_norm.json: including 1 configs.
-- Operator layer_norm does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/layer_norm.json.

-- Processing /work/benchmark/api/json/results/leaky_relu.json: including 2 configs.
-- Operator leaky_relu does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/leaky_relu.json.

-- Processing /work/benchmark/api/json/results/logical.json: including 2 configs.
-- Operator logical does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/logical.json.

-- Processing /work/benchmark/api/json/results/logical_not.json: including 1 configs.
-- Operator logical_not does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/logical_not.json.

-- Processing /work/benchmark/api/json/results/matmul.json: including 5 configs.
-- Operator matmul does not have use_cudnn argument. Skipped.
-- Writing 5 unified configs back to /work/benchmark/api/json/results_unified/matmul.json.

-- Processing /work/benchmark/api/json/results/mean.json: including 2 configs.
-- Operator mean does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/mean.json.

-- Processing /work/benchmark/api/json/results/one_hot.json: including 1 configs.
-- Operator one_hot does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/one_hot.json.

-- Processing /work/benchmark/api/json/results/pad2d.json: including 2 configs.
-- Operator pad2d does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/pad2d.json.

-- Processing /work/benchmark/api/json/results/pool2d.json: including 4 configs.
-- Writing 8 unified configs back to /work/benchmark/api/json/results_unified/pool2d.json.

-- Processing /work/benchmark/api/json/results/reduce.json: including 4 configs.
-- Operator reduce does not have use_cudnn argument. Skipped.
-- Writing 4 unified configs back to /work/benchmark/api/json/results_unified/reduce.json.

-- Processing /work/benchmark/api/json/results/reshape.json: including 2 configs.
-- Operator reshape does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/reshape.json.

-- Processing /work/benchmark/api/json/results/scale.json: including 2 configs.
-- Operator scale does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/scale.json.

-- Processing /work/benchmark/api/json/results/sequence_mask.json: including 1 configs.
-- Operator sequence_mask does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/sequence_mask.json.

-- Processing /work/benchmark/api/json/results/shape.json: including 1 configs.
-- Operator shape does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/shape.json.

-- Processing /work/benchmark/api/json/results/sigmoid_cross_entropy_with_logits.json: including 2 configs.
-- Operator sigmoid_cross_entropy_with_logits does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/sigmoid_cross_entropy_with_logits.json.

-- Processing /work/benchmark/api/json/results/slice.json: including 3 configs.
-- Operator slice does not have use_cudnn argument. Skipped.
-- Writing 3 unified configs back to /work/benchmark/api/json/results_unified/slice.json.

-- Processing /work/benchmark/api/json/results/softmax.json: including 3 configs.
-- Writing 6 unified configs back to /work/benchmark/api/json/results_unified/softmax.json.

-- Processing /work/benchmark/api/json/results/softmax_with_cross_entropy.json: including 2 configs.
-- Operator softmax_with_cross_entropy does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/softmax_with_cross_entropy.json.

-- Processing /work/benchmark/api/json/results/split.json: including 2 configs.
-- Operator split does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/split.json.

-- Processing /work/benchmark/api/json/results/squeeze.json: including 1 configs.
-- Operator squeeze does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/squeeze.json.

-- Processing /work/benchmark/api/json/results/stack.json: including 1 configs.
-- Operator stack does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/stack.json.

-- Processing /work/benchmark/api/json/results/switch_case.json: including 1 configs.
-- Operator switch_case does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/switch_case.json.

-- Processing /work/benchmark/api/json/results/topk.json: including 2 configs.
-- Operator topk does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/topk.json.

-- Processing /work/benchmark/api/json/results/transpose.json: including 3 configs.
-- Operator transpose does not have use_cudnn argument. Skipped.
-- Writing 3 unified configs back to /work/benchmark/api/json/results_unified/transpose.json.

-- Processing /work/benchmark/api/json/results/unsqueeze.json: including 1 configs.
-- Operator unsqueeze does not have use_cudnn argument. Skipped.
-- Writing 1 unified configs back to /work/benchmark/api/json/results_unified/unsqueeze.json.

-- Processing /work/benchmark/api/json/results/zeros_like.json: including 2 configs.
-- Operator zeros_like does not have use_cudnn argument. Skipped.
-- Writing 2 unified configs back to /work/benchmark/api/json/results_unified/zeros_like.json.
```

log中可以看出，conv2d、conv2d_transpose、depthwise_conv2d、pool2d、softmax共5个op有use_cudnn参数，经过这个脚本处理后，json配置数量加倍。