### PR TITLE
Support python3.

### DIFF
--- a/api/common/feeder.py
+++ b/api/common/feeder.py
@@ -14,12 +14,17 @@
 
 from __future__ import print_function
 
+import six
 import collections
 import numpy as np
 import paddle.fluid as fluid
 
-import paddle_api_benchmark as paddle_api
-import tensorflow_api_benchmark as tensorflow_api
+if six.PY3:
+    from . import paddle_api_benchmark as paddle_api
+    from . import tensorflow_api_benchmark as tensorflow_api
+else:
+    import paddle_api_benchmark as paddle_api
+    import tensorflow_api_benchmark as tensorflow_api
 
 
 def copy_feed_spec(feed_spec):

--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -21,11 +21,15 @@ import contextlib
 import importlib
 import logging
 import numpy as np
-import cProfile, pstats, StringIO
-import utils
 
-import api_param
-import feeder
+if six.PY3:
+    from . import utils
+    from . import api_param
+    from . import feeder
+else:
+    import utils
+    import api_param
+    import feeder
 
 try:
     import paddle
@@ -44,6 +48,8 @@ def profile_context(name, use_gpu, profiler):
                 profile_type, 'total', output_file, tracer_option=profiler):
             yield
     elif profiler == "pyprof":
+        import cProfile, pstats, StringIO
+
         profiler_handle = cProfile.Profile()
         profiler_handle.enable()
         yield

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -20,10 +20,15 @@ import time
 import abc, six
 import importlib
 import numpy as np
-import cProfile, pstats, StringIO
-import utils
-import api_param
-import feeder
+
+if six.PY3:
+    from . import utils
+    from . import api_param
+    from . import feeder
+else:
+    import utils
+    import api_param
+    import feeder
 
 try:
     import tensorflow as tf
@@ -48,6 +53,7 @@ class Profiler(object):
 
     def __enter__(self):
         if self.profiler == "pyprof":
+            import cProfile
             self.profiler_handle = cProfile.Profile()
             self.profiler_handle.enable()
         elif self.profiler != "none":
@@ -77,6 +83,7 @@ class Profiler(object):
 
     def __exit__(self, exception_type, exception_value, traceback):
         if self.profiler == "pyprof":
+            import pstats, StringIO
             self.profiler_handle.disable()
             # self.profiler_handle.dump_stats("./outputs/" + self.name + ".pyprof")
             s = StringIO.StringIO()

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -14,13 +14,18 @@
 
 from __future__ import print_function
 
+import six
 import os, sys
 import traceback
 import numpy as np
 import json
 import collections
 import subprocess
-import special_op_list
+
+if six.PY3:
+    from . import special_op_list
+else:
+    import special_op_list
 
 
 def str2bool(v):
@@ -179,7 +184,7 @@ def check_outputs(list1,
                 len(list1), len(list2))
 
         num_outputs = len(list1)
-        for i in xrange(num_outputs):
+        for i in range(num_outputs):
             output1 = list1[i]
             output2 = list2[i]
 


### PR DESCRIPTION
由于TF 2.2.0以后不再发布Python2.7版本的[whl包](https://pypi.org/project/tensorflow/2.2.0/#files)，因此为了测试最新TF版本的性能，OP Benchmark需要支持Python3。