### PR TITLE
Add API config for transpose

### DIFF
--- a/api/tests/configs/transpose.json
+++ b/api/tests/configs/transpose.json
@@ -34,9 +34,122 @@
         },
         "x": {
             "dtype": "float32",
-            "shape": "[-1L, 128L, 256L]",
+            "shape": "[-1, 128L, 256L]",
             "type": "Variable"
         }
     },
     "repeat": 5000
-}]
+}, {
+    "op": "transpose",
+    "param_info": {
+        "perm": {
+            "type": "list",
+            "value": "[2, 3, 0, 1]"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[4L, 12L, 512L, 896L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 5000
+}, {
+    "op": "transpose",
+    "param_info": {
+        "perm": {
+            "type": "list",
+            "value": "[2, 3, 0, 1]"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[4L, 12L, 512L, 896L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 5000
+}, {
+    "op": "transpose",
+    "param_info": {
+        "perm": {
+            "type": "list",
+            "value": "[1, 2, 0, 3]"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[4L, 512L, 512L, 1L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 5000
+},{
+   "op": "transpose",
+   "param_info": {
+       "perm": {
+           "type": "list",
+           "value": "[1, 2, 0, 3]"
+       },
+       "x": {
+           "dtype": "float16",
+           "shape": "[4L, 512L, 512L, 1L]",
+           "type": "Variable"
+       }
+   },
+   "repeat": 5000
+}, {
+    "op": "transpose",
+    "param_info": {
+        "perm": {
+            "type": "list",
+            "value": "[0, 2, 1, 3]"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[512L, 896L, 4L, 2L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 5000
+}, {
+      "op": "transpose",
+      "param_info": {
+          "perm": {
+              "type": "list",
+              "value": "[0, 2, 1, 3]"
+          },
+          "x": {
+              "dtype": "float16",
+              "shape": "[512L, 896L, 4L, 2L]",
+              "type": "Variable"
+          }
+      },
+      "repeat": 5000
+}, {
+    "op": "transpose",
+    "param_info": {
+        "perm": {
+            "type": "list",
+            "value": "[3, 0, 1, 2]"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[4L, 12L, 64L, 512L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 5000
+}, {
+    "op": "transpose",
+    "param_info": {
+        "perm": {
+            "type": "list",
+            "value": "[3, 0, 1, 2]"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[4L, 12L, 64L, 512L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 5000
+}
+]   

--- a/api/tests/configs/transpose.json
+++ b/api/tests/configs/transpose.json
@@ -34,7 +34,7 @@
         },
         "x": {
             "dtype": "float32",
-            "shape": "[-1, 128L, 256L]",
+            "shape": "[-1L, 128L, 256L]",
             "type": "Variable"
         }
     },
@@ -95,61 +95,4 @@
        }
    },
    "repeat": 5000
-}, {
-    "op": "transpose",
-    "param_info": {
-        "perm": {
-            "type": "list",
-            "value": "[0, 2, 1, 3]"
-        },
-        "x": {
-            "dtype": "float32",
-            "shape": "[512L, 896L, 4L, 2L]",
-            "type": "Variable"
-        }
-    },
-    "repeat": 5000
-}, {
-      "op": "transpose",
-      "param_info": {
-          "perm": {
-              "type": "list",
-              "value": "[0, 2, 1, 3]"
-          },
-          "x": {
-              "dtype": "float16",
-              "shape": "[512L, 896L, 4L, 2L]",
-              "type": "Variable"
-          }
-      },
-      "repeat": 5000
-}, {
-    "op": "transpose",
-    "param_info": {
-        "perm": {
-            "type": "list",
-            "value": "[3, 0, 1, 2]"
-        },
-        "x": {
-            "dtype": "float32",
-            "shape": "[4L, 12L, 64L, 512L]",
-            "type": "Variable"
-        }
-    },
-    "repeat": 5000
-}, {
-    "op": "transpose",
-    "param_info": {
-        "perm": {
-            "type": "list",
-            "value": "[3, 0, 1, 2]"
-        },
-        "x": {
-            "dtype": "float16",
-            "shape": "[4L, 12L, 64L, 512L]",
-            "type": "Variable"
-        }
-    },
-    "repeat": 5000
-}
-]   
+}]   


### PR DESCRIPTION
ERNIE DOC AMP训练中transpose存在性能问题，根据perm参数的不同，从模型中选取了两种占比较高的配置：
- perm=[2, 3, 0, 1]会调用TilingSwapDim1And2 cuda kernel
- perm=[1, 2, 0, 3]会调用Eigen 