### PR TITLE
Improve the testing and reocrding of backward running

### DIFF
--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -141,6 +141,7 @@ class PaddleAPIBenchmarkBase(object):
 
         gradients = fluid.backward.gradients(targets, inputs)
         self.__backward = True
+        print("Gradients: ", gradients)
         if isinstance(gradients, list):
             for grad in gradients:
                 self.fetch_vars.append(grad)

--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -126,6 +126,13 @@ class PaddleAPIBenchmarkBase(object):
         result = func(**kwargs)
         return result
 
+    @property
+    def backward(self):
+        if hasattr(self, "__backward"):
+            return self.__backward
+        else:
+            return False
+
     def append_gradients(self, targets, inputs):
         if isinstance(inputs, fluid.framework.Variable):
             inputs = [inputs]
@@ -133,6 +140,7 @@ class PaddleAPIBenchmarkBase(object):
             raise TypeError("inputs should be a list.")
 
         gradients = fluid.backward.gradients(targets, inputs)
+        self.__backward = True
         if isinstance(gradients, list):
             for grad in gradients:
                 self.fetch_vars.append(grad)
@@ -171,7 +179,8 @@ class PaddleAPIBenchmarkBase(object):
             "framework": "paddle",
             "version": paddle.__version__,
             "name": self.name,
-            "device": "GPU" if use_gpu else "CPU"
+            "device": "GPU" if use_gpu else "CPU",
+            "backward": self.__backward
         }
 
         def _run_main_iter():
@@ -233,6 +242,7 @@ class PaddleAPIBenchmarkBase(object):
             self._feed_spec = feeder.copy_feed_spec(config.feed_spec)
             self._feed_dict = {}
 
+            self.__backward = False
             self.main_program = fluid.Program()
             self.startup_program = fluid.Program()
             with fluid.program_guard(self.main_program, self.startup_program):
@@ -250,6 +260,7 @@ class PaddleAPIBenchmarkBase(object):
         self.name = config.api_name
         feeder_adapter = self.generate_random_feeder(config, use_feed_fetch,
                                                      feeder_adapter)
+        assert self.__backward == args.backward, "Backward is not surported for %s." % self.name
 
         feed_list = feeder_adapter.to_paddle(self.feed_vars)
         assert len(feed_list) == len(self.feed_vars)

--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -261,7 +261,7 @@ class PaddleAPIBenchmarkBase(object):
         self.name = config.api_name
         feeder_adapter = self.generate_random_feeder(config, use_feed_fetch,
                                                      feeder_adapter)
-        assert self.__backward == args.backward, "Backward is not surported for %s." % self.name
+        # assert self.__backward == args.backward, "Backward is not surported for %s." % self.name
 
         feed_list = feeder_adapter.to_paddle(self.feed_vars)
         assert len(feed_list) == len(self.feed_vars)

