### PR TITLE
Fix while_loop bug

### DIFF
--- a/api/tests/while_loop.py
+++ b/api/tests/while_loop.py
@@ -14,13 +14,14 @@
 
 from common_import import *
 from fc import FCConfig
+tf.compat.v1.disable_v2_behavior()
 
 
 class WhileLoopConfig(APIConfig):
     def __init__(self):
         super(WhileLoopConfig, self).__init__('while_loop')
         self.alias_config = FCConfig()
-        self.run_tf = False
+        self.run_tf = True
 
 
 class PDWhileLoop(PaddleAPIBenchmarkBase):


### PR DESCRIPTION
添加`tf.compat.v1.disable_v2_behavior()`使`while_loop`的测试脚本能在tf-2.0中正常运行。