### PR TITLE
Add an argument "unknown_dim" to allow to replace -1 in variable's shape and polish the parse of json output of log.

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -212,7 +212,7 @@ class APIConfig(object):
     def disabled(self):
         return False
 
-    def init_from_json(self, filename, config_id=0):
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
         if hasattr(self, "alias_config"):
             self.alias_config.init_from_json(
                 self.alias_filename(filename), config_id)
@@ -244,12 +244,12 @@ class APIConfig(object):
         for var in self.variable_list:
             for i in range(len(var.shape)):
                 if var.shape[i] == -1:
-                    var.shape[i] = 16
+                    var.shape[i] = unknown_dim
                 var_temp = var.shape[i]
                 if type(var_temp) == list:
                     for j in range(len(var_temp)):
                         if var_temp[j] == -1:
-                            var_temp[j] = 16
+                            var_temp[j] = unknown_dim
             setattr(self, var.name + '_shape', var.shape)
             setattr(self, var.name + '_dtype', var.dtype)
         return self

--- a/api/common/feeder.py
+++ b/api/common/feeder.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 import six
 import collections
 import numpy as np
-import paddle.fluid as fluid
 
 if six.PY3:
     from . import paddle_api_benchmark as paddle_api
@@ -101,6 +100,8 @@ class FeederAdapter(object):
         self.__feed_list = feed_list
 
     def to_paddle(self, feed_vars):
+        import paddle.fluid as fluid
+
         if self.__framework == "paddle":
             return self.__feed_list
         else:  # self.__framework == "tensorflow"

--- a/api/json/clear_params.py
+++ b/api/json/clear_params.py
@@ -92,6 +92,7 @@ def check_and_clear_params(api_name, params, print_detail=False):
                 if print_detail:
                     print("   Argument %s is not set." % (arg_name))
 
+        non_params = []
         for name, content in params.items():
             if name not in argspec.args or name in no_need_args:
                 if print_detail:
@@ -102,7 +103,9 @@ def check_and_clear_params(api_name, params, print_detail=False):
                     else:
                         print("   Remove %s (type: %s, value: %s)." %
                               (name, content["type"], content["value"]))
-                params.pop(name)
+                non_params.append(name)
+        for name in non_params:
+            params.pop(name)
 
         no_need_args.remove("name")
 

--- a/api/tests/accuracy.py
+++ b/api/tests/accuracy.py
@@ -19,8 +19,9 @@ class AccuracyConfig(APIConfig):
     def __init__(self):
         super(AccuracyConfig, self).__init__('accuracy')
 
