### PR TITLE
Add two configs of conv2d.

### DIFF
--- a/api/tests/configs/conv2d.json
+++ b/api/tests/configs/conv2d.json
@@ -999,4 +999,94 @@
             "value": "False"
         }
     }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "tuple",
+            "value": "(16, 16)"
+        },
+        "filter_size": {
+            "type": "tuple",
+            "value": "(3, 3)"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[2L, 512L, 129L, 129L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "512"
+        },
+        "padding": {
+            "type": "tuple",
+            "value": "(0, 0)"
+        },
+        "stride": {
+            "type": "tuple",
+            "value": "(1, 1)"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+}, {
+    "op": "conv2d",
+    "param_info": {
+        "act": {
+            "type": "string",
+            "value": "None"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "dilation": {
+            "type": "tuple",
+            "value": "(16, 16)"
+        },
+        "filter_size": {
+            "type": "tuple",
+            "value": "(3, 3)"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[2L, 512L, 129L, 129L]",
+            "type": "Variable"
+        },
+        "num_filters": {
+            "type": "int",
+            "value": "512"
+        },
+        "padding": {
+            "type": "tuple",
+            "value": "(0, 0)"
+        },
+        "stride": {
+            "type": "tuple",
+            "value": "(1, 1)"
+        },
+        "use_cudnn": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
 }]


### PR DESCRIPTION
添加2个conv2d的配置。主要参数：
```
input (Variable) - dtype: float32, shape: [2, 512, 129, 129]
act (string): None
data_format (string): NCHW
dilation (tuple): [16, 16]
filter_size (tuple): [3, 3]
groups (int): 1
num_filters (int): 512
padding (tuple): [0, 0]
stride (tuple): [1, 1]
```


- GPU Kernel时间

| 测试类型 | paddle | tf2.3 |
|---|---|---|
| use_cudnn=True, backward=False | 6.5492 ms | 6.5767 ms |
| use_cudnn=False, backward=False | 7.8169 ms | - |
| use_cudnn=True, backward=True | 169.8235 ms | 21.5862 ms |
| use_cudnn=False, baclward=True | 34.2407 ms | - |

### nvprof数据
- paddle，use_cudnn=True，backward=False
```
run command: nvprof /root/.virtualenvs_cuda10.1/paddle_py37/bin/python /work/benchmark/api/tests/conv2d.py --task speed --framework paddle --json_file /work/benchmark/api/tests/configs/conv2d.json --config_id 22 --check_output False --profiler none --backward False --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   99.35%  6.50664s      1001  6.5001ms  6.4113ms  7.2945ms  volta_scudnn_128x64_relu_interior_nn_v1
                    0.62%  40.295ms         9  4.4772ms  1.6960us  35.926ms  [CUDA memcpy HtoD]
                    0.03%  1.6799ms      1001  1.6780us  1.6310us  4.0320us  cask_cudnn::computeOffsetsKernel(cask_cudnn::ComputeOffsetsParams)
                    0.01%  327.45us         1  327.45us  327.45us  327.45us  void thrust::cuda_cub::core::_kernel_agent<thrust::cuda_cub::__parallel_for::ParallelForAgent<thrust::cuda_cub::__transform::unary_transform_f<thrust::counting_iterator<unsigned int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::GaussianGenerator<float>, thrust::cuda_cub::__transform::always_true_predicate>, long>, thrust::cuda_cub::__transform::unary_transform_f<thrust::counting_iterator<unsigned int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::GaussianGenerator<float>, thrust::cuda_cub::__transform::always_true_predicate>, long>(thrust::use_default, thrust::use_default)

percent: 0.99; gpu_time: 6506.6400 ms; calls: 1001; function: volta_scudnn_128x64_relu_interior_nn_v1
total gpu_time: 6549.2099 ms
```

- paddle，use_cudnn=False，backward=False
```
run command: nvprof /root/.virtualenvs_cuda10.1/paddle_py37/bin/python /work/benchmark/api/tests/conv2d.py --task speed --framework paddle --json_file /work/benchmark/api/tests/configs/conv2d.json --config_id 23 --check_output False --profiler none --backward False --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   83.76%  6.54741s      2002  3.2704ms  3.2223ms  3.7428ms  volta_sgemm_128x128_nn
                   15.70%  1.22761s      2002  613.19us  603.26us  625.63us  void paddle::operators::math::im2col<float>(float const *, int, int, int, int, int, int, int, int, int, int, int, int, int, paddle::operators::math::im2col<float>*, paddle::framework::DataLayout)
                    0.48%  37.784ms         9  4.1982ms  1.7280us  33.578ms  [CUDA memcpy HtoD]
                    0.05%  3.5573ms      2006  1.7730us  1.6000us  7.5200us  [CUDA memset]

percent: 0.84; gpu_time: 6547.4100 ms; calls: 2002; function: volta_sgemm_128x128_nn
total gpu_time: 7816.8696 ms
```

- paddle，use_cudnn=True，backward=True
```
run command: nvprof /root/.virtualenvs_cuda10.1/paddle_py37/bin/python /work/benchmark/api/tests/conv2d.py --task speed --framework paddle --json_file /work/benchmark/api/tests/configs/conv2d.json --config_id 22 --check_output False --profiler none --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   91.77%  155.847s      1001  155.69ms  153.95ms  180.53ms  void dgrad2d_grouped_direct_kernel<float, float, float, bool=1, int=0, int=3, cudnnTensorFormat_t=0>(cudnnTensorStruct, float const *, cudnnFilterStruct, float const *, cudnnConvolutionStruct, cudnnTensorStruct, float*, float, float, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor)
                    4.51%  7.66446s      1001  7.6568ms  7.6120ms  8.6830ms  volta_scudnn_128x64_stridedB_splitK_interior_nn_v1
                    3.69%  6.27040s      1001  6.2641ms  6.2247ms  7.2944ms  volta_scudnn_128x64_relu_interior_nn_v1
                    0.02%  32.527ms         9  3.6141ms  1.6960us  28.865ms  [CUDA memcpy HtoD]
                    0.00%  3.1344ms      2006  1.5620us  1.5030us  7.4560us  [CUDA memset]
                    0.00%  1.6697ms      1001  1.6670us  1.6000us  6.9120us  cask_cudnn::computeWgradSplitKOffsetsKernel(cask_cudnn::ComputeSplitKOffsetsParams)
                    0.00%  1.6344ms      1001  1.6320us  1.5990us  6.8800us  cask_cudnn::computeOffsetsKernel(cask_cudnn::ComputeOffsetsParams)
                    0.00%  1.2856ms      1001  1.2840us  1.2160us  7.0080us  cask_cudnn::computeWgradBOffsetsKernel(cask_cudnn::ComputeWgradBOffsetsParams)
                    0.00%  328.03us         1  328.03us  328.03us  328.03us  void thrust::cuda_cub::core::_kernel_agent<thrust::cuda_cub::__parallel_for::ParallelForAgent<thrust::cuda_cub::__transform::unary_transform_f<thrust::counting_iterator<unsigned int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::GaussianGenerator<float>, thrust::cuda_cub::__transform::always_true_predicate>, long>, thrust::cuda_cub::__transform::unary_transform_f<thrust::counting_iterator<unsigned int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::device_ptr<float>, thrust::cuda_cub::__transform::no_stencil_tag, paddle::operators::GaussianGenerator<float>, thrust::cuda_cub::__transform::always_true_predicate>, long>(thrust::use_default, thrust::use_default)

percent: 0.92; gpu_time: 155847.0000 ms; calls: 1001; function: void dgrad2d_grouped_direct_kernel<float, float, float, bool=1, int=0, int=3, cudnnTensorFormat_t=0>(cudnnTensorStruct, float const *, cudnnFilterStruct, float const *, cudnnConvolutionStruct, cudnnTensorStruct, float*, float, float, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor)
total gpu_time: 169823.4717 ms
```

- paddle，use_cudnn=False，backward=True
```
run command: nvprof /root/.virtualenvs_cuda10.1/paddle_py37/bin/python /work/benchmark/api/tests/conv2d.py --task speed --framework paddle --json_file /work/benchmark/api/tests/configs/conv2d.json --config_id 23 --check_output False --profiler none --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   34.86%  11.9363s      2002  5.9622ms  5.8151ms  6.7139ms  void paddle::operators::math::col2im<float>(int, float const *, int, int, int, int, int, int, int, int, int, int, int, int, paddle::operators::math::col2im<float>*, paddle::framework::DataLayout)
                   19.84%  6.79447s      2002  3.3938ms  3.2183ms  3.7996ms  volta_sgemm_128x32_tn
                   19.46%  6.66478s      2002  3.3291ms  3.2520ms  3.7305ms  volta_sgemm_128x128_nn
                   18.28%  6.25979s      2002  3.1268ms  3.0598ms  3.4959ms  volta_sgemm_32x128_nt
                    7.14%  2.44611s      4004  610.92us  599.81us  625.31us  void paddle::operators::math::im2col<float>(float const *, int, int, int, int, int, int, int, int, int, int, int, int, int, paddle::operators::math::im2col<float>*, paddle::framework::DataLayout)
                    0.26%  89.635ms      2003  44.750us  10.144us  81.503us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                    0.13%  42.905ms         9  4.7673ms  1.7280us  38.419ms  [CUDA memcpy HtoD]
                    0.02%  7.3414ms      4008  1.8310us  1.6000us  7.4880us  [CUDA memset]

percent: 0.35; gpu_time: 11936.3000 ms; calls: 2002; function: void paddle::operators::math::col2im<float>(int, float const *, int, int, int, int, int, int, int, int, int, int, int, int, paddle::operators::math::col2im<float>*, paddle::framework::DataLayout)
total gpu_time: 34240.6770 ms
```

- tf，backward=False
```
run command: nvprof /root/.virtualenvs_cuda10.1/paddle_py37/bin/python /work/benchmark/api/tests/conv2d.py --task speed --framework tf --json_file /work/benchmark/api/tests/configs/conv2d.json --config_id 22 --check_output False --profiler none --backward False --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   98.99%  6.51023s      1002  6.4972ms  6.4141ms  7.2946ms  volta_scudnn_128x64_relu_interior_nn_v1
                    0.75%  49.433ms      1001  49.383us  48.511us  57.407us  void tensorflow::functor::ShuffleInTensor3Simple<float, int=2, int=1, int=0, bool=0>(int, float const *, tensorflow::functor::Dimension<int=3>, tensorflow::functor::ShuffleInTensor3Simple<float, int=2, int=1, int=0, bool=0>*)
                    0.13%  8.5625ms         1  8.5625ms  8.5625ms  8.5625ms  void cudnn::detail::implicit_convolve_sgemm<float, float, int=128, int=6, int=7, int=3, int=3, int=5, int=1, bool=1, bool=0, bool=0>(int, int, int, float const *, int, float*, cudnn::detail::implicit_convolve_sgemm<float, float, int=128, int=6, int=7, int=3, int=3, int=5, int=1, bool=1, bool=0, bool=0>*, kernel_conv_params, int, float, float, int, float, float, int, int)
                    0.10%  6.3445ms         5  1.2689ms  1.6960us  5.5659ms  [CUDA memcpy HtoD]
                    0.03%  1.6743ms      1002  1.6700us  1.6000us  6.5920us  cask_cudnn::computeOffsetsKernel(cask_cudnn::ComputeOffsetsParams)
                    0.00%  271.46us         6  45.242us  43.808us  48.000us  redzone_checker
                    0.00%  29.375us        14  2.0980us  1.5680us  7.3280us  [CUDA memset]

percent: 0.99; gpu_time: 6510.2300 ms; calls: 1002; function: volta_scudnn_128x64_relu_interior_nn_v1
total gpu_time: 6576.6542 ms
```

- tf，backward=True
```
run command: nvprof /root/.virtualenvs_cuda10.1/paddle_py37/bin/python /work/benchmark/api/tests/conv2d.py --task speed --framework tf --json_file /work/benchmark/api/tests/configs/conv2d.json --config_id 22 --check_output False --profiler none --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   34.41%  7.42780s      1002  7.4130ms  7.2733ms  7.7402ms  void cudnn::detail::dgrad_engine<float, int=128, int=6, int=8, int=3, int=3, int=5, bool=1>(int, int, int, float const *, int, float const , int, cudnn::detail::dgrad_engine<float, int=128, int=6, int=8, int=3, int=3, int=5, bool=1>*, kernel_grad_params, int, int, float, int, int, int)
                   33.64%  7.26168s      1002  7.2472ms  7.1010ms  8.3015ms  void cudnn::detail::wgrad_alg0_engine<float, int=128, int=6, int=8, int=3, int=3, int=5, bool=1, int=512>(int, int, int, float const *, int, cudnn::detail::wgrad_alg0_engine<float, int=128, int=6, int=8, int=3, int=3, int=5, bool=1, int=512>*, float const , kernel_grad_params, int, float, int, int, int, int)
                   29.58%  6.38561s      1002  6.3729ms  6.2878ms  7.2931ms  volta_scudnn_128x64_relu_interior_nn_v1
                    0.98%  211.99ms      3003  70.591us  47.136us  125.34us  void tensorflow::functor::ShuffleInTensor3Simple<float, int=2, int=1, int=0, bool=0>(int, float const *, tensorflow::functor::Dimension<int=3>, tensorflow::functor::ShuffleInTensor3Simple<float, int=2, int=1, int=0, bool=0>*)
                    0.81%  174.09ms         1  174.09ms  174.09ms  174.09ms  void dgrad2d_grouped_direct_kernel<float, float, float, bool=1, int=0, int=3, cudnnTensorFormat_t=0>(cudnnTensorStruct, float const *, cudnnFilterStruct, float const *, cudnnConvolutionStruct, cudnnTensorStruct, float*, float, float, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor, cudnn::reduced_divisor)
                    0.45%  97.057ms      1002  96.863us  95.423us  100.99us  void scalePackedTensor_kernel<float, float>(cudnnTensor4dStruct, float*, float)
                    0.04%  9.5286ms         6  1.5881ms  1.6960us  5.5785ms  [CUDA memcpy HtoD]
                    0.04%  8.7620ms         1  8.7620ms  8.7620ms  8.7620ms  volta_scudnn_128x64_stridedB_splitK_interior_nn_v1
                    0.04%  8.0951ms         1  8.0951ms  8.0951ms  8.0951ms  void cudnn::detail::implicit_convolve_sgemm<float, float, int=128, int=6, int=7, int=3, int=3, int=5, int=1, bool=1, bool=0, bool=0>(int, int, int, float const *, int, float*, cudnn::detail::implicit_convolve_sgemm<float, float, int=128, int=6, int=7, int=3, int=3, int=5, int=1, bool=1, bool=0, bool=0>*, kernel_conv_params, int, float, float, int, float, float, int, int)
                    0.01%  1.6208ms      1002  1.6170us  1.5680us  2.9440us  cask_cudnn::computeOffsetsKernel(cask_cudnn::ComputeOffsetsParams)
                    0.01%  1.6132ms      1032  1.5630us  1.5040us  7.1360us  [CUDA memset]
                    0.00%  709.88us        16  44.367us  40.896us  48.352us  redzone_checker
                    0.00%  16.896us         8  2.1120us  1.8880us  2.9120us  [CUDA memcpy DtoH]
                    0.00%  2.4320us         1  2.4320us  2.4320us  2.4320us  cask_cudnn::computeWgradSplitKOffsetsKernel(cask_cudnn::ComputeSplitKOffsetsParams)

percent: 0.34; gpu_time: 7427.8000 ms; calls: 1002; function: void cudnn::detail::dgrad_engine<float, int=128, int=6, int=8, int=3, int=3, int=5, bool=1>(int, int, int, float const *, int, float const , int, cudnn::detail::dgrad_engine<float, int=128, int=6, int=8, int=3, int=3, int=5, bool=1>*, kernel_grad_params, int, int, float, int, int, int)
total gpu_time: 21586.1668 ms
```