### PR TITLE
Support auto permutation for output when outputs shape are different.

### DIFF
--- a/api/common/feeder.py
+++ b/api/common/feeder.py
@@ -123,10 +123,7 @@ class FeederAdapter(object):
                 if self.__feed_spec is not None and self.__feed_spec[i].get(
                         "permute", None) is not None:
                     permute_paddle2tf = self.__feed_spec[i]["permute"]
-                    # In Python 3.x, 'range' object does not support item assignment.
-                    permute_tf2paddle = []
-                    for i in range(len(permute_paddle2tf)):
-                        permute_tf2paddle.append(i)
+                    permute_tf2paddle = [0] * len(permute_paddle2tf)
                     for pos in range(len(permute_paddle2tf)):
                         permute_tf2paddle[permute_paddle2tf[pos]] = pos
                     value = np.transpose(value, permute_tf2paddle)

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -21,6 +21,7 @@ import numpy as np
 import json
 import collections
 import subprocess
+import itertools
 
 if six.PY3:
     from . import special_op_list
@@ -93,8 +94,9 @@ def check_commit():
 def _compare(output1, output2, atol):
     max_diff = np.float32(-0.0)
     offset = -1
+    assert output1.shape == output2.shape, "Outputs' shape must be the same, but receieved %s vs %s." % (
+        str(output1.shape), str(output2.shape))
     try:
-        assert len(output1) == len(output2)
         if output1.dtype == np.bool:
             diff = np.array_equal(output1, output2)
             max_diff = np.float32(np.logical_not(diff))
@@ -136,7 +138,7 @@ def _check_type(output1, output2):
 
 
 def _check_shape(name, output1, output2, i):
-    if name in ["reshape", "squeeze", "unsqueeze"]:
+    if name in ["reshape", "squeeze", "unsqueeze", "transpose"]:
         assert output1.shape == output2.shape, "The %d-the output's shape is different, %s vs %s." % (
             i, str(output1.shape), str(output2.shape))
         return output1, output2
@@ -144,16 +146,32 @@ def _check_shape(name, output1, output2, i):
     if output1.shape != output2.shape:
         output1_squeezed = np.squeeze(output1)
         output2_squeezed = np.squeeze(output2)
-        if output1_squeezed.shape != output2_squeezed.shape:
+        shape1_permutations = list(
+            itertools.permutations(output1_squeezed.shape,
+                                   len(output1_squeezed.shape)))
+        if output1_squeezed.shape != output2_squeezed.shape and output2_squeezed.shape not in shape1_permutations:
             raise RuntimeError(
                 "The %d-the output's shape is different, %s vs %s." % (
                     i, str(output1.shape), str(output2.shape)))
         else:
             print(
-                "The %d-the output's shape is compatible (same after squeezed), %s vs %s."
+                "---- The %d-th output's shape is compatible (same after squeezed/permuted), %s vs %s."
                 % (i, str(output1.shape), str(output2.shape)))
         return output1_squeezed, output2_squeezed
     return output1, output2