--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -18,7 +18,7 @@ NO_FETCHES_OPS = ["feed", "null"]
 
 # operators without grad ops.
 NO_BACKWARD_OPS = [
-    "accuracy", "argsort", "assign", "cast", "compare", "less_than",
+    "accuracy", "argmax", "argmin", "argsort", "assign", "cast", "less_than",
     "less_equal", "not_equal", "greater_than", "greater_equal", "equal",
     "cumsum", "feed", "fetch", "fill_constant", "increment", "isfinite",
     "logical_not", "logical_and", "logical_or", "null", "one_hot", "scale",

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -238,6 +238,7 @@ class TensorflowAPIBenchmarkBase(object):
 
         gradients = tf.gradients(targets, inputs)
         self.__backward = True
+        print("Gradients: ", gradients)
         if isinstance(gradients, list):
             for grad in gradients:
                 self.fetch_list.append(grad)

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -355,7 +355,7 @@ class TensorflowAPIBenchmarkBase(object):
         self.name = config.api_name
         feeder_adapter = self.generate_random_feeder(config, use_feed_fetch,
                                                      feeder_adapter)
-        assert self.__backward == args.backward, "Backward is not surported for %s." % self.name
+        # assert self.__backward == args.backward, "Backward is not surported for %s." % self.name
 
         feed_list = feeder_adapter.to_tensorflow(self.feed_list)
         assert len(feed_list) == len(self.feed_list)

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 
-import sys
+import os, sys
 import traceback
 import numpy as np
 import json
@@ -45,6 +45,44 @@ def run_command(command, shell=True):
         stdout += line
 
     return stdout, exit_code
+
+
+def check_commit():
+    try:
+        current_dir = os.getcwd()
+        print("-- Current directory: %s" % current_dir)
+
+        dir_of_this_file = os.path.dirname(os.path.abspath(__file__))
+        print("-- Entering %s" % dir_of_this_file)
+        os.chdir(dir_of_this_file)
+        print("-- Current directory: %s" % os.getcwd())
+        benchmark_commit, _ = run_command("git rev-parse HEAD")
+        benchmark_commit = benchmark_commit.replace("\n", "")
+        benchmark_update_time, _ = run_command("git show -s --format=%ad")
+        benchmark_update_time = benchmark_update_time.replace("\n", "")
+        os.chdir(current_dir)
+        print("-- Current directory: %s" % os.getcwd())
+
+        import paddle
+        paddle_version = paddle.version.full_version
+        paddle_commit = paddle.version.commit
+
+        import tensorflow as tf
+        tf_version = tf.__version__
+
+        print(
+            "==========================================================================="
+        )
+        print("-- paddle version             : %s" % paddle_version)
+        print("-- paddle commit              : %s" % paddle_commit)
+        print("-- tensorflow version         : %s" % tf_version)
+        print("-- benchmark commit           : %s" % benchmark_commit)
+        print("-- benchmark last update time : %s" % benchmark_update_time)
+        print(
+            "==========================================================================="
+        )
+    except Exception:
+        pass
 
 
 def _compare(output1, output2, atol):

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+import sys
 import traceback
 import numpy as np
 import json
@@ -163,10 +164,11 @@ def check_outputs(list1, list2, name, atol=1e-6, config_params=None):
             print(
                 "---- The output is not consistent, but %s is in the white list."
                 % name)
-            print(json.dumps(status))
-        else:
-            print(json.dumps(status))
-            assert consistent == True, "The output is not consistent."
+        elif not consistent:
+            print("The output is not consistent.")
+        print(json.dumps(status))
+        if not consistent:
+            sys.exit(1)
     else:
         print(json.dumps(status))
 

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -104,7 +104,12 @@ def _check_shape(output1, output2, i):
     return output1, output2
 
 
-def check_outputs(list1, list2, name, atol=1e-6, config_params=None):
+def check_outputs(list1,
+                  list2,
+                  name,
+                  atol=1e-6,
+                  backward=False,
+                  config_params=None):
     if not isinstance(list1, list) or not isinstance(list2, list):
         raise TypeError(
             "input argument's type should be list of numpy.ndarray.")
@@ -154,6 +159,7 @@ def check_outputs(list1, list2, name, atol=1e-6, config_params=None):
 
     status = collections.OrderedDict()
     status["name"] = name
+    status["backward"] = backward
     status["consistent"] = consistent
     status["num_outputs"] = num_outputs
     status["diff"] = max_diff.astype("float")
@@ -181,6 +187,7 @@ def print_benchmark_result(result, log_level=0, config_params=None):
     status["version"] = result["version"]
     status["name"] = result["name"]
     status["device"] = result["device"]
+    status["backward"] = result["backward"]
 
     runtimes = result.get("total", None)
     if runtimes is None:

--- a/api/deploy/api_info.txt
+++ b/api/deploy/api_info.txt
@@ -1,7 +1,7 @@
 abs,abs,activation.json,True
 accuracy,accuracy,accuracy.json,False
-argmax,arg,arg.json,True
-argmin,arg,arg.json,True
+argmax,arg,arg.json,False
+argmin,arg,arg.json,False
 argsort,argsort,argsort.json,False
 assign,assign,assign.json,False
 batch_norm,batch_norm,batch_norm.json,True

--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -59,8 +59,8 @@ function print_detail_status() {
         printf "  [%d-%d][%s] %-90s ...... %s\n" ${config_id} ${case_id} "${timestamp}" "${print_str}" "${run_status}"
     elif [ ${print_str_length} -lt 100 ]; then
         printf "  [%d-%d][%s] %-100s ...... %s\n" ${config_id} ${case_id} "${timestamp}" "${print_str}" "${run_status}"
-    elif [ ${print_str_length} -lt 110 ]; then
-        printf "  [%d-%d][%s] %-110s ...... %s\n" ${config_id} ${case_id} "${timestamp}" "${print_str}" "${run_status}"
+    else
+        printf "  [%d-%d][%s] %-120s ...... %s\n" ${config_id} ${case_id} "${timestamp}" "${print_str}" "${run_status}"
     fi
 }
 

--- a/api/tests/arg.py
+++ b/api/tests/arg.py
@@ -29,8 +29,6 @@ class PDArg(PaddleAPIBenchmarkBase):
 
         self.feed_vars = [x]
         self.fetch_vars = [result]
-        if config.backward:
-            self.append_gradients(result, [x])
 
 
 class TFArg(TensorflowAPIBenchmarkBase):
@@ -40,8 +38,6 @@ class TFArg(TensorflowAPIBenchmarkBase):
 
         self.feed_list = [x]
         self.fetch_list = [result]
-        if config.backward:
-            self.append_gradients(result, [x])
 
 
 if __name__ == '__main__':

--- a/api/tests/cond.py
+++ b/api/tests/cond.py
@@ -36,7 +36,7 @@ class PDCond(PaddleAPIBenchmarkBase):
         self.feed_vars = [x, y, input]
         self.fetch_vars = [result]
         if config.backward:
-            self.append_gradients(result, [x, y, input])
+            self.append_gradients(result, [x, y])
 
 
 class TFCond(TensorflowAPIBenchmarkBase):
@@ -60,7 +60,7 @@ class TFCond(TensorflowAPIBenchmarkBase):
         self.feed_list = [x, y, input]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, [x, y, input])
