### PR TITLE
Add an argument to allow adaptively changing the value of repeat according to that in json configs

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -19,6 +19,24 @@ import numpy as np
 from operator import attrgetter
 
 
+def parse_float(value):
+    if isinstance(value, float):
+        return value
+    elif isinstance(value, unicode):
+        return float(value.encode("utf-8"))
+    else:
+        return float(value)
+
+
+def parse_int(value):
+    if isinstance(value, int):
+        return value
+    elif isinstance(value, unicode):
+        return int(value.encode("utf-8"))
+    else:
+        return int(value)
+
+
 def parse_list(value_str, sub_dtype="int"):
     if isinstance(value_str, unicode):
         value_str = value_str.encode("utf-8")
@@ -179,6 +197,8 @@ class APIConfig(object):
         if hasattr(self, "alias_config"):
             self.alias_config.init_from_json(
                 self.alias_filename(filename), config_id)
+            if hasattr(self.alias_config, "repeat"):
+                self.repeat = self.alias_config.repeat
             return self
 
         print("---- Initialize APIConfig from %s, config_id = %d.\n" %
@@ -190,11 +210,12 @@ class APIConfig(object):
                 "The filename: %s, config_id: %d." % (
                     op, self.name, self.alias_name, filename, config_id)
             self.params = data[config_id]["param_info"]
+
             if data[config_id].get("atol", None) is not None:
-                if isinstance(data[config_id]["atol"], str):
-                    self.atol = float(data[config_id]["atol"])
-                elif isinstance(data[config_id]["atol"], float):
-                    self.atol = data[config_id]["atol"]
+                self.atol = parse_float(data[config_id]["atol"])
+
+            if data[config_id].get("repeat", None) is not None:
+                self.repeat = parse_int(data[config_id]["repeat"])
 
         self._parse_params()
         for param in self.params_list:
@@ -254,7 +275,7 @@ class APIConfig(object):
         ]
         if hasattr(self, "is_alias_of_other") and self.is_alias_of_other:
             prefix = "  "
-            for name in ["run_tf", "atol"]:
+            for name in ["run_tf", "atol", "repeat"]:
                 exclude_attrs.append(name)
         else:
             prefix = ""

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -286,13 +286,13 @@ def print_benchmark_result(result, log_level=0, config_params=None):
         status["precision"]["stable"] = stable
         status["precision"]["diff"] = diff
     status["speed"] = collections.OrderedDict()
-    status["speed"]["repeat"] = len(sorted_runtimes)
+    status["speed"]["repeat"] = repeat
     status["speed"]["begin"] = begin
     status["speed"]["end"] = end
     status["speed"]["total"] = total
     status["speed"]["wall_time"] = avg_walltime
     status["speed"]["total_include_wall_time"] = avg_runtime
     if gpu_time is not None:
-        status["speed"]["gpu_time"] = gpu_time
+        status["speed"]["gpu_time"] = gpu_time / repeat
     status["parameters"] = config_params
     print(json.dumps(status))

--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -151,7 +151,8 @@ do
                               --config_id $i \
                               --backward ${backward} \
                               --use_gpu ${use_gpu} \
-                              --repeat $repeat"
+                              --repeat $repeat \
+                              --allow_adaptive_repeat True"
 
                         run_start=`date +%s%N`
                         if [ "${OUTPUT_DIR}" != "" ]; then

--- a/api/run_op_benchmark.sh
+++ b/api/run_op_benchmark.sh
@@ -9,7 +9,7 @@ if [ ! -d ${OP_BENCHMARK_ROOT}/logs ]; then
     mkdir -p ${OP_BENCHMARK_ROOT}/logs
 fi
 
-gpu_id="0"
+gpu_id=${1:-"0"}
 config_dir=${OP_BENCHMARK_ROOT}/tests/configs
 log_path=${OP_BENCHMARK_ROOT}/logs/log_${timestamp}.txt
 bash ${OP_BENCHMARK_ROOT}/deploy/main_control.sh ${config_dir} ${output_dir} ${gpu_id} > ${log_path} 2>&1 &

--- a/api/tests/configs/activation.json
+++ b/api/tests/configs/activation.json
@@ -6,7 +6,8 @@
             "shape": "[-1L, 128L, 257L, 257L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "activation",
     "param_info": {

--- a/api/tests/configs/arg.json
+++ b/api/tests/configs/arg.json
@@ -10,5 +10,6 @@
             "shape": "[-1L, 513L, 513L, 19L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 2000
 }]

