### PR TITLE
Enhance scripts for several ops

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -137,7 +137,6 @@ class APIConfig(object):
         self.params_list = None
         self.backward = False
         self.feed_spec = None
-        self.atol = 1e-6
         self.run_tf = True
 
     def alias_filename(self, filename):
@@ -179,6 +178,7 @@ class APIConfig(object):
         if hasattr(self, "alias_config"):
             self.alias_config.init_from_json(
                 self.alias_filename(filename), config_id)
+            self.atol = self.alias_config.atol
             return self
 
         print("---- Initialize APIConfig from %s, config_id = %d.\n" %
@@ -190,6 +190,8 @@ class APIConfig(object):
                 "The filename: %s, config_id: %d." % (
                     op, self.name, self.alias_name, filename, config_id)
             self.params = data[config_id]["param_info"]
+
+            self.atol = 1e-6
             if data[config_id].get("atol", None) is not None:
                 if isinstance(data[config_id]["atol"], str):
                     self.atol = float(data[config_id]["atol"])
@@ -237,11 +239,6 @@ class APIConfig(object):
         for attr in self.alias.params_list:
             params_str = params_str + attr.to_string() + "\n"
         return params_str
-
-    def clear(self):
-        for name in vars(self).keys():
-            if name not in ['name', 'backward', 'feed_spec']:
-                setattr(self, name, None)
 
     def __str__(self):
         if hasattr(self, "alias_config"):

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -130,15 +130,24 @@ def _check_type(output1, output2):
     return output1, output2
 
 
-def _check_shape(output1, output2, i):
-    shape1 = list(output1.shape)
-    shape2 = list(output2.shape)
-    if shape1 == shape2 + [1]:
-        output2 = np.reshape(output2, output1.shape)
-    elif shape1 + [1] == shape2:
-        output1 = np.reshape(output1, output2.shape)
-    assert output1.shape == output2.shape, "The %d-the output's shape is different, %s vs %s." % (
-        i, str(output1.shape), str(output2.shape))
+def _check_shape(name, output1, output2, i):
+    if name in ["reshape", "squeeze", "unsqueeze"]:
+        assert output1.shape == output2.shape, "The %d-the output's shape is different, %s vs %s." % (
+            i, str(output1.shape), str(output2.shape))
+        return output1, output2
+
+    if output1.shape != output2.shape:
+        output1_squeezed = np.squeeze(output1)
+        output2_squeezed = np.squeeze(output2)
+        if output1_squeezed.shape != output2_squeezed.shape:
+            raise RuntimeError(
+                "The %d-the output's shape is different, %s vs %s." % (
+                    i, str(output1.shape), str(output2.shape)))
+        else:
+            print(
+                "The %d-the output's shape is compatible (same after squeezed), %s vs %s."
+                % (i, str(output1.shape), str(output2.shape)))
+        return output1_squeezed, output2_squeezed
     return output1, output2
 
 
@@ -175,7 +184,7 @@ def check_outputs(list1,
             output2 = list2[i]
 
             output1, output2 = _check_type(output1, output2)
-            output1, output2 = _check_shape(output1, output2, i)
+            output1, output2 = _check_shape(name, output1, output2, i)
 
             if output1.dtype != output2.dtype:
                 print(

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -154,7 +154,7 @@ def _check_shape(name, output1, output2, i):
 def check_outputs(list1,
                   list2,
                   name,
-                  atol=1e-6,
+                  atol=1E-6,
                   backward=False,
                   config_params=None):
     if not isinstance(list1, list) or not isinstance(list2, list):
@@ -192,13 +192,13 @@ def check_outputs(list1,
                     % (i, str(output1.dtype), str(output2.dtype)))
 
             max_diff_i, offset_i = _compare(output1, output2, atol)
-            if max_diff_i > atol:
+            if max_diff_i > 1E-6:
                 print(
                     "---- The %d-th output (shape: %s, data type: %s) has diff. "
-                    "The maximum diff is %e, offset is %d: %s vs %s." %
-                    (i, str(output1.shape), str(output1.dtype), max_diff_i,
-                     offset_i, str(output1.flatten()[offset_i]),
-                     str(output2.flatten()[offset_i])))
+                    "The maximum diff is %e, offset is %d: %s vs %s. atol is %.2e."
+                    % (i, str(output1.shape), str(output1.dtype), max_diff_i,
+                       offset_i, str(output1.flatten()[offset_i]),
+                       str(output2.flatten()[offset_i]), atol))
 
             max_diff = max_diff_i if max_diff_i > max_diff else max_diff
             if max_diff > atol:

--- a/api/tests/configs/conv2d.json
+++ b/api/tests/configs/conv2d.json
@@ -87,7 +87,8 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "atol": 0.01
 }, {
     "op": "conv2d",
     "param_info": {
@@ -132,7 +133,8 @@
             "type": "bool",
             "value": "True"
         }
-    }
+    },
+    "atol": 0.001
 }, {
     "op": "conv2d",
     "param_info": {
@@ -177,7 +179,8 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "atol": 0.0001
 }, {
     "op": "conv2d",
     "param_info": {
@@ -447,7 +450,8 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "atol": 0.001
 }, {
     "op": "conv2d",
     "param_info": {
@@ -627,7 +631,8 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "atol": 0.00001
 }, {
     "op": "conv2d",
     "param_info": {
@@ -807,7 +812,8 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "atol": 0.00001
 }, {
     "op": "conv2d",
     "param_info": {
@@ -852,7 +858,8 @@
             "type": "bool",
             "value": "True"
         }
-    }
+    },
+    "atol": 0.01
 }, {
     "op": "conv2d",
     "param_info": {
@@ -897,7 +904,8 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "atol": 0.01
 }, {
     "op": "conv2d",
     "param_info": {

--- a/api/tests/configs/matmul.json
+++ b/api/tests/configs/matmul.json
@@ -49,7 +49,8 @@
             "shape": "[1500L, 10000L]",
             "type": "Variable"
         }
-    }
+    },
+    "atol": 0.001
 }, {
     "op": "matmul",
     "param_info": {

--- a/api/tests/configs/reduce.json
+++ b/api/tests/configs/reduce.json
@@ -14,7 +14,8 @@
             "type": "bool",
             "value": "True"
         }
-    }
+    },
+    "atol": 0.0001
 }, {
     "op": "reduce",
     "param_info": {
@@ -65,5 +66,6 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "atol": 0.001
 }]

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -20,9 +20,10 @@ class Conv2dConfig(APIConfig):
         super(Conv2dConfig, self).__init__('conv2d')
         self.feed_spec = [
             {
-                "range": [0, 1]
+                "range": [-1, 1]
             },  # input
             {
+                "range": [-1, 1],
                 "permute": [2, 3, 1, 0]
             }  # filters
         ]