+            self.append_gradients(result, [x, y])
 
 
 if __name__ == '__main__':

--- a/api/tests/configs/elementwise.json
+++ b/api/tests/configs/elementwise.json
@@ -98,12 +98,12 @@
             "value": "-1"
         },
         "x": {
-            "dtype": "int32",
+            "dtype": "float32",
             "shape": "[-1L, 1L, 513L, 513L]",
             "type": "Variable"
         },
         "y": {
-            "dtype": "int32",
+            "dtype": "float32",
             "shape": "[1L]",
             "type": "Variable"
         }

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -37,6 +37,8 @@ class Conv2dConfig(APIConfig):
             self.input_shape[0] = 64
         if isinstance(self.filter_size, int):
             self.filter_size = [self.filter_size, self.filter_size]
+        if self.groups is None:
+            self.groups = 1
         if self.num_channels % self.groups != 0:
             raise ValueError(
                 "the channel of input must be divisible by groups,"

--- a/api/tests/conv2d_transpose.py
+++ b/api/tests/conv2d_transpose.py
@@ -37,6 +37,8 @@ class Conv2dTransposeConfig(APIConfig):
             self.input_shape[0] = 64
         if isinstance(self.filter_size, int):
             self.filter_size = [self.filter_size, self.filter_size]
+        if self.groups is None:
+            self.groups = 1
         if self.num_channels % self.groups != 0:
             raise ValueError(
                 "the channel of input must be divisible by groups,"

--- a/api/tests/gather.py
+++ b/api/tests/gather.py
@@ -46,7 +46,7 @@ class PDGather(PaddleAPIBenchmarkBase):
         self.feed_vars = [input, index]
         self.fetch_vars = [result]
         if config.backward:
-            self.append_gradients(result, [input, index])
+            self.append_gradients(result, [input])
 
 
 class TFGather(TensorflowAPIBenchmarkBase):
@@ -60,7 +60,7 @@ class TFGather(TensorflowAPIBenchmarkBase):
         self.feed_list = [params, indices]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, [params, indices])
+            self.append_gradients(result, [params])
 
 
 if __name__ == '__main__':

--- a/api/tests/launch.py
+++ b/api/tests/launch.py
@@ -79,12 +79,12 @@ def launch(benchmark_script, benchmark_script_args, with_nvprof=False):
         if exit_code == 0:
             return _parse_nvprof_logs(stdout.split("\n"))
         else:
-            print("stdout: {}".format(stdout))
+            print("Runing Error:\n {}".format(stdout))
     else:
         stdout, exit_code = utils.run_command(cmd)
         print(stdout)
         if exit_code != 0:
-            sys.exit(1)
+            sys.exit(exit_code)
     return 0.0
 
 

--- a/api/tests/launch.py
+++ b/api/tests/launch.py
@@ -118,6 +118,8 @@ if __name__ == "__main__":
     profiler = benchmark_args_dict.get("profiler", "none")
     repeat = benchmark_args_dict.get("repeat", "1")
 
+    utils.check_commit()
+
     if use_gpu and task == "speed" and profiler == "none":
         total_gpu_time = launch(
             args.benchmark_script,

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -185,7 +185,7 @@ def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
                 pd_stats,
                 log_level=args.log_level,
                 config_params=config.to_string())
-            
+
         if pd_outputs == False:
             sys.exit(1)
 
@@ -196,6 +196,7 @@ def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
                 tf_outputs,
                 name=config.api_name,
                 atol=config.atol,
+                backward=pd_obj.backward,
                 config_params=config.to_string())
         else:
             warnings.simplefilter('always', UserWarning)

