### PR TITLE
Split summary.py to four files and enhance summary of different level.

### DIFF
--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -302,6 +302,6 @@ def print_benchmark_result(result, log_level=0, config_params=None):
     status["speed"]["wall_time"] = avg_walltime
     status["speed"]["total_include_wall_time"] = avg_runtime
     if gpu_time is not None:
-        status["speed"]["gpu_time"] = gpu_time / repeat
+        status["speed"]["gpu_time"] = gpu_time
     status["parameters"] = config_params
     print(json.dumps(status))

--- a/api/deploy/op_benchmark_unit.py
+++ b/api/deploy/op_benchmark_unit.py
@@ -1,0 +1,229 @@
+#!/bin/python
+
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os, sys
+
+package_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(package_path)
+
+from common import special_op_list
+
+
+def parse_op_type(case_name):
+    import re
+    return re.sub("_[0-9]*$", "", case_name)
+
+
+def _compare(time1, time2):
+    try:
+        ratio = float(time1) / float(time2)
+        if float(time1) > 0 and float(time2) < 0:
+            result_str = "Less"
+        elif ratio <= 0.95:
+            result_str = "Better"
+        elif ratio >= 1.05:
+            result_str = "Less"
+        else:
+            result_str = "Equal"
+        return result_str
+    except Exception:
+        return "--"
+
+
+class OpBenchmarkUnit(object):
+    def __init__(self, case_detail):
+        self.case_name = case_detail["name"]
+        self.op_type = parse_op_type(self.case_name)
+
+        if case_detail.get("parameters", None):
+            parameters = case_detail["parameters"].encode("utf-8")
+            parameters = parameters.replace(" ", "")
+            parameters = parameters.replace("\n", " ")
+        else:
+            parameters = "--"
+        self.parameters = parameters
+
+        self.gpu_forward = {}
+        self.gpu_backward = {}
+        self.cpu_forward = {}
+        self.cpu_backward = {}
+        for device in ["gpu", "cpu"]:
+            for direction in ["forward", "backward"]:
+                attr_name = device + "_" + direction
+                result = getattr(self, attr_name)
+
+                paddle_total, paddle_gpu_time = self._get_case_value(
+                    case_detail, "paddle", device, "speed", direction)
+                result["paddle"] = {
+                    "total": paddle_total,
+                    "gpu_time": paddle_gpu_time
+                }
+
+                tf_total, tf_gpu_time = self._get_case_value(
+                    case_detail, "tensorflow", device, "speed", direction)
+                result["tensorflow"] = {
+                    "total": tf_total,
+                    "gpu_time": tf_gpu_time
+                }
+                result["compare"] = {
+                    "total": _compare(paddle_total, tf_total),
+                    "gpu_time": _compare(paddle_gpu_time, tf_gpu_time)
+                }
+
+                accuracy = self._get_case_value(case_detail, "paddle", device,
+                                                "accuracy", direction)
+                result["accuracy"] = str(accuracy)
+
+    def __str__(self):
+        debug_str = "case_name    : " + self.case_name + "\n"
+        debug_str += "op_type      : " + self.op_type + "\n"
+        debug_str += "gpu_forward  : " + str(self.gpu_forward) + "\n"
+        debug_str += "gpu_backward : " + str(self.gpu_backward) + "\n"
+        debug_str += "cpu_forward  : " + str(self.cpu_forward) + "\n"
+        debug_str += "cpu_backward : " + str(self.cpu_backward) + "\n"
+        return debug_str
+
+    def to_string(self, device, direction, with_parameters):
+        attr_name = device + "_" + direction
+        result = getattr(self, attr_name)
+
+        case_line = "%s" % self.case_name.ljust(40)
+        time_set = ["total"] if device == "cpu" else ["total", "gpu_time"]
+        for key in time_set:
+            case_line += "%s%s%s" % (result["paddle"][key].ljust(20),
+                                     result["tensorflow"][key].ljust(20),
+                                     result["compare"][key].ljust(10))
+        case_line += "%s" % result["accuracy"].ljust(10)
+        if with_parameters:
+            case_line += parameters
+        return case_line
+
+    def get(self, device, direction):
+        attr_name = device + "_" + direction
+        return getattr(self, attr_name)
+
+    def get_compare_value(self, device, direction):
+        attr_name = device + "_" + direction
+        result = getattr(self, attr_name)
+
+        total = result["compare"]["total"]
+        if total == "--":
+            if direction == "backward" and self.op_type in special_op_list.NO_BACKWARD_OPS:
+                total = "Unsupport"
+            else:
+                total = "Unkown"
+        if device == "gpu":
+            gpu_time = result["compare"]["gpu_time"]
+            if gpu_time == "--":
+                if direction == "backward" and self.op_type in special_op_list.NO_BACKWARD_OPS:
+                    gpu_time = "Unsupport"
+                else:
+                    gpu_time = "Unkown"
+            return total, gpu_time
+        else:
+            return total, None
+
+    def _get_case_value(self, case_detail, framework, device, task, direction):
+        assert framework in ["paddle", "tensorflow"]
+        assert device in ["cpu", "gpu"]
+        assert task in ["speed", "accuracy"]
+        assert direction in ["forward", "backward"]
+
+        if task == "accuracy":
+            try:
+                key = "paddle_" + device + "_accuracy_" + direction
+                return case_detail[key]
+            except Exception:
+                return "--"
+        else:
+            try:
+                total_key = framework + "_" + device + "_speed_" + direction
+                if device == "cpu":
+                    return case_detail[total_key], "--"
+
+                framework_alias = "" if framework == "paddle" else "tf_"
+                direction_alias = "" if direction == "forward" else "_backward"
+                gpu_time_key = framework_alias + "gpu_time" + direction_alias
+                return case_detail[total_key], case_detail[gpu_time_key]
+            except Exception:
+                return "--", "--"
+
+
+def summary_compare_result(benchmark_result_list, op_type=None):
+    compare_result_list = {}
+    compare_result_key_list = [
+        "Better", "Equal", "Less", "Unkown", "Unsupport", "Total"
+    ]
+    for result_type in [
+            "gpu_forward_total", "gpu_forward_kernel", "gpu_backward_total",
+            "gpu_backward_kernel", "cpu_forward_total", "cpu_backward_total"
+    ]:
+        compare_result_list[result_type] = {}
+        for compare_result_key in compare_result_key_list:
+            compare_result_list[result_type][compare_result_key] = 0
+
+    for op_unit in benchmark_result_list:
+        for device in ["gpu", "cpu"]:
+            for direction in ["forward", "backward"]:
+                result_type = device + "_" + direction
+
+                compare_result_total, compare_result_kernel = op_unit.get_compare_value(
+                    device, direction)
+                compare_result_list[result_type + "_total"][
+                    compare_result_total] += 1
+                compare_result_list[result_type + "_total"]["Total"] += 1
+                if device == "gpu":
+                    compare_result_list[result_type + "_kernel"][
+                        compare_result_kernel] += 1
+                    compare_result_list[result_type + "_kernel"]["Total"] += 1
+
+    if op_type is None:
+        category_width = 24
+        compare_result_str = "%s" % (" ".ljust(category_width))
+    else:
+        category_width = 24 if len(op_type) < 24 else len(op_type) + 4
+        compare_result_str = "%s" % (op_type.ljust(category_width))
+
+    content_width = 16
+    for compare_result_key in compare_result_key_list:
+        compare_result_str += "%s" % compare_result_key.ljust(content_width)
+    compare_result_str += "\n"
+
+    for key, value in sorted(compare_result_list.items(), reverse=True):
+        compare_result_str += "%s" % key.ljust(category_width)
+        num_total_cases = value["Total"]
+        for compare_result_key in compare_result_key_list:
+            ratio = float(value[compare_result_key]) / float(num_total_cases)
+            ratio_str = "%.2f" % (ratio * 100)
+            this_str = "{} ({}%)".format(value[compare_result_key], ratio_str)
+            compare_result_str += "%s" % str(this_str).ljust(content_width)
+        compare_result_str += "\n"
+    print(compare_result_str)
+    return compare_result_list, compare_result_str
+
+
+def summary_compare_result_for_op(benchmark_result_list):
+    benchmark_result_dict = {}
+    for op_unit in benchmark_result_list:
+        op_type = op_unit.op_type
+        if op_type not in benchmark_result_dict.keys():
+            benchmark_result_dict[op_type] = []
+        benchmark_result_dict[op_type].append(op_unit)
+
+    for op_type, result in sorted(benchmark_result_dict.items()):
+        _, _ = summary_compare_result(result, op_type)