-    def init_from_json(self, filename, config_id=0):
-        super(AccuracyConfig, self).init_from_json(filename, config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(AccuracyConfig, self).init_from_json(filename, config_id,
+                                                   unknown_dim)
         input_rank = len(self.input_shape)
         self.num_classes = self.input_shape[input_rank - 1]
         self.feed_spec = [

--- a/api/tests/batch_norm.py
+++ b/api/tests/batch_norm.py
@@ -19,10 +19,9 @@ class BatchNormConfig(APIConfig):
     def __init__(self):
         super(BatchNormConfig, self).__init__('batch_norm')
 
-    def init_from_json(self, filename, config_id=0):
-        super(BatchNormConfig, self).init_from_json(filename, config_id)
-        if self.input_shape[0] == -1:
-            self.input_shape[0] = 16
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(BatchNormConfig, self).init_from_json(filename, config_id,
+                                                    unknown_dim)
         # TFBatchNorm does not have data_layout param, it only support NHWC format.
         if self.data_layout == "NCHW":
             self.run_tf = False

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -33,16 +33,15 @@ class Conv2dConfig(APIConfig):
             return True
         return False
 
-    def init_from_json(self, filename, config_id=0):
-        super(Conv2dConfig, self).init_from_json(filename, config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(Conv2dConfig, self).init_from_json(filename, config_id,
+                                                 unknown_dim)
         if isinstance(self.padding, int):
             self.padding = [self.padding, self.padding]
         if self.data_format == "NCHW":
             self.num_channels = self.input_shape[1]
         elif self.data_format == "NHWC":
             self.num_channels = self.input_shape[3]
-        if self.input_shape[0] == -1:
-            self.input_shape[0] = 64
         if isinstance(self.filter_size, int):
             self.filter_size = [self.filter_size, self.filter_size]
         if self.groups is None:

--- a/api/tests/conv2d_transpose.py
+++ b/api/tests/conv2d_transpose.py
@@ -20,8 +20,9 @@ class Conv2dTransposeConfig(Conv2dConfig):
     def __init__(self):
         super(Conv2dTransposeConfig, self).__init__("conv2d_transpose")
 
-    def init_from_json(self, filename, config_id=0):
-        super(Conv2dTransposeConfig, self).init_from_json(filename, config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(Conv2dTransposeConfig, self).init_from_json(filename, config_id,
+                                                          unknown_dim)
         self.filter_shape = [
             self.num_channels // self.groups, self.num_filters,
             self.filter_size[0], self.filter_size[1]

--- a/api/tests/depthwise_conv2d.py
+++ b/api/tests/depthwise_conv2d.py
@@ -21,8 +21,9 @@ class DepthwiseConv2dConfig(Conv2dConfig):
         super(DepthwiseConv2dConfig, self).__init__("depthwise_conv2d")
         self.run_tf = False
 
-    def init_from_json(self, filename, config_id=0):
-        super(DepthwiseConv2dConfig, self).init_from_json(filename, config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(DepthwiseConv2dConfig, self).init_from_json(filename, config_id,
+                                                          unknown_dim)
         assert self.num_channels == self.groups and self.num_filters % self.num_channels == 0
         if isinstance(self.dilation, int):
             self.dilation = [self.dilation, self.dilation]

--- a/api/tests/embedding.py
+++ b/api/tests/embedding.py
@@ -19,8 +19,9 @@ class EmbeddingConfig(APIConfig):
     def __init__(self):
         super(EmbeddingConfig, self).__init__('embedding')
 
-    def init_from_json(self, filename, config_id=0):
-        super(EmbeddingConfig, self).init_from_json(filename, config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(EmbeddingConfig, self).init_from_json(filename, config_id,
+                                                    unknown_dim)
         self.feed_spec = [
             {
                 "range": [0, self.size[0]]

--- a/api/tests/fc.py
+++ b/api/tests/fc.py
@@ -19,8 +19,8 @@ class FCConfig(APIConfig):
     def __init__(self):
         super(FCConfig, self).__init__('fc')
 
-    def init_from_json(self, filename, config_id=0):
-        super(FCConfig, self).init_from_json(filename, config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(FCConfig, self).init_from_json(filename, config_id, unknown_dim)
         num_flatten_dims = self.num_flatten_dims
         if num_flatten_dims < 0:
             num_flatten_dims = num_flatten_dims + len(self.input_shape)

--- a/api/tests/gather.py
+++ b/api/tests/gather.py
@@ -19,8 +19,9 @@ class GatherConfig(APIConfig):
     def __init__(self):
         super(GatherConfig, self).__init__('gather')
 
-    def init_from_json(self, filename, config_id=0):
-        super(GatherConfig, self).init_from_json(filename, config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(GatherConfig, self).init_from_json(filename, config_id,
+                                                 unknown_dim)
         self.feed_spec = [
             {
                 "range": [-10, 10]

--- a/api/tests/main.py
+++ b/api/tests/main.py
@@ -59,6 +59,11 @@ def parse_args():
         help='Only import params of API from json file in the specified position [0|1|...]'
     )
     parser.add_argument(
+        '--unknown_dim',
+        type=int,
+        default=16,
+        help='Specify the unknown dimension.')
+    parser.add_argument(
         '--check_output',
         type=utils.str2bool,
         default=False,
@@ -112,8 +117,8 @@ def parse_args():
 def test_main(pd_obj=None, tf_obj=None, config=None):
     assert config is not None, "API config must be set."
 
-    def _test_with_json_impl(filename, config_id):
-        config.init_from_json(filename, config_id)
+    def _test_with_json_impl(filename, config_id, unknown_dim):
+        config.init_from_json(filename, config_id, unknown_dim)
         if hasattr(config, "api_list"):
             if args.api_name != None:
                 assert args.api_name in config.api_list, "api_name should be one value in %s, but recieved %s." % (
@@ -132,13 +137,13 @@ def test_main(pd_obj=None, tf_obj=None, config=None):
         # Set the filename to alias config's filename, when there is a alias config.
         filename = config.alias_filename(args.json_file)
         if args.config_id is not None and args.config_id >= 0:
-            _test_with_json_impl(filename, args.config_id)
+            _test_with_json_impl(filename, args.config_id, args.unknown_dim)
         else:
             num_configs = 0
             with open(filename, 'r') as f:
                 num_configs = len(json.load(f))
             for config_id in range(0, num_configs):
-                _test_with_json_impl(filename, config_id)
+                _test_with_json_impl(filename, config_id, args.unknown_dim)
     else:
         test_main_without_json(pd_obj, tf_obj, config)
 

--- a/api/tests/one_hot.py
+++ b/api/tests/one_hot.py
@@ -19,8 +19,9 @@ class OneHotConfig(APIConfig):
     def __init__(self):
         super(OneHotConfig, self).__init__('one_hot')
 
-    def init_from_json(self, filename, config_id=0):
-        super(OneHotConfig, self).init_from_json(filename, config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(OneHotConfig, self).init_from_json(filename, config_id,
+                                                 unknown_dim)
         self.feed_spec = {"range": [0, self.depth]}
 
 

--- a/api/tests/pool2d.py
+++ b/api/tests/pool2d.py
@@ -19,8 +19,9 @@ class Pool2dConfig(APIConfig):
     def __init__(self):
         super(Pool2dConfig, self).__init__('pool2d')
 
-    def init_from_json(self, filename, config_id=0):
-        super(Pool2dConfig, self).init_from_json(filename, config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(Pool2dConfig, self).init_from_json(filename, config_id,
+                                                 unknown_dim)
         self.pool_type = self.pool_type.lower()
         if isinstance(self.pool_padding, int):
             self.pool_size = [self.pool_padding, self.pool_padding]

--- a/api/tests/resize_nearest.py
+++ b/api/tests/resize_nearest.py
@@ -19,8 +19,9 @@ class ResizeNearestConfig(APIConfig):
     def __init__(self, op_type="resize_nearest"):
         super(ResizeNearestConfig, self).__init__(op_type)
 
-    def init_from_json(self, filename, config_id=0):
-        super(ResizeNearestConfig, self).init_from_json(filename, config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(ResizeNearestConfig, self).init_from_json(filename, config_id,
+                                                        unknown_dim)
         if self.data_format == "NCHW":
             # tf only support NHWC
             if len(self.input_shape) == 4:

--- a/api/tests/sequence_mask.py
+++ b/api/tests/sequence_mask.py
@@ -19,8 +19,9 @@ class SequenceMaskConfig(APIConfig):
     def __init__(self):
         super(SequenceMaskConfig, self).__init__('sequence_mask')
 
-    def init_from_json(self, filename, config_id=0):
-        super(SequenceMaskConfig, self).init_from_json(filename, config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(SequenceMaskConfig, self).init_from_json(filename, config_id,
+                                                       unknown_dim)
         if hasattr(self, "maxlen_shape"):
             self.maxlen = 3
 

--- a/api/tests/softmax_with_cross_entropy.py
+++ b/api/tests/softmax_with_cross_entropy.py
@@ -21,9 +21,9 @@ class SoftmaxWithCrossEntropyConfig(APIConfig):
               self).__init__("softmax_with_cross_entropy")
         self.atol = 1e-3
 
-    def init_from_json(self, filename, config_id=0):
-        super(SoftmaxWithCrossEntropyConfig, self).init_from_json(filename,
-                                                                  config_id)
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(SoftmaxWithCrossEntropyConfig, self).init_from_json(
+            filename, config_id, unknown_dim)
         logits_rank = len(self.logits_shape)
         self.num_classes = self.logits_shape[logits_rank - 1]
         self.feed_spec = [


### PR DESCRIPTION
- op测试的json配置在模型组网阶段收集到的，因此会存在很多-1，这些-1在运行时通常都会被实际使用的batch_size替换。master的做法是把这个-1都替换成了16，实际可能需要测试一些不同的batch_size，因此添加参数`unknown_dim`，允许通过参数`--unknown_dim 128`来设置不同的batch_size。

- summary.py在解析log文件中的json输出时，默认json是在log文件的最后一行。升级到py3.7和tf2.3之后，tf的log文件最后几行如下，json不在最后一行，因此解析失败。这个PR对json解析进行了加强，会尝试从最后一行往上追溯，直到解析到json格式的输出，或者遍历到最后一行。

```
...
{"name": "abs", "backward": true, "consistent": true, "num_outputs": 2, "diff": 0.0, "parameters": "x (Variable) - dtype: float32, shape: [1]\n"}
/usr/local/lib/python3.7/site-packages/tensorflow/python/data/ops/iterator_ops.py:546: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  class IteratorBase(collections.Iterator, trackable.Trackable,
/usr/local/lib/python3.7/site-packages/tensorflow/python/autograph/utils/testing.py:21: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
```

----------

CI挂掉是因为一些op的精度检查atol不满足条件：

```
[11:00:33]	---- The 0-th output (shape: (16, 512, 16, 16), data type: float32) has diff. The maximum diff is 1.678467e-04, offset is 639873: 79.33097 vs 79.3308. atol is 1.00e-04.
[11:00:33]	The output is not consistent.
[11:00:33]	{"name": "conv2d_transpose", "backward": false, "consistent": false, "num_outputs": 1, "diff": 0.0001678466796875, "parameters": "input (Variable) - dtype: float32, shape: [16, 1549, 8, 8]\nact (string): None\ndata_format (string): NCHW\ndilation (int): 1\nfilter_size (int): 4\ngroups (string): None\nnum_filters (int): 512\noutput_size (list): [16, 16]\npadding (list): [1, 1]\nstride (int): 2\nuse_cudnn (bool): True\n"}
```