### PR TITLE
 fixed out of mem

### DIFF
--- a/scripts/static_graph_models.sh
+++ b/scripts/static_graph_models.sh
@@ -29,13 +29,13 @@ CycleGAN(){
     cp ${BENCHMARK_ROOT}/static_graph/CycleGAN/paddle/run_benchmark.sh ./
     sed -i '/set\ -xe/d' run_benchmark.sh
     echo "index is speed, begin"
-    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 1 sp 300 | tee ${log_path}/${FUNCNAME}_speed_1gpus 2>&1
+    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 1 sp 600 | tee ${log_path}/${FUNCNAME}_speed_1gpus 2>&1
     sleep 60
     echo "index is speed, profiler is on, begin"
     CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 3 sp 300 | tee ${log_path}/${FUNCNAME}_speed_1gpus_profiler 2>&1
     sleep 60
     echo "index is mem, begin"
-    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 2 sp 300 | tee ${log_path}/${FUNCNAME}_mem_1gpus 2>&1
+    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 2 sp 600 | tee ${log_path}/${FUNCNAME}_mem_1gpus 2>&1
 }
 
 
@@ -209,13 +209,13 @@ Pix2pix(){
     sed -i '/set\ -xe/d' run_benchmark.sh
 
     echo "index is speed, begin"
-    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 1 Pix2pix sp 300 | tee ${log_path}/${FUNCNAME}_speed_1gpus 2>&1
+    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 1 Pix2pix sp 600 | tee ${log_path}/${FUNCNAME}_speed_1gpus 2>&1
     sleep 60
     echo "index is speed, profiler is on, begin"
     CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 3 Pix2pix sp 300 | tee ${log_path}/${FUNCNAME}_speed_1gpus_profiler 2>&1
     sleep 60
     echo "index is mem, begin"
-    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 2 Pix2pix sp 300 | tee ${log_path}/${FUNCNAME}_mem_1gpus 2>&1
+    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 2 Pix2pix sp 600 | tee ${log_path}/${FUNCNAME}_mem_1gpus 2>&1
 }
 
 
