### PR TITLE
add fp16 API config for slice

### DIFF
--- a/api/tests/configs/slice.json
+++ b/api/tests/configs/slice.json
@@ -62,4 +62,46 @@
             "value": "[0]"
         }
     }
+}, {
+    "op": "slice", 
+    "param_info": {
+        "axes": {
+            "type": "list", 
+            "value": "[0, 1, 2, 3]"
+        }, 
+        "ends": {
+            "type": "list", 
+            "value": "[100000000, 896L, 100000000, 100000000]"
+        }, 
+        "input": {
+            "dtype": "float32", 
+            "shape": "[512L, 1407L, 4L, 12L]", 
+            "type": "Variable"
+        }, 
+        "starts": {
+            "type": "list", 
+            "value": "[0, 0, 0, 0]"
+        }
+    }
+}, {
+    "op": "slice", 
+    "param_info": {
+        "axes": {
+            "type": "list", 
+            "value": "[0, 1, 2, 3]"
+        }, 
+        "ends": {
+            "type": "list", 
+            "value": "[100000000, 896L, 100000000, 100000000]"
+        }, 
+        "input": {
+            "dtype": "float16", 
+            "shape": "[512L, 1407L, 4L, 12L]", 
+            "type": "Variable"
+        }, 
+        "starts": {
+            "type": "list", 
+            "value": "[0, 0, 0, 0]"
+        }
+    }
 }]


### PR DESCRIPTION
ERNIE DOC模型中发现：AMP训练下slice_grad的反向GPU时间和FP32训练下基本一致，FP16性能需要优化。
添加的配置为模型中占比最高的一种