### PR TITLE
change TF use one cpu core

### DIFF
--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -384,7 +384,14 @@ class TensorflowAPIBenchmarkBase(object):
     def _init_session(self, use_gpu):
         if tf.__version__ >= "1.15.0":
             config = tf.compat.v1.ConfigProto()
-            config.gpu_options.allow_growth = self.allow_growth
+            if use_gpu:
+                config.gpu_options.allow_growth = self.allow_growth
+            else:
+                # In default, TF use full cpu cores, but Paddle use one cpu core.
+                # To make the same experiment, set TF use one cpu core as well.
+                # See https://github.com/PaddlePaddle/Paddle/issues/18665#issuecomment-513780210
+                config.intra_op_parallelism_threads = 1
+                config.inter_op_parallelism_threads = 1
             sess = tf.compat.v1.Session(config=config)
             sess.run(tf.compat.v1.global_variables_initializer())
             sess.run(tf.compat.v1.local_variables_initializer())


### PR DESCRIPTION
原因：跑CPU程序时，TF默认打满所有CPU，而Paddle只使用1个。导致CPU两者性能数据差比较多。详细分析见 https://github.com/PaddlePaddle/Paddle/issues/18665#issuecomment-513780210

本PR：

- 在CPU测试时，使TF也只使用1个CPU。以abs_0配置的CPU前向为例子（单位ms）

|   测试条件  | Paddle  | TF| 备注|
|  ----  | ----  |----  |----  |
| 虚拟机develop分支  | 555 | 1.45
| 物理机develop分支  | 20 |26 | TF的cpu利用率740%
| 物理机develop分支  | 20 |72 | TF的cpu利用率100% 

- 为了不影响GPU测试，用`use_gpu`进行判断。