--- a/api/tests/pool2d.py
+++ b/api/tests/pool2d.py
@@ -24,7 +24,7 @@ class Pool2dConfig(APIConfig):
         self.pool_type = self.pool_type.lower()
         # The argument of tf's padding algorithm, must be "SAME" or "VALID".
         if not isinstance(self.pool_padding, str):
-            config.run_tf = False
+            self.run_tf = False
 
     def to_tensorflow(self):
         tf_config = super(Pool2dConfig, self).to_tensorflow()

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -15,16 +15,18 @@ export PYTHONPATH=${OP_BENCHMARK_ROOT}:${PYTHONPATH}
 
 name=${1:-"abs"}
 config_id=${2:-"0"}
+api_name=${3:-"${name}"}
 filename="${OP_BENCHMARK_ROOT}/tests/examples/${name}.json"
 
 python -m tests.launch ${OP_BENCHMARK_ROOT}/tests/${name}.py \
       --task "accuracy" \
       --framework "paddle" \
+      --api_name "${api_name}" \
       --json_file ${filename} \
       --config_id ${config_id} \
       --check_output False \
       --profiler "none" \
-      --backward False \
+      --backward True \
       --use_gpu True \
       --repeat 1 \
       --log_level 0

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -21,12 +21,11 @@ filename="${OP_BENCHMARK_ROOT}/tests/examples/${name}.json"
 python -m tests.launch ${OP_BENCHMARK_ROOT}/tests/${name}.py \
       --task "accuracy" \
       --framework "paddle" \
-      --api_name "${api_name}" \
       --json_file ${filename} \
       --config_id ${config_id} \
       --check_output False \
       --profiler "none" \
-      --backward True \
+      --backward False \
       --use_gpu True \
       --repeat 1 \
       --log_level 0