--- a/api/deploy/summary.py
+++ b/api/deploy/summary.py
@@ -1,5 +1,5 @@
 #!/bin/python
-#coding=utf-8
+
 #   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,156 +20,15 @@ from __future__ import print_function
 
 import os, sys
 import json
-import time
 import argparse
 
 package_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(package_path)
 
 from common import utils
-from common import special_op_list
+import op_benchmark_unit
 
 res = {}
-
-
-def _compare(time1, time2):
-    try:
-        ratio = float(time1) / float(time2)
-        if float(time1) > 0 and float(time2) < 0:
-            result_str = "Less"
-        elif ratio <= 0.95:
-            result_str = "Better"
-        elif ratio >= 1.05:
-            result_str = "Less"
-        else:
-            result_str = "Equal"
-        return result_str
-    except Exception:
-        return "--"
-
-
-def parse_op_type(case_name):
-    import re
-    return re.sub("_[0-9]*$", "", case_name)
-
-
-class OpBenchmarkUnit(object):
-    def __init__(self, case_detail):
-        self.case_name = case_detail["name"]
-        self.op_type = parse_op_type(self.case_name)
-
-        if case_detail.get("parameters", None):
-            parameters = case_detail["parameters"].encode("utf-8")
-            parameters = parameters.replace(" ", "")
-            parameters = parameters.replace("\n", " ")
-        else:
-            parameters = "--"
-        self.parameters = parameters
-
-        self.gpu_forward = {}
-        self.gpu_backward = {}
-        self.cpu_forward = {}
-        self.cpu_backward = {}
-        for device in ["gpu", "cpu"]:
-            for direction in ["forward", "backward"]:
-                attr_name = device + "_" + direction
-                result = getattr(self, attr_name)
-
-                paddle_total, paddle_gpu_time = self._get_case_value(
-                    case_detail, "paddle", device, "speed", direction)
-                result["paddle"] = {
-                    "total": paddle_total,
-                    "gpu_time": paddle_gpu_time
-                }
-
-                tf_total, tf_gpu_time = self._get_case_value(
-                    case_detail, "tensorflow", device, "speed", direction)
-                result["tensorflow"] = {
-                    "total": tf_total,
-                    "gpu_time": tf_gpu_time
-                }
-                result["compare"] = {
-                    "total": _compare(paddle_total, tf_total),
-                    "gpu_time": _compare(paddle_gpu_time, tf_gpu_time)
-                }
-
-                accuracy = self._get_case_value(case_detail, "paddle", device,
-                                                "accuracy", direction)
-                result["accuracy"] = str(accuracy)
-
-    def __str__(self):
-        debug_str = "case_name    : " + self.case_name + "\n"
-        debug_str += "op_type      : " + self.op_type + "\n"
-        debug_str += "gpu_forward  : " + str(self.gpu_forward) + "\n"
-        debug_str += "gpu_backward : " + str(self.gpu_backward) + "\n"
-        debug_str += "cpu_forward  : " + str(self.cpu_forward) + "\n"
-        debug_str += "cpu_backward : " + str(self.cpu_backward) + "\n"
-        return debug_str
-
-    def to_string(self, device, direction, with_parameters):
-        attr_name = device + "_" + direction
-        result = getattr(self, attr_name)
-
-        case_line = "%s" % self.case_name.ljust(40)
-        time_set = ["total"] if device == "cpu" else ["total", "gpu_time"]
-        for key in time_set:
-            case_line += "%s%s%s" % (result["paddle"][key].ljust(20),
-                                     result["tensorflow"][key].ljust(20),
-                                     result["compare"][key].ljust(10))
-        case_line += "%s" % result["accuracy"].ljust(10)
-        if with_parameters:
-            case_line += parameters
-        return case_line
-
-    def get(self, device, direction):
-        attr_name = device + "_" + direction
-        return getattr(self, attr_name)
-
-    def get_compare_value(self, device, direction):
-        attr_name = device + "_" + direction
-        result = getattr(self, attr_name)
-
-        total = result["compare"]["total"]
-        if total == "--":
-            if direction == "backward" and self.op_type in special_op_list.NO_BACKWARD_OPS:
-                total = "Unsupport"
-            else:
-                total = "Unkown"
-        if device == "gpu":
-            gpu_time = result["compare"]["gpu_time"]
-            if gpu_time == "--":
-                if direction == "backward" and self.op_type in special_op_list.NO_BACKWARD_OPS:
-                    gpu_time = "Unsupport"
-                else:
-                    gpu_time = "Unkown"
-            return total, gpu_time
-        else:
-            return total, None
-
-    def _get_case_value(self, case_detail, framework, device, task, direction):
-        assert framework in ["paddle", "tensorflow"]
-        assert device in ["cpu", "gpu"]
-        assert task in ["speed", "accuracy"]
-        assert direction in ["forward", "backward"]
-
-        if task == "accuracy":
-            try:
-                key = "paddle_" + device + "_accuracy_" + direction
-                return case_detail[key]
-            except Exception:
-                return "--"
-        else:
-            try:
-                total_key = framework + "_" + device + "_speed_" + direction
-                if device == "cpu":
-                    return case_detail[total_key], "--"
-
-                framework_alias = "" if framework == "paddle" else "tf_"
-                direction_alias = "" if direction == "forward" else "_backward"
-                gpu_time_key = framework_alias + "gpu_time" + direction_alias
-                return case_detail[total_key], case_detail[gpu_time_key]
-            except Exception:
-                return "--", "--"
 
 
 def _read_last_line(inputfile):
