### PR TITLE
Reduce the size of cumsum's input.

### DIFF
--- a/api/tests/configs/cumsum.json
+++ b/api/tests/configs/cumsum.json
@@ -38,7 +38,7 @@
         },
         "x": {
             "dtype": "float32",
-            "shape": "[1700971L, 200L]",
+            "shape": "[1700971L, 100L]",
             "type": "Variable"
         }
     },


### PR DESCRIPTION
原来的配置可能是因为size太大，会导致运行失败，故减小size。