--- a/api/tests/sequence_mask.py
+++ b/api/tests/sequence_mask.py
@@ -19,6 +19,7 @@ class PDSequenceMask(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         data = self.variable(
             name='data', shape=config.x_shape, dtype=config.x_dtype)
+        # TODO: maxlen is a variable
         result = fluid.layers.sequence_mask(
             x=data, maxlen=config.maxlen, dtype=config.dtype)
 

--- a/api/tests/switch_case.py
+++ b/api/tests/switch_case.py
@@ -37,7 +37,7 @@ class PDSwitchCase(PaddleAPIBenchmarkBase):
         self.feed_vars = [x, y, input]
         self.fetch_vars = [result]
         if config.backward:
-            self.append_gradients(result, [x, y, input])
+            self.append_gradients(result, [x, y])
 
 
 class TFSwitchCase(TensorflowAPIBenchmarkBase):
@@ -64,7 +64,7 @@ class TFSwitchCase(TensorflowAPIBenchmarkBase):
         self.feed_list = [x, y, input]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, [x, y, input])
+            self.append_gradients(result, [x, y])
 
 
 if __name__ == '__main__':

--- a/api/tests/while_loop.py
+++ b/api/tests/while_loop.py
@@ -21,7 +21,6 @@ class WhileLoopConfig(APIConfig):
     def __init__(self):
         super(WhileLoopConfig, self).__init__('while_loop')
         self.alias_config = FCConfig()
-        self.run_tf = True
 
 
 class PDWhileLoop(PaddleAPIBenchmarkBase):
@@ -55,7 +54,7 @@ class PDWhileLoop(PaddleAPIBenchmarkBase):
             cond, body, [i, loop_len, input, result])
         self.feed_vars = [input]
         self.fetch_vars = [results]
-        if config.alias_config.backward:
+        if config.backward:
             self.append_gradients(results, [input])
 
 
@@ -95,7 +94,7 @@ class TFWhileLoop(TensorflowAPIBenchmarkBase):
                                          [i, loop_len, input, result])
         self.feed_list = [input]
         self.fetch_list = [results]
-        if config.alias_config.backward:
+        if config.backward:
             self.append_gradients(results, [input])
 
 

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -27,7 +27,15 @@ fi
 BENCHMARK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 echo ${BENCHMARK_ROOT}
 
-function prepare_tf_env(){
+function prepare_env(){
+    # Update pip
+    easy_install --upgrade pip
+    # Install latest paddle
+    PADDLE_WHL="paddlepaddle_gpu-0.0.0-cp27-cp27mu-linux_x86_64.whl"
+    PADDLE_URL="https://paddle-wheel.bj.bcebos.com/0.0.0-gpu-cuda10-cudnn7-mkl/${PADDLE_WHL}"
+    wget ${PADDLE_URL}
+    pip install -U ${PADDLE_WHL}
+    # Install tensorflow and other packages
     pip install tensorflow-gpu==2.0 pre-commit==1.21 pylint==1.9.5 pytest==4.6.9
     python -c "import tensorflow as tf; print(tf.__version__)"
     apt-get update
@@ -130,7 +138,7 @@ function main(){
     local CMD=$1
     case $CMD in
       run_api_test)
-        prepare_tf_env
+        prepare_env
         check_style
         run_api
         ;;


### PR DESCRIPTION
这个PR主要根据op benchmark平台上的展示结果，修复了一些问题：

- 修改精度不满足时的输出，确保dict是log的最后一行。
- dict中添加backward字段，调用了`append_gradients`接口才认为是在执行backward。
    - TODO：打开`self.__backward == config.backward`的检查，组网代码中没有调用`append_gradients`接口的op，运行参数也不能设置`backward=True`
- `argmax`、`argmin`没有反向op，加入`NO_BACKWARD_OPS`。
- 获取一些基本信息，包括
    - benchmark最新的commit以及该commit的时间
    - paddle的commit和版本号
    - tensorflow的版本号
- fix一些tf不会生成梯度的case
    - elementwise_add，最后一个config中x、y是int类型，这种情况下梯度没有意义
    - gather的index输入没有梯度
    - cond、switch_case中用于比较的变量没有梯度
- fix一些op的脚本问题

由于CI环境的改变，导致CI检查一直不通过，故这个PR也进行了更新：
- 每次都强制重新安装pip，避免安装tensorflow找不到2.0以上版本的问题
- 每次拉取paddle最新的安装包进行更新