@@ -53,8 +54,8 @@ class Conv2dConfig(APIConfig):
     def to_tensorflow(self):
         tf_config = super(Conv2dConfig, self).to_tensorflow()
         tf_config.filter_shape = [
-            self.filter_size[0], self.filter_size[1], self.num_channels,
-            self.num_filters
+            self.filter_size[0], self.filter_size[1],
+            self.num_channels // self.groups, self.num_filters
         ]
         tf_config.padding = self._convert_padding(self.padding)
         return tf_config

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -30,6 +30,10 @@ class Conv2dConfig(APIConfig):
 
     def init_from_json(self, filename, config_id=0):
         super(Conv2dConfig, self).init_from_json(filename, config_id)
+        if self.input_dtype == "float16" and self.use_cudnn == False:
+            self.disabled = True
+            return
+
         if self.data_format == "NCHW":
             self.num_channels = self.input_shape[1]
         elif self.data_format == "NHWC":

--- a/api/tests/conv2d_transpose.py
+++ b/api/tests/conv2d_transpose.py
@@ -57,7 +57,7 @@ class Conv2dTransposeConfig(APIConfig):
         tf_config = super(Conv2dTransposeConfig, self).to_tensorflow()
         tf_config.filter_shape = [
             self.filter_size[0], self.filter_size[1], self.num_filters,
-            self.num_channels
+            self.num_channels // self.groups
         ]
         return tf_config
 

--- a/api/tests/elementwise.py
+++ b/api/tests/elementwise.py
@@ -21,7 +21,6 @@ class ElementwiseConfig(APIConfig):
     def __init__(self):
         super(ElementwiseConfig, self).__init__('elementwise')
         self.api_name = 'elementwise_add'
-        self.atol = 1e-3
         self.api_list = {
             'elementwise_add': 'add',
             'elementwise_div': 'divide',
@@ -31,6 +30,7 @@ class ElementwiseConfig(APIConfig):
             'elementwise_mul': 'multiply',
             'elementwise_pow': 'pow'
         }
+        self.feed_spec = [{"range": [-1, 1]}, {"range": [-1, 1]}]
 
     def to_tensorflow(self):
         tf_config = super(ElementwiseConfig, self).to_tensorflow()
@@ -59,7 +59,7 @@ class PDElementwise(PaddleAPIBenchmarkBase):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
         result = self.layers(
-            config.api_name, x=x, y=y, axis=config.axis, act=config.act)
+            config.api_name, x=x, y=y, axis=config.axis, act=None)
 
         self.feed_vars = [x, y]
         self.fetch_vars = [result]

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -155,6 +155,10 @@ def _is_tensorflow_enabled(args, config):
 
 def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
     assert config is not None, "API config must be set."
