### PR TITLE
Enable parallel execution On CPU op benchmark

### DIFF
--- a/api/deploy/docker_run.sh
+++ b/api/deploy/docker_run.sh
@@ -198,11 +198,7 @@ function run(){
     export CUDA_SO="$(\ls /usr/lib64/libcuda* | xargs -I{} echo '-v {}:{}') $(\ls /usr/lib64/libnvidia* | xargs -I{} echo '-v {}:{}')"
     export DEVICES=$(\ls /dev/nvidia* | xargs -I{} echo '--device {}:{}')
     RUN_IMAGE_NAME=paddlepaddle/paddle:latest-dev-cuda${cuda_version}-cudnn${cudnn_version}-gcc82
-    # 由于，deploy/main_control.sh 跑gpu和cpu的两个任务是同时在后台启动的，
-    # 因此，两个任务都需要绑到对应的CPU核上，避免CPU冲突，导致CPU数据不准。
-    # 具体绑核规则如下：
-    # - GPU任务：使用的CPU_VISIBLE_DEVICES 号和CUDA_VISIBLE_DEVICES 一致，即如果使用0-7个GPU卡，则对应使用0-7个CPU核。
-    # - CPU任务：请使用剩下的CPU核，假设有40个核，GPU任务用了前8个核，应该export CPU_VISIBLE_DEVICES="8-39"，即用剩下的32个CPU核。 
+    # CPU任务：export CPU_VISIBLE_DEVICES="0,1,2,3,4"，即并行开启5个CPU任务，用了第0-4个核。 
     run_cmd="python -m pip install --upgrade pip;
              pip install nvidia-ml-py;
              pip install psutil;

--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -136,12 +136,9 @@ function execute_one_case() {
     # DEVICE_SET is specified by argument: "gpu", "cpu"
     for device in ${DEVICE_SET[@]}; do 
         if [ ${device} = "gpu" ]; then
-            local actual_gpu_id="${gpu_id}"
             local use_gpu="True"
             local repeat=1000
         else
-            local actual_gpu_id=""
-            local actual_cpu_id="${gpu_id}"
             local use_gpu="False"
             local repeat=100
         fi
@@ -182,17 +179,17 @@ function execute_one_case() {
                         # Set maxmimum runtime to 10min, or it will be considered
                         #  hanged and will be killed.
                         if [ ${device} = "gpu" ]; then
-                            CUDA_VISIBLE_DEVICES="${actual_gpu_id}" timeout 600s ${run_cmd} > $logfile 2>&1
+                            CUDA_VISIBLE_DEVICES="${gpu_id}" timeout 600s ${run_cmd} > $logfile 2>&1
                         else
-                            CUDA_VISIBLE_DEVICES="${actual_gpu_id}" taskset -c ${actual_cpu_id} timeout 600s ${run_cmd} > $logfile 2>&1
+                            CUDA_VISIBLE_DEVICES="" taskset -c ${gpu_id} timeout 600s ${run_cmd} > $logfile 2>&1
                         fi
                         return_status=$?
                     else
                         logfile=""
                         if [ ${device} = "gpu" ]; then
-                            CUDA_VISIBLE_DEVICES="${actual_gpu_id}" ${run_cmd}
+                            CUDA_VISIBLE_DEVICES="${gpu_id}" ${run_cmd}
                         else
-                            CUDA_VISIBLE_DEVICES="${actual_gpu_id}" taskset -c ${actual_cpu_id} ${run_cmd}
+                            CUDA_VISIBLE_DEVICES="" taskset -c ${gpu_id} ${run_cmd}
                         fi
                         return_status=$?
                     fi

--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -137,10 +137,12 @@ function execute_one_case() {
     for device in ${DEVICE_SET[@]}; do 
         if [ ${device} = "gpu" ]; then
             local actual_gpu_id="${gpu_id}"
+            local actual_cpu_id="${gpu_id}"
             local use_gpu="True"
             local repeat=1000
         else
             local actual_gpu_id=""
+            local actual_cpu_id="${gpu_id}"
             local use_gpu="False"
             local repeat=100
         fi
@@ -180,11 +182,11 @@ function execute_one_case() {
                         logfile=${OUTPUT_DIR}/${api_name}"_"${i}"-"${framework}"_"${device}"_"${task}"_"${direction}".txt"
                         # Set maxmimum runtime to 10min, or it will be considered
                         #  hanged and will be killed.
-                        CUDA_VISIBLE_DEVICES="${actual_gpu_id}" timeout 600s ${run_cmd} > $logfile 2>&1
+                        CUDA_VISIBLE_DEVICES="${actual_gpu_id}" taskset -c ${actual_cpu_id} timeout 600s ${run_cmd} > $logfile 2>&1
                         return_status=$?
                     else
                         logfile=""
-                        CUDA_VISIBLE_DEVICES="${actual_gpu_id}" ${run_cmd}
+                        CUDA_VISIBLE_DEVICES="${actual_gpu_id}" taskset -c ${actual_cpu_id} ${run_cmd}
                         return_status=$?
                     fi
                     run_end=`date +%s%N`;


### PR DESCRIPTION
支持并行跑CPU op benchmark：
- 使用绑核操作，将每个Op示例绑到一个CPU核上运行，达到并行跑Cpu benchmark的效果。
- 绑多少核：< 物理核，假设有20个物理核，不能全部用满。因为有额外的线程是用于读数据的，全部用满会导致性能急剧下降。

### 正确性验证
以下是在20核的6148物理机上，绑15核并行跑出来的abs-0效果
| abs-0   | 前向ms  |反向ms|
|  ----  | ----  |----|
| paddle  | 281.54 |928.81
| tensorflow  | 329.31 |791.66

以下是显示在性能网站，在v100虚拟机上，串行跑出来的abs-0效果

| abs-0   | 前向ms  |反向ms|
|  ----  | ----  |----|
| paddle  | 546.82 |1644.69
| tensorflow  | 511.56 |1179.83

可以看到，两个数据的比例是一致的。