--- a/api/tests/configs/assign.json
+++ b/api/tests/configs/assign.json
@@ -25,7 +25,8 @@
             "shape": "[30522L, 1024L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "assign",
     "param_info": {

--- a/api/tests/configs/batch_norm.json
+++ b/api/tests/configs/batch_norm.json
@@ -120,7 +120,8 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "batch_norm",
     "param_info": {
@@ -202,5 +203,6 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/cast.json
+++ b/api/tests/configs/cast.json
@@ -36,7 +36,8 @@
             "shape": "[-1L, 1L, 513L, 513L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "cast",
     "param_info": {
@@ -49,7 +50,8 @@
             "shape": "[30522L, 1024L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "cast",
     "param_info": {
@@ -88,5 +90,6 @@
             "shape": "[-1L, -1L, 1024L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/compare.json
+++ b/api/tests/configs/compare.json
@@ -41,5 +41,6 @@
             "shape": "[256L, 1024L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 10000
 }]

--- a/api/tests/configs/concat.json
+++ b/api/tests/configs/concat.json
@@ -18,7 +18,8 @@
             },
             "type": "list<Variable>"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "concat",
     "param_info": {
@@ -1122,5 +1123,6 @@
             },
             "type": "list<Variable>"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/conv2d.json
+++ b/api/tests/configs/conv2d.json
@@ -312,7 +312,8 @@
             "type": "bool",
             "value": "True"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "conv2d",
     "param_info": {
@@ -357,7 +358,8 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "repeat": 2000
 }, {
     "op": "conv2d",
     "param_info": {
@@ -582,7 +584,8 @@
             "type": "bool",
             "value": "True"
         }
-    }
+    },
+    "repeat": 2000
 }, {
     "op": "conv2d",
     "param_info": {

--- a/api/tests/configs/dropout.json
+++ b/api/tests/configs/dropout.json
@@ -22,7 +22,8 @@
             "shape": "[-1L, 36864L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 2000
 }, {
     "op": "dropout",
     "param_info": {
@@ -47,7 +48,8 @@
             "shape": "[-1L, 16L, -1L, -1L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 2000
 }, {
     "op": "dropout",
     "param_info": {
@@ -72,7 +74,8 @@
             "shape": "[-1L, 35L, 1500L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 2000
 }, {
     "op": "dropout",
     "param_info": {

--- a/api/tests/configs/elementwise.json
+++ b/api/tests/configs/elementwise.json
@@ -19,7 +19,8 @@
             "shape": "[128L, 1000L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "elementwise",
     "param_info": {
@@ -41,7 +42,8 @@
             "shape": "[1L, 128L, 1000L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "elementwise",
     "param_info": {
@@ -63,7 +65,8 @@
             "shape": "[-1L, 2048L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "elementwise",
     "param_info": {
@@ -85,7 +88,8 @@
             "shape": "[-1L, 2048L, -1L, -1L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "elementwise",
     "param_info": {
@@ -107,5 +111,6 @@
             "shape": "[1L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/embedding.json
+++ b/api/tests/configs/embedding.json
@@ -72,7 +72,8 @@
             "type": "list",
             "value": "[10000, 1500]"
         }
-    }
+    },
+    "repeat": 20000
 }, {
     "op": "embedding",
     "param_info": {

--- a/api/tests/configs/fc.json
+++ b/api/tests/configs/fc.json
@@ -60,7 +60,8 @@
             "type": "int",
             "value": "1024"
         }
-    }
+    },
+    "repeat": 2000
 }, {
     "op": "fc",
     "param_info": {

--- a/api/tests/configs/gather.json
+++ b/api/tests/configs/gather.json
@@ -33,5 +33,6 @@
             "type": "bool",
             "value": "True"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/instance_norm.json
+++ b/api/tests/configs/instance_norm.json
@@ -10,5 +10,6 @@
             "shape": "[-1L, 256L, 32L, 32L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/leaky_relu.json
+++ b/api/tests/configs/leaky_relu.json
@@ -10,7 +10,8 @@
             "shape": "[-1L, 32L, -1L, -1L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 2000
 }, {
     "op": "leaky_relu",
     "param_info": {
@@ -23,5 +24,6 @@
             "shape": "[-1L, 512L, 31L, 31L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/matmul.json
+++ b/api/tests/configs/matmul.json
@@ -75,7 +75,8 @@
             "shape": "[3000L, 6000L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 10000
 }, {
     "op": "matmul",
     "param_info": {
@@ -101,7 +102,8 @@
             "shape": "[-1L, -1L, 512L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 2000
 }, {
     "op": "matmul",
     "param_info": {
@@ -127,5 +129,6 @@
             "shape": "[37007L, 1024L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 10000
 }]

--- a/api/tests/configs/mean.json
+++ b/api/tests/configs/mean.json
@@ -15,5 +15,6 @@
             "shape": "[-1L, 3L, 128L, 128L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 10000
 }]

--- a/api/tests/configs/pad2d.json
+++ b/api/tests/configs/pad2d.json
@@ -22,7 +22,8 @@
             "type": "list",
             "value": "[0, 1, 0, 1]"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "pad2d",
     "param_info": {
@@ -47,5 +48,6 @@
             "type": "list",
             "value": "[3, 3, 3, 3]"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/pool2d.json
+++ b/api/tests/configs/pool2d.json
@@ -42,7 +42,8 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "pool2d",
     "param_info": {
@@ -87,7 +88,8 @@
             "type": "bool",
             "value": "True"
         }
-    }
+    },
+    "repeat": 10000
 }, {
     "op": "pool2d",
     "param_info": {
@@ -132,7 +134,8 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "repeat": 10000
 }, {
     "op": "pool2d",
     "param_info": {
@@ -177,7 +180,8 @@
             "type": "bool",
             "value": "True"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "pool2d",
     "param_info": {
@@ -222,7 +226,8 @@
             "type": "bool",
             "value": "True"
         }
-    }
+    },
+    "repeat": 10000
 }, {
     "op": "pool2d",
     "param_info": {
@@ -267,7 +272,8 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "pool2d",
     "param_info": {
@@ -312,7 +318,8 @@
             "type": "bool",
             "value": "True"
         }
-    }
+    },
+    "repeat": 10000
 }, {
     "op": "pool2d",
     "param_info": {
@@ -357,5 +364,6 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/reduce.json
+++ b/api/tests/configs/reduce.json
@@ -14,7 +14,8 @@
             "type": "bool",
             "value": "True"
         }
-    }
+    },
+    "repeat": 10000
 }, {
     "op": "reduce",
     "param_info": {
@@ -65,5 +66,6 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "repeat": 10000
 }]

