### PR TITLE
Enhance the tesing and checking of CPU performance and fix serveral op scripts

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -102,13 +102,26 @@ class VarParamInfo(BaseParamInfo):
             self.shape = shape_str
         self.lod_level = self._encode_item(lod_level)
 
+    def _is_same(self, dtypes, shapes):
+        dtype_0 = dtypes[0]
+        shape_0 = shapes[0]
+        for i in range(len(dtypes)):
+            if dtype_0 != dtypes[i] or shape_0 != shapes[i]:
+                return False
+        return True
+
     def to_string(self):
         if self.type == "Variable":
             return self.name + " (Variable) - dtype: " + str(
                 self.dtype) + ", shape: " + str(self.shape)
         elif self.type == "list<Variable>":
-            str_list = self.name + " (list<Variable>) - "
-            for i in range(len(self.dtype)):
+            str_list = "%s (list<Variable>[%d]) - " % (self.name,
+                                                       len(self.dtype))
+            if self._is_same(self.dtype, self.shape):
+                params_len = 1
+            else:
+                params_len = len(self.dtype)
+            for i in range(params_len):
                 str_list = str_list + "dtype: " + str(self.dtype[
                     i]) + ", shape: " + str(self.shape[i]) + "; "
             return str_list

--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -128,7 +128,7 @@ class PaddleAPIBenchmarkBase(object):
 
     @property
     def backward(self):
-        if hasattr(self, "__backward"):
+        if hasattr(self, "_PaddleAPIBenchmarkBase__backward"):
             return self.__backward
         else:
             return False
@@ -141,7 +141,7 @@ class PaddleAPIBenchmarkBase(object):
 
         gradients = fluid.backward.gradients(targets, inputs)
         self.__backward = True
-        print("Gradients: ", gradients)
+        # print("Gradients: ", gradients)
         if isinstance(gradients, list):
             for grad in gradients:
                 self.fetch_vars.append(grad)

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -270,7 +270,8 @@ class TensorflowAPIBenchmarkBase(object):
                  check_output=False,
                  profiler="none"):
         sess = self._init_session(use_gpu)
-        tf.debugging.set_log_device_placement(True)
+
+        #tf.debugging.set_log_device_placement(True)
 
         def _run_main_iter(run_options=None, run_metadata=None):
             feed_dict = feed if self._need_feed else None

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -225,7 +225,7 @@ class TensorflowAPIBenchmarkBase(object):
 
     @property
     def backward(self):
-        if hasattr(self, "__backward"):
+        if hasattr(self, "_TensorflowAPIBenchmarkBase__backward"):
             return self.__backward
         else:
             return False
@@ -238,7 +238,7 @@ class TensorflowAPIBenchmarkBase(object):
 
         gradients = tf.gradients(targets, inputs)
         self.__backward = True
-        print("Gradients: ", gradients)
+        # print("Gradients: ", gradients)
         if isinstance(gradients, list):
             for grad in gradients:
                 self.fetch_list.append(grad)

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -270,8 +270,7 @@ class TensorflowAPIBenchmarkBase(object):
                  check_output=False,
                  profiler="none"):
         sess = self._init_session(use_gpu)
-
-        # tf.debugging.set_log_device_placement(True)
+        tf.debugging.set_log_device_placement(True)
 
         def _run_main_iter(run_options=None, run_metadata=None):
             feed_dict = feed if self._need_feed else None

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -273,6 +273,14 @@ def print_benchmark_result(result, log_level=0, config_params=None):
             print("Iter %4d, Runtime: %.5f ms, Walltime: %.5f ms" %
                   (i, runtimes[i], walltime))
 
+    if avg_runtime - avg_walltime > 0.001:
+        total = avg_runtime - avg_walltime
+    else:
+        print(
+            "Average runtime (%.5f ms) is less than average walltime (%.5f ms)."
+            % (avg_runtime, avg_walltime))
+        total = 0.001
+
     if stable is not None and diff is not None:
         status["precision"] = collections.OrderedDict()
         status["precision"]["stable"] = stable
@@ -281,7 +289,7 @@ def print_benchmark_result(result, log_level=0, config_params=None):
     status["speed"]["repeat"] = len(sorted_runtimes)
     status["speed"]["begin"] = begin
     status["speed"]["end"] = end
-    status["speed"]["total"] = avg_runtime - avg_walltime
+    status["speed"]["total"] = total
     status["speed"]["wall_time"] = avg_walltime
     status["speed"]["total_include_wall_time"] = avg_runtime
     if gpu_time is not None:

--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -1,7 +1,9 @@
 #! /bin/bash
 
+# Usage:
+#   bash main_control.sh json_config_dir output_dir gpu_id cpu|gpu|both speed|accuracy|both"
+
 export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH
