### PR TITLE
Add several configs for matmul.

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -209,6 +209,9 @@ class APIConfig(object):
         else:
             return self
 
+    def disabled(self):
+        return False
+
     def init_from_json(self, filename, config_id=0):
         if hasattr(self, "alias_config"):
             self.alias_config.init_from_json(

--- a/api/tests/configs/matmul.json
+++ b/api/tests/configs/matmul.json
@@ -132,4 +132,160 @@
         }
     },
     "repeat": 10000
+}, {
+    "op": "matmul",
+    "param_info": {
+        "alpha": {
+            "type": "float",
+            "value": "1.0"
+        },
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "True"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[512L, 4L, 896L, 2L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[512L, 4L, 12L, 2L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "matmul",
+    "param_info": {
+        "alpha": {
+            "type": "float",
+            "value": "1.0"
+        },
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "True"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[512L, 4L, 896L, 2L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[512L, 4L, 12L, 2L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "matmul",
+    "param_info": {
+        "alpha": {
+            "type": "float",
+            "value": "1.0"
+        },
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "True"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[512L, 4L, 896L, 8L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[512L, 4L, 16L, 8L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "matmul",
+    "param_info": {
+        "alpha": {
+            "type": "float",
+            "value": "1.0"
+        },
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[4L, 12L, 64L, 85L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[4L, 12L, 85L, 512L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "matmul",
+    "param_info": {
+        "alpha": {
+            "type": "float",
+            "value": "1.0"
+        },
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[4L, 12L, 64L, 85L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[4L, 12L, 85L, 512L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "matmul",
+    "param_info": {
+        "alpha": {
+            "type": "float",
+            "value": "1.0"
+        },
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[4L, 12L, 64L, 88L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[4L, 12L, 88L, 512L]",
+            "type": "Variable"
+        }
+    }
 }]

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -28,12 +28,13 @@ class Conv2dConfig(APIConfig):
             }  # filters
         ]
 
+    def disabled(self):
+        if self.input_dtype == "float16" and self.use_cudnn == False:
+            return True
+        return False
+
     def init_from_json(self, filename, config_id=0):
         super(Conv2dConfig, self).init_from_json(filename, config_id)
-        if self.input_dtype == "float16" and self.use_cudnn == False:
-            self.disabled = True
-            return
-
         if isinstance(self.padding, int):
             self.padding = [self.padding, self.padding]
         if self.data_format == "NCHW":

--- a/api/tests/elementwise.py
+++ b/api/tests/elementwise.py
@@ -32,6 +32,13 @@ class ElementwiseConfig(APIConfig):
         }
         self.feed_spec = [{"range": [-1, 1]}, {"range": [-1, 1]}]
 
+    def disabled(self):
+        if self.api_name in [
+                "elementwise_max", "elementwise_min", "elementwise_pow"
+        ] and self.x_dtype == "float16":
+            return True
+        return False
+
     def to_tensorflow(self):
         tf_config = super(ElementwiseConfig, self).to_tensorflow()
         if len(self.x_shape) > len(self.y_shape) and self.y_shape != [1]:

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -167,7 +167,7 @@ def _adaptive_repeat(config, args):
 
 def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
     assert config is not None, "API config must be set."
-    if hasattr(config, "disabled") and config.disabled:
+    if config.disabled():
         warnings.simplefilter('always', UserWarning)
         warnings.warn("This config is disabled.")
         return


### PR DESCRIPTION
- matmul增加6个配置，分别对比以下几种配置的性能：float32 vs float16、float16 MNK是否8的倍数。
- elementwise_pow不支持float16数据类型，对于数据类型是float16的配置，APIConfig里面标记为disabled。