+
+
+def _permute_order(output1, output2):
+    numbers = list(range(len(output2.shape)))
+    all_permutations = list(itertools.permutations(numbers, len(numbers)))
+    choosed_permutations = []
+    for permutation in all_permutations:
+        permuted_shape2 = []
+        for pos in permutation:
+            permuted_shape2.append(output2.shape[pos])
+        if permuted_shape2 == list(output1.shape):
+            choosed_permutations.append(permutation)
+    return choosed_permutations
 
 
 def check_outputs(list1,
@@ -196,7 +214,25 @@ def check_outputs(list1,
                     "---- The %d-the output's data type is different, %s vs %s."
                     % (i, str(output1.dtype), str(output2.dtype)))
 
-            max_diff_i, offset_i = _compare(output1, output2, atol)
+            if output1.shape != output2.shape:
+                choosed_permutations = _permute_order(output1, output2)
+                max_diff_i_posible = []
+                offset_i_posible = []
+                for permutation in choosed_permutations:
+                    output2_transposed = np.transpose(output2, permutation)
+                    max_diff_i, offset_i = _compare(output1,
+                                                    output2_transposed, atol)
+                    max_diff_i_posible.append(max_diff_i)
+                    offset_i_posible.append(offset_i)
+                index = np.argmin(max_diff_i_posible)
+                max_diff_i = max_diff_i_posible[index]
+                offset_i = offset_i_posible[index]
+                print(
+                    "---- The %d-th output need permute. The permutation is %s, outputs shape are %s vs %s."
+                    % (i, str(choosed_permutations[index]), str(output1.shape),
+                       str(output2.shape)))
+            else:
+                max_diff_i, offset_i = _compare(output1, output2, atol)
             if max_diff_i > 1E-6:
                 print(
                     "---- The %d-th output (shape: %s, data type: %s) has diff. "

--- a/api/deploy/op_benchmark_unit.py
+++ b/api/deploy/op_benchmark_unit.py
@@ -29,6 +29,16 @@ def parse_op_type(case_name):
     return re.sub("_[0-9]*$", "", case_name)
 
 
+def parse_case_id(case_name):
+    return case_name.split("_")[-1]
+
+
+def unify_case_name(case_name):
+    op_type = parse_op_type(case_name)
+    case_id = int(parse_case_id(case_name))
+    return "%s_%02d" % (op_type, case_id)
+
+
 def _compare(time1, time2):
     try:
         ratio = float(time1) / float(time2)

--- a/api/deploy/op_benchmark_unit.py
+++ b/api/deploy/op_benchmark_unit.py
@@ -85,9 +85,10 @@ class OpBenchmarkUnit(object):
                     "gpu_time": _compare(paddle_gpu_time, tf_gpu_time)
                 }
 
-                accuracy = self._get_case_value(case_detail, "paddle", device,
-                                                "accuracy", direction)
+                accuracy, difference = self._get_case_value(
+                    case_detail, "paddle", device, "accuracy", direction)
                 result["accuracy"] = str(accuracy)
+                result["difference"] = str(difference)
 
     def __str__(self):
         debug_str = "case_name    : " + self.case_name + "\n"
@@ -146,8 +147,9 @@ class OpBenchmarkUnit(object):
 
         if task == "accuracy":
             try:
-                key = "paddle_" + device + "_accuracy_" + direction
-                return case_detail[key]
+                accuracy_key = "paddle_" + device + "_accuracy_" + direction
+                difference_key = "paddle_" + device + "_difference_" + direction
+                return case_detail[accuracy_key], case_detail[difference_key]
             except Exception:
                 return "--"
         else:

--- a/api/deploy/summary.py
+++ b/api/deploy/summary.py
@@ -377,7 +377,9 @@ if __name__ == '__main__':
 
     data = []
     benchmark_result_list = []
-    for key, value in sorted(res.items()):
+    for key, value in sorted(
+            res.items(),
+            key=lambda t: op_benchmark_unit.unify_case_name(t[0])):
         case_detail = value.copy()
         case_detail['name'] = key
         data.append(case_detail)

--- a/api/deploy/summary.py
+++ b/api/deploy/summary.py
@@ -37,6 +37,7 @@ import op_benchmark_unit
 res = {}
 TABLE_HEADER = ["op", "case_name", "指标", "标准值", "当前值", "波动范围", "config"]
 
+
 def _read_last_line(inputfile):
     filesize = os.path.getsize(inputfile)
     f = open(inputfile, 'r')
@@ -110,6 +111,7 @@ def _parse_speed(case_name, statistic_type, last_line):
 def _parse_accuracy(case_name, statistic_type, last_line):
     assert res.get(case_name, None) is not None
 
+    difference_key = statistic_type.replace("accuracy", "difference")
     try:
         data = json.loads(last_line)
         # May set following values:
@@ -117,10 +119,17 @@ def _parse_accuracy(case_name, statistic_type, last_line):
         #   paddle_gpu_accuracy_backward
         #   paddle_cpu_accuracy_forward
         #   paddle_cpu_accuracy_backward
-        consitent_status = data['consistent']
-        res[case_name][statistic_type] = consitent_status
+        res[case_name][statistic_type] = data["consistent"]
+
+        # May set following values:
+        #   paddle_gpu_difference_forward
+        #   paddle_gpu_difference_backward
+        #   paddle_cpu_difference_forward
+        #   paddle_cpu_difference_backward
+        res[case_name][difference_key] = data["diff"]
     except Exception:
         res[case_name][statistic_type] = "--"
+        res[case_name][difference_key] = "--"
 
 
 def get_job_res(inputfile, specified_op_list=None):
@@ -187,7 +196,8 @@ def check_results(op_record, index, html_results, check_key):
     """
 
     from benchmark_op import models
-    results = models.OpRecord2.objects.filter(case_name=op_record.case_name).order_by('-timestamp')[:10:1]
+    results = models.OpRecord2.objects.filter(
+        case_name=op_record.case_name).order_by('-timestamp')[:10:1]
     for key, verbose in check_key.items():
         results_list = []
         count = 0
@@ -212,7 +222,8 @@ def check_results(op_record, index, html_results, check_key):
             avg_values = round(np.array(results_list).mean(), 4)
             if not avg_values:
                 return
-            ranges = round((float(getattr(op_record, key)) - avg_values) / avg_values, 4)
+            ranges = round(
+                (float(getattr(op_record, key)) - avg_values) / avg_values, 4)
         except Exception as rw:
             print("range solve error {}".format(rw))
             traceback.print_exc()
@@ -224,22 +235,22 @@ def check_results(op_record, index, html_results, check_key):
             color = "red"
         elif ranges <= -0.05:
             color = "green"
-        current_html_result = [dict(value='_'.join(str(op_record.case_name).split('_')[:-1])),
-                               dict(value=op_record.case_name),
-                               dict(value=verbose),
-                               dict(value=avg_values),
-                               dict(value=getattr(op_record, key)),
-                               dict(value=ranges, color=color),
-                               dict(value=op_record.config)]
+        current_html_result = [
+            dict(value='_'.join(str(op_record.case_name).split('_')[:-1])),
+            dict(value=op_record.case_name), dict(value=verbose),
+            dict(value=avg_values), dict(value=getattr(op_record, key)), dict(
+                value=ranges, color=color), dict(value=op_record.config)
+        ]
         html_results[index]["data"].append(current_html_result)
 
 
 def dump_mysql(data):
-    import models.benchmark_server.helper as helper
-    from benchmark_op import models
     """
     dump data to mysql database
     """
+    import models.benchmark_server.helper as helper
+    from benchmark_op import models
+
     html_results = OrderedDict()
     index = "performance"
     html_results[index] = {}
@@ -278,23 +289,25 @@ def dump_mysql(data):
         op_record.tf_gpu_time_backward = dic.get("tf_gpu_time_backward", "--")
         op_record.tf_gpu_time = dic.get("tf_gpu_time", "--")
         op_record.save()
-        check_key = dict(paddle_cpu_perf="CPU正向",
-                         paddle_gpu_perf="GPU正向",
-                         paddle_gpu_perf_backwards="GPU后向",
-                         gpu_time="GPU正向内核",
-                         gpu_time_backward="GPU反向内核")
+        check_key = dict(
+            paddle_cpu_perf="CPU正向",
+            paddle_gpu_perf="GPU正向",
+            paddle_gpu_perf_backwards="GPU后向",
+            gpu_time="GPU正向内核",
+            gpu_time_backward="GPU反向内核")
         check_results(op_record, index, html_results, check_key)
     if html_results[index]["data"]:
         import scripts.template as template
         title = "op_benchmark"
-        env = dict(PADDLE_VERSION=timestamp,
-                   DOCKER_IMAGES=os.getenv('RUN_IMAGE_NAME'),
-                   CUDA_VERSION=os.getenv('CUDA_VERSION'),
-                   CUDNN_VERSION=os.getenv('CUDNN_VERSION'),
-                   PADDLE_COMMIT_ID=os.getenv('PADDLE_COMMIT_ID'))
-        email_t = template.EmailTemplate(title, env, html_results, args.op_result_dir)
+        env = dict(
+            PADDLE_VERSION=timestamp,
+            DOCKER_IMAGES=os.getenv('RUN_IMAGE_NAME'),
+            CUDA_VERSION=os.getenv('CUDA_VERSION'),
+            CUDNN_VERSION=os.getenv('CUDNN_VERSION'),
+            PADDLE_COMMIT_ID=os.getenv('PADDLE_COMMIT_ID'))
+        email_t = template.EmailTemplate(title, env, html_results,
+                                         args.op_result_dir)
         email_t.construct_email_content()
-
 
 
 if __name__ == '__main__':

--- a/api/deploy/write_excel.py
+++ b/api/deploy/write_excel.py
@@ -225,8 +225,9 @@ def dump_excel(benchmark_result_list,
                             ws.write(row, col, op_time, cell_formats[color])
                         col += 1
 
-                    ws.write(row, col, result["compare"][key],
-                             cell_formats[color])
+                    compare_result = COMPARE_RESULT_SHOWS.get(
+                        result["compare"][key], "--")
+                    ws.write(row, col, compare_result, cell_formats[color])
                     col += 1
 
                 op_acc_path = _op_result_path(op_result_dir, op_unit.case_name,

--- a/api/tests/configs/resize_bilinear.json
+++ b/api/tests/configs/resize_bilinear.json
@@ -1,0 +1,175 @@
+[{
+    "op": "resize_bilinear",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        },
+        "align_mode": {
+            "type": "int",
+            "value": "1"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 512L, 64L, 402L]",
+            "type": "Variable"
+        },
+        "out_shape": {
+            "type": "list",
+            "value": "[128L, 402L]"
+        },
+        "scale": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "op": "resize_bilinear",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        },
+        "align_mode": {
+            "type": "int",
+            "value": "1"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NHWC"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 64L, 402L, 512L]",
+            "type": "Variable"
+        },
+        "out_shape": {
+            "type": "list",
+            "value": "[128L, 402L]"
+        },
+        "scale": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "op": "resize_bilinear",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        },
+        "align_mode": {
+            "type": "int",
+            "value": "1"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 256L, 1L, 1L]",
+            "type": "Variable"
+        },
+        "out_shape": {
+            "type": "tuple",
+            "value": "(33L, 33L)"
+        },
+        "scale": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "op": "resize_bilinear",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        },
+        "align_mode": {
+            "type": "int",
+            "value": "1"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NHWC"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 1L, 1L, 256L]",
+            "type": "Variable"
+        },
+        "out_shape": {
+            "type": "tuple",
+            "value": "(33L, 33L)"
+        },
+        "scale": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "op": "resize_bilinear",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        },
+        "align_mode": {
+            "type": "int",
+            "value": "1"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 19L, 129L, 129L]",
+            "type": "Variable"
+        },
+        "out_shape": {
+            "type": "tuple",
+            "value": "(513L, 513L)"
+        },
+        "scale": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "op": "resize_bilinear",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        },
+        "align_mode": {
+            "type": "int",
+            "value": "1"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NHWC"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 129L, 129L, 19L]",
+            "type": "Variable"
+        },
+        "out_shape": {
+            "type": "tuple",
+            "value": "(513L, 513L)"
+        },
+        "scale": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}]

--- a/api/tests/configs/resize_nearest.json
+++ b/api/tests/configs/resize_nearest.json
@@ -1,0 +1,51 @@
+[{
+    "op": "resize_nearest",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 256L, 16L, 16L]",
+            "type": "Variable"
+        },
+        "out_shape": {
+            "type": "list",
+            "value": "[32L, 32L]"
+        },
+        "scale": {
+            "type": "float",
+            "value": "2.0"
+        }
+    }
+}, {
+    "op": "resize_nearest",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NHWC"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[-1L, 16L, 16L, 256L]",
+            "type": "Variable"
+        },
+        "out_shape": {
+            "type": "list",
+            "value": "[32L, 32L]"
+        },
+        "scale": {
+            "type": "float",
+            "value": "2.0"
+        }
+    }
+}]

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -108,7 +108,7 @@ class PDConv2d(PaddleAPIBenchmarkBase):
         self.feed_vars = [input, filter]
         self.fetch_vars = [result]
         if config.backward:
-            self.append_gradients(result, [input])
+            self.append_gradients(result, [input, filter])
 
 
 class TFConv2d(TensorflowAPIBenchmarkBase):
@@ -138,7 +138,7 @@ class TFConv2d(TensorflowAPIBenchmarkBase):
         self.feed_list = [input, filter]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, [input])
+            self.append_gradients(result, [input, filter])
 
 
 if __name__ == '__main__':

--- a/api/tests/conv2d_transpose.py
+++ b/api/tests/conv2d_transpose.py
@@ -88,7 +88,7 @@ class PDConv2dTranspose(PaddleAPIBenchmarkBase):
         self.feed_vars = [input, filter]
         self.fetch_vars = [result]
         if config.backward:
-            self.append_gradients(result, [input])
+            self.append_gradients(result, [input, filter])
 
 
 class TFConv2dTranspose(TensorflowAPIBenchmarkBase):
@@ -109,7 +109,7 @@ class TFConv2dTranspose(TensorflowAPIBenchmarkBase):
         self.feed_list = [input, filter]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, [input])
+            self.append_gradients(result, [input, filter])
 
 
 if __name__ == '__main__':

--- a/api/tests/resize_bilinear.py
+++ b/api/tests/resize_bilinear.py
@@ -1,0 +1,61 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+from resize_nearest import ResizeNearestConfig
+
+
+class ResizeBilinearConfig(ResizeNearestConfig):
+    def __init__(self):
+        super(ResizeBilinearConfig, self).__init__("resize_bilinear")
+
+
+class PDResizeBilinear(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        input = self.variable(
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
+        result = fluid.layers.resize_bilinear(
+            input=input,
+            out_shape=config.out_shape,
+            scale=config.scale,
+            align_corners=True,
+            align_mode=1,
+            data_format=config.data_format)
+
+        self.feed_vars = [input]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [input])
+
+
+class TFResizeBilinear(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        input = self.variable(
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
+        result = tf.image.resize(
+            images=input,
+            size=config.out_shape,
+            method=tf.image.ResizeMethod.BILINEAR,
+            preserve_aspect_ratio=False,
+            antialias=False)
+
+        self.feed_list = [input]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [input])
+
+
+if __name__ == '__main__':
+    test_main(
+        PDResizeBilinear(), TFResizeBilinear(), config=ResizeBilinearConfig())

--- a/api/tests/resize_nearest.py
+++ b/api/tests/resize_nearest.py
@@ -1,0 +1,83 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class ResizeNearestConfig(APIConfig):
+    def __init__(self, op_type="resize_nearest"):
+        super(ResizeNearestConfig, self).__init__(op_type)
+
+    def init_from_json(self, filename, config_id=0):
+        super(ResizeNearestConfig, self).init_from_json(filename, config_id)
+        if self.data_format == "NCHW":
+            # tf only support NHWC
+            if len(self.input_shape) == 4:
+                self.feed_spec = {"permute": [0, 2, 3, 1]}
+            elif len(self.input_shape) == 3:
+                self.feed_spec = {"permute": [1, 2, 0]}
+
+    def to_tensorflow(self):
+        tf_config = super(ResizeNearestConfig, self).to_tensorflow()
+        if self.data_format == "NCHW":
+            # tf only support NHWC
+            if len(self.input_shape) == 4:
+                tf_config.input_shape = [
+                    self.input_shape[0], self.input_shape[2],
+                    self.input_shape[3], self.input_shape[1]
+                ]
+            elif len(self.input_shape) == 3:
+                tf_config.input_shape = [
+                    self.input_shape[1], self.input_shape[2],
+                    self.input_shape[0]
+                ]
+        return tf_config
+
+
+class PDResizeNearest(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        input = self.variable(
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
+        result = fluid.layers.resize_nearest(
+            input=input,
+            out_shape=None,
+            scale=config.scale,
+            align_corners=True,
+            data_format=config.data_format)
+
+        self.feed_vars = [input]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [input])
+
+
+class TFResizeNearest(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        input = self.variable(
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
+        result = tf.image.resize(
+            images=input,
+            size=config.out_shape,
+            method=tf.image.ResizeMethod.NEAREST_NEIGHBOR,
+            preserve_aspect_ratio=False)
+
+        self.feed_list = [input]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [input])
+
+
+if __name__ == '__main__':
+    test_main(
+        PDResizeNearest(), TFResizeNearest(), config=ResizeNearestConfig())


### PR DESCRIPTION
- conv2d系列op，paddle的filter存储格式是NCHW，tf的filter存储格式是HWNC。当前的实现，不支持对fetch tensor进行permute，所以conv2d反向测试时，不能fetch filter_grad，导致tf反向没有计算filter_grad、但paddle算了，因此计时比较不公平。采取的解决方法是：
    - 在正确性比较时，自动对所有的可能的permutation进行比较。
- 添加resize_nearest、resize_bilinear两个op的测试脚本。
- 调整了excel的输出内容和格式，包括：
    - case_name按照op_type、case_id的顺序输出
    - 速度比较结果换成中文输出
    - 正确性比较结果，直接输出diff

![image](https://user-images.githubusercontent.com/12538138/88617469-59187380-d0c9-11ea-8d38-9d215be4c171.png)

