### PR TITLE
Add a config to elementwise ops: [512, 896, 4, 12] and [512, 896, 4, 1], float32 and float16.

### DIFF
--- a/api/tests/configs/elementwise.json
+++ b/api/tests/configs/elementwise.json
@@ -113,4 +113,50 @@
         }
     },
     "repeat": 5000
+}, {
+    "op": "elementwise",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[512L, 896L, 4L, 12L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[512L, 896L, 4L, 1L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 5000
+}, {
+    "op": "elementwise",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[512L, 896L, 4L, 12L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[512L, 896L, 4L, 1L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 5000
 }]


### PR DESCRIPTION
增加一种elementwise的广播配置，该配置来自ERNIE AMP训练，性能不符合预期。