--- a/api/tests/configs/reshape.json
+++ b/api/tests/configs/reshape.json
@@ -22,7 +22,8 @@
             "shape": "[-1L, 513L, 513L, 19L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "reshape",
     "param_info": {

--- a/api/tests/configs/scale.json
+++ b/api/tests/configs/scale.json
@@ -47,5 +47,6 @@
             "shape": "[-1L, -1L, 1024L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/sigmoid_cross_entropy_with_logits.json
+++ b/api/tests/configs/sigmoid_cross_entropy_with_logits.json
@@ -41,5 +41,6 @@
             "shape": "[-1L, 63504L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/slice.json
+++ b/api/tests/configs/slice.json
@@ -39,7 +39,8 @@
             "type": "list",
             "value": "[34]"
         }
-    }
+    },
+    "repeat": 20000
 }, {
     "op": "slice",
     "param_info": {

--- a/api/tests/configs/transpose.json
+++ b/api/tests/configs/transpose.json
@@ -23,7 +23,8 @@
             "shape": "[-1L, 19L, 513L, 513L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "transpose",
     "param_info": {
@@ -36,5 +37,6 @@
             "shape": "[-1L, 128L, 256L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }]

--- a/api/tests/configs/zeros_like.json
+++ b/api/tests/configs/zeros_like.json
@@ -10,7 +10,8 @@
             "shape": "[30522L, 1024L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 10000
 }, {
     "op": "zeros_like",
     "param_info": {

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -159,7 +159,8 @@ def _is_tensorflow_enabled(args, config):
 
 
 def _adaptive_repeat(config, args):
-    if args.allow_adaptive_repeat and hasattr(config, "repeat"):
+    if args.task == "speed" and args.allow_adaptive_repeat and hasattr(
+            config, "repeat"):
         if args.use_gpu and args.repeat < config.repeat:
             args.repeat = config.repeat
 

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -87,6 +87,11 @@ def parse_args():
     parser.add_argument(
         '--repeat', type=int, default=1, help='Iterations of Repeat running')
     parser.add_argument(
+        '--allow_adaptive_repeat',
+        type=utils.str2bool,
+        default=False,
+        help='Whether use the value repeat in json config [True|False]')
+    parser.add_argument(
         '--log_level', type=int, default=0, help='level of logging')
     args = parser.parse_args()
     if args.task not in ["speed", "accuracy"]:
@@ -153,10 +158,17 @@ def _is_tensorflow_enabled(args, config):
     return False
 
 
+def _adaptive_repeat(config, args):
+    if args.allow_adaptive_repeat and hasattr(config, "repeat"):
+        if args.use_gpu and args.repeat < config.repeat:
+            args.repeat = config.repeat
+
+
 def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
     assert config is not None, "API config must be set."
 
     args = parse_args()
+    _adaptive_repeat(config, args)
     config.backward = args.backward
     use_feed_fetch = True if args.task == "accuracy" else False
 

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export CUDA_VISIBLE_DEVICES="1"
+export CUDA_VISIBLE_DEVICES="0"   # Set to "" if testing CPU
 #export GLOG_vmodule=operator=4
 #export LD_LIBRARY_PATH=/work/cudnn/cudnn-7.6.5/lib64:${LD_LIBRARY_PATH}
 
@@ -15,17 +15,28 @@ export PYTHONPATH=${OP_BENCHMARK_ROOT}:${PYTHONPATH}
 
 name=${1:-"abs"}
 config_id=${2:-"0"}
-api_name=${3:-"${name}"}
-filename="${OP_BENCHMARK_ROOT}/tests/examples/${name}.json"
+
+task="accuracy"     # "accuracy" or "speed"
+framework="paddle"  # "paddle" or "tensorflow"
+filename="${OP_BENCHMARK_ROOT}/tests/configs/${name}.json"
+
+run_args="--task ${task} \
+          --framework ${framework} \
+          --json_file ${filename} \
+          --config_id ${config_id} \
+          --check_output False \
+          --profiler none \
+          --backward False \
+          --use_gpu True \
+          --repeat 1 \
+          --allow_adaptive_repeat False \
+          --log_level 0"
+
+if [ $# -ge 3 ]; then
+  api_name=${3}
+  run_args="${run_args} \
+            --api_name ${api_name}"
+fi
 
 python -m tests.launch ${OP_BENCHMARK_ROOT}/tests/${name}.py \
-      --task "accuracy" \
-      --framework "paddle" \
-      --json_file ${filename} \
-      --config_id ${config_id} \
-      --check_output False \
-      --profiler "none" \
-      --backward False \
-      --use_gpu True \
-      --repeat 1 \
-      --log_level 0
+         ${run_args}


### PR DESCRIPTION
OP测试时，虽然已经能够避免了每次feed和fetch，但初始化的HtoD Memcpy无法避免。
- paddle的abs
```
run command: nvprof /usr/local/python2.7.15/bin/python /work/benchmark/api/tests/abs.py --api_name abs --task speed --framework paddle --json_file /work/benchmark/api/tests/configs/activation.json --config_id 0 --backward False --use_gpu True --repeat 1000
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   93.81%  1.41084s      1001  1.4094ms  1.3686ms  1.4216ms  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_abs_op<float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, int>(float, int=1)
                    6.19%  93.157ms         8  11.645ms  1.7920us  93.143ms  [CUDA memcpy HtoD]
```

- tensorflow的abs
```
run command: nvprof /usr/local/python2.7.15/bin/python /work/benchmark/api/tests/abs.py --api_name abs --task speed --framework tensorflow --json_file /work/benchmark/api/tests/configs/activation.json --config_id 0 --backward False --use_gpu True --repeat 1000
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   94.55%  1.41082s      1001  1.4094ms  1.4015ms  1.4199ms  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, int>(float, int=1)
                    5.45%  81.367ms         2  40.684ms  1.6960us  81.365ms  [CUDA memcpy HtoD]
```

从上述nvprof的log可以看出，Paddle有8次HtoD，TensorFlow有2次HtoD。因GPU时间是通过提取第一个GPU activities的`Time / Time(%)`得到的，如果HtoD所占比例太高，得到的GPU时间就不够准确。如上述case，真正有效的GPU时间为1.41084s，实际计算得到的GPU时间为 1.41084s / 93.81% = 1.50393 ms，1.41 vs 1.50的差别还是比较大，不可忽视。因此可通过增大repeat次数，减少HtoD所占时间的比例，以提高实际计算得到的GPU时间的准确性。

这个PR通过在每个json配置中加一个repeat设置，测试时通过设置`--allow_adaptive_repeat True`，允许speed任务、gpu测试时，自动调整repeat值。