@@ -253,7 +253,7 @@ nextvlad(){
 
     sed -i '/set\ -xe/d' run_benchmark.sh
 
-    model_list=(nextvlad) #CTCN)
+    model_list=(nextvlad CTCN)
     for model_name in ${model_list[@]}; do
         echo "index is speed, 1gpu, begin, ${model_name}"
         PYTHONPATH=$(pwd):${PYTHONPATH} CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 1 32 ${model_name} sp 2 | tee ${log_path}/${model_name}_speed_1gpus 2>&1
@@ -533,18 +533,18 @@ transformer(){
     sleep 60
     echo "model_type is ${model_type}, index is speed, 8gpus, begin"
     CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 1 ${model_type} sp 600 | tee ${log_path}/${FUNCNAME}_${model_type}_speed_8gpus 2>&1
-    #sleep 60
-    #echo "model_type is ${model_type}, index is mem, 1gpus, begin"
-    #CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 2 ${model_type} sp 400 | tee ${log_path}/${FUNCNAME}_${model_type}_mem_1gpus 2>&1
-    #sleep 60
-    #echo "model_type is ${model_type}, index is mem, 8gpus, begin"
-    #CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 2 ${model_type} sp 100 | tee ${log_path}/${FUNCNAME}_${model_type}_mem_8gpus 2>&1
-    #sleep 60
-    #echo "model_type is ${model_type}, index is maxbs, 1gpus, begin"
-    #CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 6 ${model_type} sp 400 | tee ${log_path}/${FUNCNAME}_${model_type}_maxbs_1gpus 2>&1
-    #sleep 60
-    #echo "model_type is ${model_type}, index is maxbs, 8gpus, begin"
-    #CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 6 ${model_type} sp 400 | tee ${log_path}/${FUNCNAME}_${model_type}_maxbs_8gpus 2>&1
+    sleep 60
+    echo "model_type is ${model_type}, index is mem, 1gpus, begin"
+    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 2 ${model_type} sp 400 | tee ${log_path}/${FUNCNAME}_${model_type}_mem_1gpus 2>&1
+    sleep 60
+    echo "model_type is ${model_type}, index is mem, 8gpus, begin"
+    CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 2 ${model_type} sp 100 | tee ${log_path}/${FUNCNAME}_${model_type}_mem_8gpus 2>&1
+    sleep 60
+    echo "model_type is ${model_type}, index is maxbs, 1gpus, begin"
+    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 6 ${model_type} sp 400 | tee ${log_path}/${FUNCNAME}_${model_type}_maxbs_1gpus 2>&1
+    sleep 60
+    echo "model_type is ${model_type}, index is maxbs, 8gpus, begin"
+    CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 6 ${model_type} sp 400 | tee ${log_path}/${FUNCNAME}_${model_type}_maxbs_8gpus 2>&1
     sleep 60
     echo "model_type is ${model_type}, index is speed, 8gpus, run_mode is multi_process, begin"
     CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 1 ${model_type} mp 600 | tee ${log_path}/${FUNCNAME}_${model_type}_speed_8gpus8p 2>&1
@@ -559,19 +559,19 @@ transformer(){
     echo "model_type is ${model_type}, index is speed, 8gpus, begin"
     CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 1 ${model_type} sp 600 | tee ${log_path}/${FUNCNAME}_${model_type}_speed_8gpus 2>&1
     sleep 60
-#    echo "model_type is ${model_type}, index is mem, 1gpus, begin"
-#    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 2 ${model_type} sp 400 | tee ${log_path}/${FUNCNAME}_${model_type}_mem_1gpus 2>&1
-#    sleep 60
-#    echo "model_type is ${model_type}, index is mem, 8gpus, begin"
-#    CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 2 ${model_type} sp 100 | tee ${log_path}/${FUNCNAME}_${model_type}_mem_8gpus 2>&1
-#    sleep 60
+    echo "model_type is ${model_type}, index is mem, 1gpus, begin"
+    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 2 ${model_type} sp 400 | tee ${log_path}/${FUNCNAME}_${model_type}_mem_1gpus 2>&1
+    sleep 60
+    echo "model_type is ${model_type}, index is mem, 8gpus, begin"
+    CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 2 ${model_type} sp 100 | tee ${log_path}/${FUNCNAME}_${model_type}_mem_8gpus 2>&1
+    sleep 60
 
-#    echo "model_type is ${model_type}, index is maxbs, 1gpus, begin"
-#    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 6 ${model_type} sp ${train_log_dir} | tee ${log_path}/${FUNCNAME}_${model_type}_maxbs_1gpus 2>&1
-#    sleep 60
-#    echo "model_type is ${model_type}, index is maxbs, 8gpus, begin"
-#    CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 6 ${model_type} sp ${train_log_dir} | tee ${log_path}/${FUNCNAME}_${model_type}_maxbs_8gpus 2>&1
-#    sleep 60
+    echo "model_type is ${model_type}, index is maxbs, 1gpus, begin"
+    CUDA_VISIBLE_DEVICES=0 bash run_benchmark.sh 6 ${model_type} sp ${train_log_dir} | tee ${log_path}/${FUNCNAME}_${model_type}_maxbs_1gpus 2>&1
+    sleep 60
+    echo "model_type is ${model_type}, index is maxbs, 8gpus, begin"
+    CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 6 ${model_type} sp ${train_log_dir} | tee ${log_path}/${FUNCNAME}_${model_type}_maxbs_8gpus 2>&1
+    sleep 60
     echo "model_type is ${model_type}, index is speed, 8gpus, run_mode is multi_process, begin"
     CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 1 ${model_type} mp 600 | tee ${log_path}/${FUNCNAME}_${model_type}_speed_8gpus8p 2>&1
 }


### PR DESCRIPTION
 * 模型训练显存爆的问题在[#25140](https://github.com/PaddlePaddle/Paddle/pull/25140/files)里修复，故而将对应模型再次开启训练
* CycleGAN 与Pix2pix 模型训练较快，无法及时抓取到CPU 利用率和GPU 利用率，故而增大训练iter数