@@ -289,7 +148,7 @@ def get_job_res(inputfile, specified_op_list=None):
     """
     filename = os.path.splitext(os.path.basename(inputfile))[0]
     case_name = filename.split("-")[0]
-    op_type = parse_op_type(case_name)
+    op_type = op_benchmark_unit.parse_op_type(case_name)
     if specified_op_list and op_type not in specified_op_list:
         return res
 
@@ -325,288 +184,6 @@ def read_frequency_from_text(op_frequency_path):
                 continue
             op_frequency_dict[contents[1]] = int(contents[2])
     return op_frequency_dict
-
-
-def summary_compare_result(benchmark_result_list, level="case"):
-    compare_result_list = {}
-    compare_result_key_list = [
-        "Better", "Equal", "Less", "Unkown", "Unsupport", "Total"
-    ]
-    for result_type in [
-            "gpu_forward_total", "gpu_forward_kernel", "gpu_backward_total",
-            "gpu_backward_kernel", "cpu_forward_total", "cpu_backward_total"
-    ]:
-        compare_result_list[result_type] = {}
-        for compare_result_key in compare_result_key_list:
-            compare_result_list[result_type][compare_result_key] = 0
-
-    for op_unit in benchmark_result_list:
-        for device in ["gpu", "cpu"]:
-            for direction in ["forward", "backward"]:
-                result_type = device + "_" + direction
-
-                compare_result_total, compare_result_kernel = op_unit.get_compare_value(
-                    device, direction)
-                compare_result_list[result_type + "_total"][
-                    compare_result_total] += 1
-                compare_result_list[result_type + "_total"]["Total"] += 1
-                if device == "gpu":
-                    compare_result_list[result_type + "_kernel"][
-                        compare_result_kernel] += 1
-                    compare_result_list[result_type + "_kernel"]["Total"] += 1
-
-    compare_result_str = "%s" % (" ".ljust(24))
-    for compare_result_key in compare_result_key_list:
-        compare_result_str += "%s" % compare_result_key.ljust(16)
-    compare_result_str += "\n"
-    for key, value in sorted(compare_result_list.items(), reverse=True):
-        compare_result_str += "%s" % key.ljust(24)
-        num_total_cases = value["Total"]
-        for compare_result_key in compare_result_key_list:
-            ratio = float(value[compare_result_key]) / float(num_total_cases)
-            ratio_str = "%.2f" % (ratio * 100)
-            this_str = "{} ({}%)".format(value[compare_result_key], ratio_str)
-            compare_result_str += "%s" % str(this_str).ljust(16)
-        compare_result_str += "\n"
-    print(compare_result_str)
-    return compare_result_list, compare_result_str
-
-
-def dump_text(benchmark_result_list, output_path, dump_with_parameters):
-    if output_path is None:
-        timestamp = time.strftime('%Y-%m-%d', time.localtime(int(time.time())))
-        output_path = "op_benchmark_summary-%s.txt" % timestamp
-        print("Output path is not specified, use %s." % output_path)
-
-    title_total = "%s%s%s" % ("Paddle(total)".ljust(20),
-                              "Tensorflow(total)".ljust(20),
-                              "status".ljust(10))
-    title_kernel = "%s%s%s" % ("Paddle(kernel)".ljust(20),
-                               "Tensorflow(kernel)".ljust(20),
-                               "status".ljust(10))
-    title_else = "%s%s" % ("accuracy".ljust(10), "paramaters")
-    gpu_title = "%s%s%s%s%s\n" % ("case_id".ljust(8), "case_name".ljust(40),
-                                  title_total, title_kernel, title_else)
-    cpu_title = "%s%s%s%s\n" % ("case_id".ljust(8), "case_name".ljust(40),
-                                title_total, title_else)
-
-    output_str_list = {
-        "gpu_forward": "",
-        "gpu_backward": "",
-        "cpu_forward": "",
-        "cpu_backward": ""
-    }
-
-    for case_id in range(len(benchmark_result_list)):
-        op_unit = benchmark_result_list[case_id]
-        for device in ["gpu", "cpu"]:
-            for direction in ["forward", "backward"]:
-                key = device + "_" + direction
-                case_line = "%s%s" % (
-                    str(case_id + 1).ljust(8),
-                    op_unit.to_string(device, direction, dump_with_parameters))
-                output_str_list[key] += case_line + "\n"
-
-    _, compare_result_str = summary_compare_result(benchmark_result_list)
-
-    with open(output_path, 'w') as f:
-        f.writelines(compare_result_str + "\n")
-        for direction in ["Forward", "Backward"]:
-            f.writelines(
-                "================================================================== %s Running on GPU ==================================================================\n"
-                % direction)
-            f.writelines(gpu_title.encode("utf-8"))
-            f.writelines(output_str_list["gpu_" + direction.lower()].encode(
-                "utf-8"))
-            f.writelines("\n")
-
-        for direction in ["Forward", "Backward"]:
-            f.writelines(
-                "========================================== %s Running on CPU =======================================\n"
-                % direction)
-            f.writelines(cpu_title.encode("utf-8"))
-            f.writelines(output_str_list["cpu_" + direction.lower()].encode(
-                "utf-8"))
-            f.writelines("\n")
-
-
-def _op_filename(case_name, framework, device, task, direction):
-    filename = case_name + "-" + framework + "_" + device + "_" + task + "_" + direction + ".txt"
-    return filename
-
-
-def _op_result_path(op_result_dir, case_name, framework, device, task,
-                    direction):
-    filename = _op_filename(case_name, framework, device, task, direction)
-    return os.path.abspath(os.path.join(op_result_dir, filename))
-
-
-def _op_result_url(url_prefix, case_name, framework, device, task, direction):
-    filename = _op_filename(case_name, framework, device, task, direction)
-    return os.path.join(url_prefix, filename)
-
-
-def dump_excel(benchmark_result_list,
-               op_result_dir,
-               url_prefix=None,
-               output_path=None,
-               op_frequency_dict=None):
-    """
-    dump data to a excel
-    """
-    import xlsxwriter as xlw
-
-    if output_path is None:
-        timestamp = time.strftime('%Y-%m-%d', time.localtime(int(time.time())))
-        output_path = "op_benchmark_summary-%s.xlsx" % timestamp
-        print("Output path is not specified, use %s." % output_path)
-
-    wb = xlw.Workbook(output_path)
-    align = wb.add_format({"align": "left"})
-    title_format = wb.add_format({
-        'bold': True,
-        'font_color': 'black',
-        'bg_color': '#6495ED'
-    })
-    cell_formats = {}
-    for underline in [False, True]:
-        for color in ["green", "red", "black"]:
-            key = color + "_underline" if underline else color
-            value = wb.add_format({
-                'bold': True,
-                'underline': underline,
-                'font_color': color
-            })
-            cell_formats[key] = value
-
-    compare_result_list, _ = summary_compare_result(benchmark_result_list)
-
-    summary_ws = wb.add_worksheet("summary")
-    summary_column_width = [40, 20, 20, 20, 20, 20, 20]
-    for col in range(len(summary_column_width)):
-        col_char = chr(ord("A") + col)
-        summary_ws.set_column(col_char + ":" + col_char,
-                              summary_column_width[col])
-    summary_title_names = [
-        "Better", "Equal", "Less", "Unkown", "Unsupport", "Total"
-    ]
-    for col in range(len(summary_title_names)):
-        summary_ws.write(0, col + 1, summary_title_names[col], title_format)
-
-    row = 1
-    for key, value in sorted(compare_result_list.items(), reverse=True):
-        summary_ws.write(row, 0, key)
-
-        col = 1
-        num_total_cases = value["Total"]
-        for compare_result_key in summary_title_names:
-            ratio = float(value[compare_result_key]) / float(num_total_cases)
-            ratio_str = "%.2f" % (ratio * 100)
-            this_str = "{} ({}%)".format(value[compare_result_key], ratio_str)
-            summary_ws.write(row, col, this_str)
-            col += 1
-        row += 1
-
-    if url_prefix:
-        print("url prefix: ", url_prefix)
-    for device in ["gpu", "cpu"]:
-        for direction in ["forward", "backward"]:
-            worksheet_name = device + "_" + direction
-            ws = wb.add_worksheet(worksheet_name)
-
-            title_names = ["case_name"]
-            column_width = [40]
-            if op_frequency_dict is not None:
-                title_names.append("frequency")
-                column_width.append(10)
-
-            time_set = ["total"] if device == "cpu" else ["total", "kernel"]
-            for key in time_set:
-                title_names.append("Paddle(%s)" % key)
-                title_names.append("Tensorflow(%s)" % key)
-                title_names.append("status")
-                column_width.append(20)
-                column_width.append(20)
-                column_width.append(10)
-            title_names.append("accuracy")
-            title_names.append("parameters")
-            column_width.append(10)
-            column_width.append(80)
-
-            for col in range(len(column_width)):
-                col_char = chr(ord("A") + col)
-                ws.set_column(col_char + ":" + col_char, column_width[col])
-
-            for col in range(len(title_names)):
-                ws.write(0, col, title_names[col], title_format)
-
-            for case_id in range(len(benchmark_result_list)):
-                op_unit = benchmark_result_list[case_id]
-                result = op_unit.get(device, direction)
-
-                row = case_id + 1
-                ws.write(row, 0, op_unit.case_name)
-
-                if op_frequency_dict is not None:
-                    num_frequency = 0
-                    if op_unit.op_type in op_frequency_dict.keys():
-                        num_frequency = op_frequency_dict[op_unit.op_type]
-                    ws.write_number(row, 1, num_frequency, align)
-                    col = 2
-                else:
-                    col = 1
-
-                time_set = ["total"
-                            ] if device == "cpu" else ["total", "gpu_time"]
-                for key in time_set:
-                    if result["compare"][key] == "Less":
-                        color = "red"
-                    elif result["compare"][key] == "Better":
-                        color = "green"
-                    else:
-                        color = "black"
-
-                    for framework in ["paddle", "tensorflow"]:
-                        op_time = result[framework][key]
-                        op_speed_path = _op_result_path(
-                            op_result_dir, op_unit.case_name, framework,
-                            device, "speed", direction)
-                        if url_prefix and os.path.exists(op_speed_path):
-                            op_speed_url = _op_result_url(
-                                url_prefix, op_unit.case_name, framework,
-                                device, "speed", direction)
-                            ws.write_url(
-                                row,
-                                col,
-                                url=op_speed_url,
-                                string=op_time,
-                                cell_format=cell_formats[color + "_underline"])
-                        else:
-                            ws.write(row, col, op_time, cell_formats[color])
-                        col += 1
-
-                    ws.write(row, col, result["compare"][key],
-                             cell_formats[color])
-                    col += 1
-
-                op_acc_path = _op_result_path(op_result_dir, op_unit.case_name,
-                                              "paddle", device, "accuracy",
-                                              direction)
-                if url_prefix and os.path.exists(op_acc_path):
-                    op_acc_url = _op_result_url(url_prefix, op_unit.case_name,
-                                                "paddle", device, "accuracy",
-                                                direction)
-                    ws.write_url(
-                        row,
-                        col,
-                        url=op_acc_url,
-                        string=result["accuracy"],
-                        cell_format=cell_formats["black_underline"])
-                else:
-                    ws.write(row, col, result["accuracy"],
-                             cell_formats["black"])
-                ws.write(row, col + 1, op_unit.parameters)
-    wb.close()
 
 
 def dump_mysql(data):
@@ -757,7 +334,7 @@ if __name__ == '__main__':
         case_detail['name'] = key
         data.append(case_detail)
 
-        op_unit = OpBenchmarkUnit(case_detail)
+        op_unit = op_benchmark_unit.OpBenchmarkUnit(case_detail)
         # print(op_unit)
         benchmark_result_list.append(op_unit)
 
@@ -766,12 +343,15 @@ if __name__ == '__main__':
         op_frequency_dict = read_frequency_from_text(args.op_frequency_path)
 
     if args.dump_to_text:
-        dump_text(benchmark_result_list, args.output_path,
-                  args.dump_with_parameters)
+        import write_text
+        write_text.dump_text(benchmark_result_list, args.output_path,
+                             args.dump_with_parameters)
 
     if args.dump_to_excel:
-        dump_excel(benchmark_result_list, op_result_dir, args.url_prefix,
-                   args.output_path, op_frequency_dict)
+        import write_excel
+        write_excel.dump_excel(benchmark_result_list, op_result_dir,
+                               args.url_prefix, args.output_path,
+                               op_frequency_dict)
 
     if args.dump_to_mysql:
         try:

--- a/api/deploy/write_excel.py
+++ b/api/deploy/write_excel.py
@@ -1,0 +1,199 @@
+#!/bin/python
+
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import xlsxwriter as xlw
+import op_benchmark_unit
+
+
+def _op_filename(case_name, framework, device, task, direction):
+    filename = case_name + "-" + framework + "_" + device + "_" + task + "_" + direction + ".txt"
+    return filename
+
+
+def _op_result_path(op_result_dir, case_name, framework, device, task,
+                    direction):
+    filename = _op_filename(case_name, framework, device, task, direction)
+    return os.path.abspath(os.path.join(op_result_dir, filename))
+
+
+def _op_result_url(url_prefix, case_name, framework, device, task, direction):
+    filename = _op_filename(case_name, framework, device, task, direction)
+    return os.path.join(url_prefix, filename)
+
+
+def _write_summary_worksheet(benchmark_result_list, workbook, title_format):
+    compare_result_list, _ = op_benchmark_unit.summary_compare_result(
+        benchmark_result_list)
+    op_benchmark_unit.summary_compare_result_for_op(benchmark_result_list)
+
+    ws = workbook.add_worksheet("summary")
+    column_width = [40, 20, 20, 20, 20, 20, 20]
+    for col in range(len(column_width)):
+        col_char = chr(ord("A") + col)
+        ws.set_column(col_char + ":" + col_char, column_width[col])
+    title_names = ["Better", "Equal", "Less", "Unkown", "Unsupport", "Total"]
+    for col in range(len(title_names)):
+        ws.write(0, col + 1, title_names[col], title_format)
+
+    row = 1
+    for key, value in sorted(compare_result_list.items(), reverse=True):
+        ws.write(row, 0, key)
+
+        col = 1
+        num_total_cases = value["Total"]
+        for compare_result_key in title_names:
+            ratio = float(value[compare_result_key]) / float(num_total_cases)
+            ratio_str = "%.2f" % (ratio * 100)
+            this_str = "{} ({}%)".format(value[compare_result_key], ratio_str)
+            ws.write(row, col, this_str)
+            col += 1
+        row += 1
+
+
+def dump_excel(benchmark_result_list,
+               op_result_dir,
+               url_prefix=None,
+               output_path=None,
+               op_frequency_dict=None):
+    """
+    dump data to a excel
+    """
+    if output_path is None:
+        timestamp = time.strftime('%Y-%m-%d', time.localtime(int(time.time())))
+        output_path = "op_benchmark_summary-%s.xlsx" % timestamp
+        print("Output path is not specified, use %s." % output_path)
+
+    wb = xlw.Workbook(output_path)
+    align = wb.add_format({"align": "left"})
+    title_format = wb.add_format({
+        'bold': True,
+        'font_color': 'black',
+        'bg_color': '#6495ED'
+    })
+    cell_formats = {}
+    for underline in [False, True]:
+        for color in ["green", "red", "black"]:
+            key = color + "_underline" if underline else color
+            value = wb.add_format({
+                'bold': True,
+                'underline': underline,
+                'font_color': color
+            })
+            cell_formats[key] = value
+
+    _write_summary_worksheet(benchmark_result_list, wb, title_format)
+
+    if url_prefix:
+        print("url prefix: ", url_prefix)
+    for device in ["gpu", "cpu"]:
+        for direction in ["forward", "backward"]:
+            worksheet_name = device + "_" + direction
+            ws = wb.add_worksheet(worksheet_name)
+
+            title_names = ["case_name"]
+            column_width = [40]
+            if op_frequency_dict is not None:
+                title_names.append("frequency")
+                column_width.append(10)
+
+            time_set = ["total"] if device == "cpu" else ["total", "kernel"]
+            for key in time_set:
+                title_names.append("Paddle(%s)" % key)
+                title_names.append("Tensorflow(%s)" % key)
+                title_names.append("status")
+                column_width.append(20)
+                column_width.append(20)
+                column_width.append(10)
+            title_names.append("accuracy")
+            title_names.append("parameters")
+            column_width.append(10)
+            column_width.append(80)
+
+            for col in range(len(column_width)):
+                col_char = chr(ord("A") + col)
+                ws.set_column(col_char + ":" + col_char, column_width[col])
+
+            for col in range(len(title_names)):
+                ws.write(0, col, title_names[col], title_format)
+
+            for case_id in range(len(benchmark_result_list)):
+                op_unit = benchmark_result_list[case_id]
+                result = op_unit.get(device, direction)
+
+                row = case_id + 1
+                ws.write(row, 0, op_unit.case_name)
+
+                if op_frequency_dict is not None:
+                    num_frequency = 0
+                    if op_unit.op_type in op_frequency_dict.keys():
+                        num_frequency = op_frequency_dict[op_unit.op_type]
+                    ws.write_number(row, 1, num_frequency, align)
+                    col = 2
+                else:
+                    col = 1
+
+                time_set = ["total"
+                            ] if device == "cpu" else ["total", "gpu_time"]
+                for key in time_set:
+                    if result["compare"][key] == "Less":
+                        color = "red"
+                    elif result["compare"][key] == "Better":
+                        color = "green"
+                    else:
+                        color = "black"
+
+                    for framework in ["paddle", "tensorflow"]:
+                        op_time = result[framework][key]
+                        op_speed_path = _op_result_path(
+                            op_result_dir, op_unit.case_name, framework,
+                            device, "speed", direction)
+                        if url_prefix and os.path.exists(op_speed_path):
+                            op_speed_url = _op_result_url(
+                                url_prefix, op_unit.case_name, framework,
+                                device, "speed", direction)
+                            ws.write_url(
+                                row,
+                                col,
+                                url=op_speed_url,
+                                string=op_time,
+                                cell_format=cell_formats[color + "_underline"])
+                        else:
+                            ws.write(row, col, op_time, cell_formats[color])
+                        col += 1
+
+                    ws.write(row, col, result["compare"][key],
+                             cell_formats[color])
+                    col += 1
+
+                op_acc_path = _op_result_path(op_result_dir, op_unit.case_name,
+                                              "paddle", device, "accuracy",
+                                              direction)
+                if url_prefix and os.path.exists(op_acc_path):
+                    op_acc_url = _op_result_url(url_prefix, op_unit.case_name,
+                                                "paddle", device, "accuracy",
+                                                direction)
+                    ws.write_url(
+                        row,
+                        col,
+                        url=op_acc_url,
+                        string=result["accuracy"],
+                        cell_format=cell_formats["black_underline"])
+                else:
+                    ws.write(row, col, result["accuracy"],
+                             cell_formats["black"])
+                ws.write(row, col + 1, op_unit.parameters)
+    wb.close()

--- a/api/deploy/write_text.py
+++ b/api/deploy/write_text.py
@@ -1,0 +1,73 @@
+#!/bin/python
+
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def dump_text(benchmark_result_list, output_path, dump_with_parameters):
+    if output_path is None:
+        timestamp = time.strftime('%Y-%m-%d', time.localtime(int(time.time())))
+        output_path = "op_benchmark_summary-%s.txt" % timestamp
+        print("Output path is not specified, use %s." % output_path)
+
+    title_total = "%s%s%s" % ("Paddle(total)".ljust(20),
+                              "Tensorflow(total)".ljust(20),
+                              "status".ljust(10))
+    title_kernel = "%s%s%s" % ("Paddle(kernel)".ljust(20),
+                               "Tensorflow(kernel)".ljust(20),
+                               "status".ljust(10))
+    title_else = "%s%s" % ("accuracy".ljust(10), "paramaters")
+    gpu_title = "%s%s%s%s%s\n" % ("case_id".ljust(8), "case_name".ljust(40),
+                                  title_total, title_kernel, title_else)
+    cpu_title = "%s%s%s%s\n" % ("case_id".ljust(8), "case_name".ljust(40),
+                                title_total, title_else)
+
+    output_str_list = {
+        "gpu_forward": "",
+        "gpu_backward": "",
+        "cpu_forward": "",
+        "cpu_backward": ""
+    }
+
+    for case_id in range(len(benchmark_result_list)):
+        op_unit = benchmark_result_list[case_id]
+        for device in ["gpu", "cpu"]:
+            for direction in ["forward", "backward"]:
+                key = device + "_" + direction
+                case_line = "%s%s" % (
+                    str(case_id + 1).ljust(8),
+                    op_unit.to_string(device, direction, dump_with_parameters))
+                output_str_list[key] += case_line + "\n"
+
+    _, compare_result_str = summary_compare_result(benchmark_result_list)
+
+    with open(output_path, 'w') as f:
+        f.writelines(compare_result_str + "\n")
+        for direction in ["Forward", "Backward"]:
+            f.writelines(
+                "================================================================== %s Running on GPU ==================================================================\n"
+                % direction)
+            f.writelines(gpu_title.encode("utf-8"))
+            f.writelines(output_str_list["gpu_" + direction.lower()].encode(
+                "utf-8"))
+            f.writelines("\n")
+
+        for direction in ["Forward", "Backward"]:
+            f.writelines(
+                "========================================== %s Running on CPU =======================================\n"
+                % direction)
+            f.writelines(cpu_title.encode("utf-8"))
+            f.writelines(output_str_list["cpu_" + direction.lower()].encode(
+                "utf-8"))
+            f.writelines("\n")

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -61,11 +61,11 @@ function fetch_upstream_master_if_not_exist() {
 function run_api(){
     fetch_upstream_master_if_not_exist
     HAS_MODIFIED_API_TEST=`git diff --name-status upstream/$BRANCH | awk '$1!="D" {print $2}' | grep "api/tests.*.py$" || true`
-    API_NAMES=(abs activation elementwise fc)
+    API_NAMES=(abs elementwise fc)
     if [ "${HAS_MODIFIED_API_TEST}" != "" ] ; then
         for api in ${HAS_MODIFIED_API_TEST[@]}; do
             new_name=`echo $api |awk -F "/" '{print $NF}' |awk -F "." '{print $NR}'`
-            if [[ "$new_name" != "main" && "$new_name" != "feeder" && "$new_name" != "common_ops" && "$new_name" != "launch" ]]; then
+            if [[ "$new_name" != "main" && "$new_name" != "common_ops" && "$new_name" != "launch" ]]; then
                 need_append="yes"
                 for name in ${API_NAMES[@]}; do
                     if [ "${name}" == "${new_name}" ]; then


### PR DESCRIPTION
这个PR主要有以下修改：

- 将summary.py拆分成4个文件
    - summary.py，全量op测试结果的提取、写入数据库、以及summary的主流程
    - op_benchmark_unit.py，一些基本单位的操作，包括统计比较结果
    - write_excel.py，写excel相关的实现
    - write_text.py，写文本文件相关的实现
- 强化了summary功能，现在支持case_level的汇总统计、op_level的汇总统计、每个op的汇总统计，具体如下：
![image](https://user-images.githubusercontent.com/12538138/86227493-aafbd580-bbbf-11ea-92af-34455bc63838.png)

- 修复了gpu_time计算的bug
