### PR TITLE
Add script of clip_by_norm.

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -18,11 +18,11 @@ NO_FETCHES_OPS = ["feed", "null"]
 
 # operators without grad ops.
 NO_BACKWARD_OPS = [
-    "accuracy", "argmax", "argmin", "argsort", "assign", "cast", "less_than",
-    "less_equal", "not_equal", "greater_than", "greater_equal", "equal",
-    "cumsum", "feed", "fetch", "fill_constant", "increment", "isfinite",
-    "logical_not", "logical_and", "logical_or", "null", "one_hot", "scale",
-    "sequence_mask", "shape", "zeros_like"
+    "accuracy", "argmax", "argmin", "argsort", "assign", "cast",
+    "clip_by_norm", "cumsum", "equal", "feed", "fetch", "fill_constant",
+    "greater_equal", "greater_than", "increment", "isfinite", "less_equal",
+    "less_than", "logical_not", "logical_and", "logical_or", "not_equal",
+    "null", "one_hot", "scale", "sequence_mask", "shape", "zeros_like"
 ]
 
 NO_NEED_ARGS = {

--- a/api/tests/clip_by_norm.py
+++ b/api/tests/clip_by_norm.py
@@ -1,0 +1,43 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class ClipByNormConfig(APIConfig):
+    def __init__(self):
+        super(ClipByNormConfig, self).__init__("clip_by_norm")
+        self.feed_spec = {"range": [-10, 10]}
+
+
+class PDClipByNorm(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        result = fluid.layers.clip_by_norm(x=x, max_norm=2.0)
+
+        self.feed_vars = [x]
+        self.fetch_vars = [result]
+
+
+class TFClipByNorm(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = tf.clip_by_norm(t=x, clip_norm=2.0, axes=None)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(PDClipByNorm(), TFClipByNorm(), config=ClipByNormConfig())

--- a/api/tests/configs/clip_by_norm.json
+++ b/api/tests/configs/clip_by_norm.json
@@ -1,0 +1,10 @@
+[{
+    "op": "clip_by_norm",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[1000L, 300L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests/elementwise.py
+++ b/api/tests/elementwise.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 from common_import import *
 
 
@@ -29,6 +31,27 @@ class ElementwiseConfig(APIConfig):
             'elementwise_mul': 'multiply',
             'elementwise_pow': 'pow'
         }
+
+    def to_tensorflow(self):
+        tf_config = super(ElementwiseConfig, self).to_tensorflow()
+        if len(self.x_shape) > len(self.y_shape) and self.y_shape != [1]:
+            tf_config.y_shape_unsqueezed = self._unsqueeze_short(
+                short=self.y_shape, long=self.x_shape)
+        elif len(self.x_shape) < len(self.y_shape) and self.x_shape != [1]:
+            tf_config.x_shape_unsqueezed = self._unsqueeze_short(
+                short=self.x_shape, long=self.y_shape)
+        return tf_config
+
+    def _unsqueeze_short(self, short, long):
+        short_extend = np.ones([len(long)], dtype=np.int32).tolist()
+        start = 0
+        for value in short:
+            for i in range(start, len(long)):
+                if long[i] == value:
+                    short_extend[i] = value
+                    start = i
+                    break
+        return short_extend
 
 
 class PDElementwise(PaddleAPIBenchmarkBase):
@@ -48,7 +71,15 @@ class TFElementwise(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
-        result = self.layers(config.api_name, x=x, y=y)
+        if hasattr(config, "x_shape_unsqueezed"):
+            x_reshape = tf.reshape(tensor=x, shape=config.x_shape_unsqueezed)
+        else:
+            x_reshape = x
+        if hasattr(config, "y_shape_unsqueezed"):
+            y_reshape = tf.reshape(tensor=y, shape=config.y_shape_unsqueezed)
+        else:
+            y_reshape = y
+        result = self.layers(config.api_name, x=x_reshape, y=y_reshape)
 
         self.feed_list = [x, y]
         self.fetch_list = [result]

--- a/api/tests/examples/clip_by_norm.json
+++ b/api/tests/examples/clip_by_norm.json
@@ -1,0 +1,1 @@
+../configs/clip_by_norm.json

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -16,7 +16,7 @@ export PYTHONPATH=${OP_BENCHMARK_ROOT}:${PYTHONPATH}
 name=${1:-"abs"}
 config_id=${2:-"0"}
 api_name=${3:-"${name}"}
-filename="${OP_BENCHMARK_ROOT}/tests/configs/${name}.json"
+filename="${OP_BENCHMARK_ROOT}/tests/examples/${name}.json"
 
 python -m tests.launch ${OP_BENCHMARK_ROOT}/tests/${name}.py \
       --task "accuracy" \

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -16,7 +16,7 @@ export PYTHONPATH=${OP_BENCHMARK_ROOT}:${PYTHONPATH}
 name=${1:-"abs"}
 config_id=${2:-"0"}
 api_name=${3:-"${name}"}
-filename="${OP_BENCHMARK_ROOT}/tests/examples/${name}.json"
+filename="${OP_BENCHMARK_ROOT}/tests/configs/${name}.json"
 
 python -m tests.launch ${OP_BENCHMARK_ROOT}/tests/${name}.py \
       --task "accuracy" \


### PR DESCRIPTION
@phlrain 反馈，clip_by_norm CPU非常慢，甚至比使用多个小OP组合的计算速度还要慢很多。测试代码如下：
```python
import paddle.fluid as fluid
import numpy as np
import time


def local_clip( input, norm):
    sq = fluid.layers.square( input )
    sum1 = fluid.layers.reduce_sum( sq )
    n = fluid.layers.sqrt( sum1)
    
    if n.numpy()  > norm:
        return input / n.numpy()
    else:
        return input


with fluid.dygraph.guard(fluid.CPUPlace() ):
    a = np.random.uniform( -1.0, 1.0, (1000, 300)).astype("float32")
    
    a = fluid.dygraph.to_variable( a )
    print( a.shape )

    start = time.time()
    b = fluid.layers.clip_by_norm(a, 1.0) 
    print( "cost", time.time() - start )

    start = time.time()
    b = local_clip( a, 1.0 )
    print( "local cost", time.time() - start )
```

运行结果为：
![image](https://user-images.githubusercontent.com/12538138/85948314-d34ac080-b982-11ea-8a6c-d0e7f7f9e373.png)

OP Benchmark测得的时间：
| op | CPU Time | GPU Time | parameters |
|---|---|---|---|
| clip_by_norm | 56950.334 | 0.275 | "x (Variable) - dtype: float32, shape: [1000, 300]\n" | 