-export CUDA_VISIBLE_DEVICES="0"
 
 OP_BENCHMARK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/../" && pwd )"
 DEPLOY_DIR="${OP_BENCHMARK_ROOT}/deploy"
@@ -15,17 +17,19 @@ if [ ! -d ${OUTPUT_DIR} ]; then
     mkdir -p ${OUTPUT_DIR}
 fi
 
+GPU_ID=${3:-"0"}
+
 DEVICE_SET=("gpu" "cpu")
-if [ $# -ge 3 ]; then
-    if [[ ${3} == "cpu" || ${3} == "gpu" ]]; then
-        DEVICE_SET=(${3})
+if [ $# -ge 4 ]; then
+    if [[ ${4} == "cpu" || ${4} == "gpu" ]]; then
+        DEVICE_SET=(${4})
     fi
 fi
 
 TASK_SET=("speed" "accuracy")
-if [ $# -ge 4 ]; then
-    if [[ ${4} == "speed" || ${4} == "accuracy" ]]; then
-        TASK_SET=(${4})
+if [ $# -ge 5 ]; then
+    if [[ ${5} == "speed" || ${5} == "accuracy" ]]; then
+        TASK_SET=(${5})
     fi
 fi
 
@@ -111,9 +115,11 @@ do
         for device in ${DEVICE_SET[@]};
         do 
             if [ ${device} = "gpu" ]; then
+                export CUDA_VISIBLE_DEVICES="${GPU_ID}"
                 use_gpu="True"
                 repeat=1000
             else
+                export CUDA_VISIBLE_DEVICES=""
                 use_gpu="False"
                 repeat=100
             fi

--- a/api/run_op_benchmark.sh
+++ b/api/run_op_benchmark.sh
@@ -11,4 +11,5 @@ fi
 
 config_dir=${OP_BENCHMARK_ROOT}/tests/configs
 log_path=${OP_BENCHMARK_ROOT}/logs/log_${timestamp}.txt
-bash ${OP_BENCHMARK_ROOT}/deploy/main_control.sh ${config_dir} ${output_dir} > ${log_path} 2>&1
+gpu_id="0"
+bash ${OP_BENCHMARK_ROOT}/deploy/main_control.sh ${config_dir} ${output_dir} ${gpu_id} > ${log_path} 2>&1 &

--- a/api/tests/case.py
+++ b/api/tests/case.py
@@ -44,7 +44,7 @@ class PDCase(PaddleAPIBenchmarkBase):
         self.feed_vars = [x, y, input]
         self.fetch_vars = [result]
         if config.backward:
-            self.append_gradients(result, [x, y, input])
+            self.append_gradients(result, [x, y])
 
 
 class TFCase(TensorflowAPIBenchmarkBase):
@@ -77,7 +77,7 @@ class TFCase(TensorflowAPIBenchmarkBase):
         self.feed_list = [x, y, input]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, [x, y, input])
+            self.append_gradients(result, [x, y])
 
 
 if __name__ == '__main__':

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -33,7 +33,7 @@ function prepare_env(){
     # Install latest paddle
     PADDLE_WHL="paddlepaddle_gpu-0.0.0-cp27-cp27mu-linux_x86_64.whl"
     PADDLE_URL="https://paddle-wheel.bj.bcebos.com/0.0.0-gpu-cuda10-cudnn7-mkl/${PADDLE_WHL}"
-    wget ${PADDLE_URL}
+    wget -q ${PADDLE_URL}
     pip install -U ${PADDLE_WHL}
     # Install tensorflow and other packages
     pip install tensorflow-gpu==2.0 pre-commit==1.21 pylint==1.9.5 pytest==4.6.9


### PR DESCRIPTION
这个PR做了以下修改：

- 修改`list<Variable>`类型的parameters格式。summary.py在解析op运行log的时候，会截取最后一行的dict，并且size不能超过1024。一些特殊的case，比如concat，拼合201个shape为[1]的变量，因为parameters超出了1024的长度限制，导致不能正常解析。另外，parameters太长展示效果也不好。因此当多个输入的dtype、shape都一样时，改成如下格式：
```
"parameters": "input (list<Variable>[201]) - dtype: float32, shape: [1]; \naxis (int): 0\n"
```
- 修复backward值获取的bug。类A的`__member`成员，使用hasattr判断时，需指定属性名为`_A__member`。
- `total = avg_runtime - avg_walltime`，设置total最小值为0.001，避免total出现极小值、甚至是负数的情况。
- CPU测试时，必须设置环境变量`export CUDA_VISIBLE_DEVICES=""`，否则tf都是使用GPU运行的。