### PR TITLE
add abs 2.0 tests

### DIFF
--- a/api/tests_v2/abs.py
+++ b/api/tests_v2/abs.py
@@ -19,7 +19,7 @@ class AbsConfig(APIConfig):
     def __init__(self):
         super(AbsConfig, self).__init__("abs")
         self.feed_spec = {"range": [-1, 1]}
-        # abs belongs to actication op series
+        # abs belongs to activation op series which only has one variable
         # thus abs can reuse activation parameters 
         self.alias_config = APIConfig("activation")
 

--- a/api/tests_v2/abs.py
+++ b/api/tests_v2/abs.py
@@ -1,0 +1,50 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class AbsConfig(APIConfig):
+    def __init__(self):
+        super(AbsConfig, self).__init__("abs")
+        self.feed_spec = {"range": [-1, 1]}
+        self.alias_config = APIConfig("activation")
+
+
+class PDAbs(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(
+            name="x", shape=config.alias.x_shape, dtype=config.alias.x_dtype)
+        result = paddle.abs(x=x)
+
+        self.feed_vars = [x]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TFAbs(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(
+            name='x', shape=config.alias.x_shape, dtype=config.alias.x_dtype)
+        result = tf.abs(x=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(PDAbs(), TFAbs(), config=AbsConfig())

--- a/api/tests_v2/abs.py
+++ b/api/tests_v2/abs.py
@@ -19,6 +19,8 @@ class AbsConfig(APIConfig):
     def __init__(self):
         super(AbsConfig, self).__init__("abs")
         self.feed_spec = {"range": [-1, 1]}
+        # abs belongs to actication op series
+        # thus abs can reuse activation parameters 
         self.alias_config = APIConfig("activation")
 
 

--- a/api/tests_v2/configs/activation.json
+++ b/api/tests_v2/configs/activation.json
@@ -1,0 +1,20 @@
+[{
+    "op": "activation",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 128L, 257L, 257L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 5000
+}, {
+    "op": "activation",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[1L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -60,8 +60,9 @@ function fetch_upstream_master_if_not_exist() {
 
 function run_api(){
     fetch_upstream_master_if_not_exist
-    HAS_MODIFIED_API_TEST=`git diff --name-status upstream/$BRANCH | awk '$1!="D" {print $2}' | grep "api/tests.*.py$" || true`
-    API_NAMES=(abs elementwise fc)
+    HAS_MODIFIED_API_TEST=`git diff --name-status upstream/$BRANCH | awk '$1!="D" {print $2}' | grep "api/tests_v2.*.py$" || true`
+    #API_NAMES=(abs elementwise fc)
+    API_NAMES=(abs)
     if [ "${HAS_MODIFIED_API_TEST}" != "" ] ; then
         for api in ${HAS_MODIFIED_API_TEST[@]}; do
             new_name=`echo $api |awk -F "/" '{print $NF}' |awk -F "." '{print $NR}'`
@@ -82,7 +83,7 @@ function run_api(){
 
     fail_name=()
     for name in ${API_NAMES[@]}; do
-        bash ${BENCHMARK_ROOT}/api/tests/run.sh $name -1
+        bash ${BENCHMARK_ROOT}/api/tests_v2/run.sh $name -1
         if [ $? -ne 0 ]; then
             fail_name[${#fail_name[@]}]="$name.py"
         fi


### PR DESCRIPTION
为了测试 paddle 2.0 的API性能，目前新建路径：api/tests_v2

- 新增 abs 2.0 测试脚本和参数