+    if hasattr(config, "disabled") and config.disabled:
+        warnings.simplefilter('always', UserWarning)
+        warnings.warn("This config is disabled.")
+        return
 
     args = parse_args()
     config.backward = args.backward

--- a/api/tests/matmul.py
+++ b/api/tests/matmul.py
@@ -15,6 +15,12 @@
 from common_import import *
 
 
+class MatmulConfig(APIConfig):
+    def __init__(self):
+        super(MatmulConfig, self).__init__("matmul")
+        self.feed_spec = [{"range": [-1, 1]}, {"range": [-1, 1]}]
+
+
 class PDMatmul(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
@@ -53,4 +59,4 @@ class TFMatmul(TensorflowAPIBenchmarkBase):
 
 
 if __name__ == '__main__':
-    test_main(PDMatmul(), TFMatmul(), config=APIConfig("matmul"))
+    test_main(PDMatmul(), TFMatmul(), config=MatmulConfig())

--- a/api/tests/reduce.py
+++ b/api/tests/reduce.py
@@ -18,8 +18,8 @@ from common_import import *
 class ReduceConfig(APIConfig):
     def __init__(self):
         super(ReduceConfig, self).__init__('reduce')
+        self.feed_spec = {"range": [-1, 1]}
         self.api_name = 'reduce_mean'
-        self.atol = 1e-5
         self.api_list = {
             'reduce_mean': 'reduce_mean',
             'reduce_sum': 'reduce_sum',

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -16,7 +16,7 @@ export PYTHONPATH=${OP_BENCHMARK_ROOT}:${PYTHONPATH}
 name=${1:-"abs"}
 config_id=${2:-"0"}
 api_name=${3:-"${name}"}
-filename="${OP_BENCHMARK_ROOT}/tests/examples/${name}.json"
+filename="${OP_BENCHMARK_ROOT}/tests/configs/${name}.json"
 
 python -m tests.launch ${OP_BENCHMARK_ROOT}/tests/${name}.py \
       --task "accuracy" \

--- a/api/tests/sequence_mask.py
+++ b/api/tests/sequence_mask.py
@@ -15,13 +15,31 @@
 from common_import import *
 
 
+class SequenceMaskConfig(APIConfig):
+    def __init__(self):
+        super(SequenceMaskConfig, self).__init__('sequence_mask')
+
+    def init_from_json(self, filename, config_id=0):
+        super(SequenceMaskConfig, self).init_from_json(filename, config_id)
+        if hasattr(self, "maxlen_shape"):
+            self.maxlen = 3
+
+
 class PDSequenceMask(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         data = self.variable(
             name='data', shape=config.x_shape, dtype=config.x_dtype)
-        # TODO: maxlen is a variable
+        if hasattr(config, "maxlen_shape"):
+            # maxlen is a Variable
+            maxlen = fluid.layers.fill_constant(
+                shape=config.maxlen_shape,
+                dtype=config.maxlen_dtype,
+                value=config.maxlen)
+        else:
+            maxlen = config.maxlen
+
         result = fluid.layers.sequence_mask(
-            x=data, maxlen=config.maxlen, dtype=config.dtype)
+            x=data, maxlen=maxlen, dtype=config.dtype)
 
         self.feed_vars = [data]
         self.fetch_vars = [result]
@@ -31,6 +49,8 @@ class TFSequenceMask(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
         data = self.variable(
             name='data', shape=config.x_shape, dtype=config.x_dtype)
+
+        # maxlen must be scalar for sequence_mask
         result = tf.sequence_mask(
             lengths=data,
             maxlen=config.maxlen,
@@ -41,5 +61,4 @@ class TFSequenceMask(TensorflowAPIBenchmarkBase):
 
 
 if __name__ == '__main__':
-    test_main(
-        PDSequenceMask(), TFSequenceMask(), config=APIConfig("sequence_mask"))
+    test_main(PDSequenceMask(), TFSequenceMask(), config=SequenceMaskConfig())


### PR DESCRIPTION
这个PR主要进行一下修改：

- 有些op，Paddle和TensorFlow的计算结果的shape不完全相同，比如gather_1。这个PR对结果的检查方式做了一些调整，修改成：除了reshape、squeeze、unsqueeze之外，输出结果squeeze之后的shape相同即可，并且通过log进行提示。
```
AssertionError: The 0-the output's shape is different, (16, 256, 14, 14) vs (16, 1, 256, 14, 14).
```

- 修复一些脚本错误，比如：
    - elementwise不应设置act
    - sequence_mask的maxlen参数，支持Variable类型
    - 一些存在累加求和操作的op，输入变量的feed范围应设置成[-1, 1]
    
- 给一些配置设置atol，应尽量避免在op测试脚本中统一设置atol
- 将CI的测试目录切换到configs
