### PR TITLE
Complete the operator list which do not have grad operators.

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -16,9 +16,16 @@ RANDOM_OP_LIST = ["dropout"]
 
 NO_FETCHES_OPS = ["feed", "null"]
 
-NO_BACKWARD_API = ["instance_norm", "feed", "fetch", "fill_constant", "null"]
+# operators without grad ops.
+NO_BACKWARD_OPS = [
+    "accuracy", "argsort", "assign", "cast", "compare", "less_than",
+    "less_equal", "not_equal", "greater_than", "greater_equal", "equal",
+    "cumsum", "feed", "fetch", "fill_constant", "increment", "isfinite",
+    "logical_not", "logical_and", "logical_or", "null", "one_hot", "scale",
+    "sequence_mask", "shape", "zeros_like", "instance_norm"
+]
 
-#When running the API backwards in HANG_CASES, the progress will hang.
+# When running the API backwards in HANG_CASES, the progress will hang.
 HANG_CASES = ["instance_norm"]
 
 NO_NEED_ARGS = {

--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -22,11 +22,8 @@ NO_BACKWARD_OPS = [
     "less_equal", "not_equal", "greater_than", "greater_equal", "equal",
     "cumsum", "feed", "fetch", "fill_constant", "increment", "isfinite",
     "logical_not", "logical_and", "logical_or", "null", "one_hot", "scale",
-    "sequence_mask", "shape", "zeros_like", "instance_norm"
+    "sequence_mask", "shape", "zeros_like"
 ]
-
-# When running the API backwards in HANG_CASES, the progress will hang.
-HANG_CASES = ["instance_norm"]
 
 NO_NEED_ARGS = {
     "batch_norm": ["moving_mean_name", "moving_variance_name"],

--- a/api/deploy/collect_api_info.py
+++ b/api/deploy/collect_api_info.py
@@ -41,29 +41,29 @@ def collect_subconfig_info():
         else:
             json_file = obj.name + '.json'
 
-        if obj.name in special_op_list.NO_BACKWARD_API:
-            backend = False
+        if obj.name in special_op_list.NO_BACKWARD_OPS:
+            backward = False
         else:
-            backend = True
+            backward = True
 
         for api in api_list:
-            REGISTER_API_INFO[api] = [obj.name, json_file, backend]
+            REGISTER_API_INFO[api] = [obj.name, json_file, backward]
 
 
 def collect_config_info():
     CONFIG_LIST = list(set(API_LIST).difference(set(SUB_CONFIG_LIST)))
     CONFIG_LIST.remove('__init__')
     for api in CONFIG_LIST:
-        if api in special_op_list.NO_BACKWARD_API:
-            backend = False
+        if api in special_op_list.NO_BACKWARD_OPS:
+            backward = False
         else:
-            backend = True
+            backward = True
         if api in NO_JSON_API:
             json_file = None
         else:
             json_file = api + '.json'
 
-        REGISTER_API_INFO[api] = [api, json_file, backend]
+        REGISTER_API_INFO[api] = [api, json_file, backward]
 
 
 def write_api_info():

--- a/api/deploy/collect_api_info.py
+++ b/api/deploy/collect_api_info.py
@@ -1,3 +1,17 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import re
 import sys

--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -45,26 +45,29 @@ function print_detail_status() {
     fi
     if  [ ${return_status} -eq 0 ]; then
         run_status="SUCCESS"
+    elif [ ${runtime} -ge 600000 ]; then
+        run_status="**TIMEOUT**"
     else
-        run_status="FAILED"
+        run_status="**FAILED**"
     fi
-    print_str="[${config_id}-${case_id}] device=${device}, backward=${backward_shorten}, ${logfile}, time=${runtime} ms"
+    print_str="device=${device}, backward=${backward_shorten}, ${logfile}, time=${runtime} ms"
     print_str_length=${#print_str}
+    timestamp=`date +"%Y-%m-%d %T"`
     if [ ${print_str_length} -lt 80 ]; then
-        printf "  %-80s ...... %s\n" "${print_str}" "${run_status}"
+        printf "  [%d-%d][%s] %-80s ...... %s\n" ${config_id} ${case_id} "${timestamp}" "${print_str}" "${run_status}"
     elif [ ${print_str_length} -lt 90 ]; then
-        printf "  %-90s ...... %s\n" "${print_str}" "${run_status}"
+        printf "  [%d-%d][%s] %-90s ...... %s\n" ${config_id} ${case_id} "${timestamp}" "${print_str}" "${run_status}"
     elif [ ${print_str_length} -lt 100 ]; then
-        printf "  %-100s ...... %s\n" "${print_str}" "${run_status}"
+        printf "  [%d-%d][%s] %-100s ...... %s\n" ${config_id} ${case_id} "${timestamp}" "${print_str}" "${run_status}"
     elif [ ${print_str_length} -lt 110 ]; then
-        printf "  %-110s ...... %s\n" "${print_str}" "${run_status}"
+        printf "  [%d-%d][%s] %-110s ...... %s\n" ${config_id} ${case_id} "${timestamp}" "${print_str}" "${run_status}"
     fi
 }
 
 if [ ${OUTPUT_DIR} != "" ]; then
     api_info_file=${OUTPUT_DIR}/api_info.txt
 else
-    api_info_file=./api_info.txt
+    api_info_file=api_info.txt
 fi
 python ${DEPLOY_DIR}/collect_api_info.py --info_file ${api_info_file}
 
@@ -143,7 +146,8 @@ do
                         run_start=`date +%s%N`
                         if [ "${OUTPUT_DIR}" != "" ]; then
                             logfile=${OUTPUT_DIR}/${api_name}"-"${framework}"_"${device}"_"${task}"_""${direction}""_"${i}".txt"
-                            ${run_cmd} > $logfile 2>&1
+                            # Set maxmimum runtime to 10min, or it will be considered hanged and will be killed.
+                            timeout 600s ${run_cmd} > $logfile 2>&1
                             return_status=$?
                         else
                             logfile=""

--- a/api/tests/assign.py
+++ b/api/tests/assign.py
@@ -24,8 +24,6 @@ class PDAssign(PaddleAPIBenchmarkBase):
 
         self.feed_vars = [data]
         self.fetch_vars = [result]
-        if config.backward:
-            self.append_gradients(result, [data])
 
 
 class TFAssign(TensorflowAPIBenchmarkBase):
@@ -41,8 +39,6 @@ class TFAssign(TensorflowAPIBenchmarkBase):
 
         self.feed_list = [data]
         self.fetch_list = [result]
-        if config.backward:
-            self.append_gradients(result, [data])
 
 
 if __name__ == '__main__':

--- a/api/tests/cast.py
+++ b/api/tests/cast.py
@@ -29,8 +29,6 @@ class PDCast(PaddleAPIBenchmarkBase):
 
         self.feed_vars = [data]
         self.fetch_vars = [result]
-        if config.backward:
-            self.append_gradients(result, [data])
 
 
 class TFCast(TensorflowAPIBenchmarkBase):
@@ -41,8 +39,6 @@ class TFCast(TensorflowAPIBenchmarkBase):
 
         self.feed_list = [data]
         self.fetch_list = [result]
-        if config.backward:
-            self.append_gradients(result, [data])
 
 
 if __name__ == '__main__':

--- a/api/tests/sequence_mask.py
+++ b/api/tests/sequence_mask.py
@@ -24,8 +24,6 @@ class PDSequenceMask(PaddleAPIBenchmarkBase):
 
         self.feed_vars = [data]
         self.fetch_vars = [result]
-        if config.backward:
-            self.append_gradients(result, [data])
 
 
 class TFSequenceMask(TensorflowAPIBenchmarkBase):
@@ -39,8 +37,6 @@ class TFSequenceMask(TensorflowAPIBenchmarkBase):
 
         self.feed_list = [data]
         self.fetch_list = [result]
-        if config.backward:
-            self.append_gradients(result, [data])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- 一些op没有注册对应的grad op，这种情况op benchmark不测试反向的功能和性能。暂时通过一个list记录没有grad的op。
- 这是op运行最长时间为10min，否则将视为hang住了。
    - 若设置timeout时间为60s，log如下：
    ```
    $ bash ./deploy/main_control.sh ./tests/configs . cpu accuracy
    [1]: api_name=instance_norm, name=instance_norm, json_file=./tests/configs/instance_norm.json, num_configs=1, json_id=0
      [1-1][2020-06-09 02:43:02] device=cpu, backward=F, ./instance_norm-paddle_cpu_accuracy_forward_0.txt, time=3925 ms    ...... SUCCESS
      [1-2][2020-06-09 02:44:02] device=cpu, backward=T, ./instance_norm-paddle_cpu_accuracy_backward_0.txt, time=60005 ms  ...... **TIMEOUT**
    ```

    - 将timeout时间设置为10min，意外地发现instance_norm grad可以跑出结果。
    ```
    $ bash ./deploy/main_control.sh ./tests/configs . cpu accuracy
    [1]: api_name=instance_norm, name=instance_norm, json_file=./tests/configs/instance_norm.json, num_configs=1, json_id=0
      [1-1][2020-06-09 02:36:14] device=cpu, backward=F, ./instance_norm-paddle_cpu_accuracy_forward_0.txt, time=4028 ms    ...... SUCCESS
      [1-2][2020-06-09 02:37:33] device=cpu, backward=T, ./instance_norm-paddle_cpu_accuracy_backward_0.txt, time=78955 ms  ...... SUCCESS
    ```

    - examples目录下有timeout的配置：
    ```
    $ bash ./deploy/main_control.sh ./tests/examples . cpu accuracy
    [1]: api_name=instance_norm, name=instance_norm, json_file=./tests/examples/instance_norm.json, num_configs=3, json_id=0
      [1-1][2020-06-09 02:54:04] device=cpu, backward=F, ./instance_norm-paddle_cpu_accuracy_forward_0.txt, time=7050 ms    ...... SUCCESS
      [1-2][2020-06-09 03:04:04] device=cpu, backward=T, ./instance_norm-paddle_cpu_accuracy_backward_0.txt, time=600016 ms           ...... **TIMEOUT**

    [2]: api_name=instance_norm, name=instance_norm, json_file=./tests/examples/instance_norm.json, num_configs=3, json_id=1
      [2-1][2020-06-09 03:04:14] device=cpu, backward=F, ./instance_norm-paddle_cpu_accuracy_forward_1.txt, time=9699 ms    ...... SUCCESS
      [2-2][2020-06-09 03:14:14] device=cpu, backward=T, ./instance_norm-paddle_cpu_accuracy_backward_1.txt, time=600008 ms           ...... **TIMEOUT**

    [3]: api_name=instance_norm, name=instance_norm, json_file=./tests/examples/instance_norm.json, num_configs=3, json_id=2
      [3-1][2020-06-09 03:14:18] device=cpu, backward=F, ./instance_norm-paddle_cpu_accuracy_forward_2.txt, time=4873 ms    ...... SUCCESS
      [3-2][2020-06-09 03:15:39] device=cpu, backward=T, ./instance_norm-paddle_cpu_accuracy_backward_2.txt, time=80731 ms  ...... SUCCESS
    ```