### PR TITLE
Set backward default True and add approval for special_op_list.py

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -50,3 +50,4 @@ ALIAS_OP_MAP = {
     "hierarchical_sigmoid": "hsigmoid",
     "sample_logits": "sampled_softmax_with_cross_entropy"
 }
+

--- a/api/tests_v2/run.sh
+++ b/api/tests_v2/run.sh
@@ -26,7 +26,7 @@ run_args="--task ${task} \
           --config_id ${config_id} \
           --check_output False \
           --profiler none \
-          --backward False \
+          --backward True \
           --use_gpu True \
           --repeat 1 \
           --allow_adaptive_repeat False \

--- a/ci/scripts/check_approval.sh
+++ b/ci/scripts/check_approval.sh
@@ -25,7 +25,7 @@ BENCHMARK_ROOT=$(cd $(dirname $0)/../../ && pwd)
 
 declare -A FILE_APPROVAL_USER_MAP
 FILE_APPROVAL_USER_MAP=(
-  ["api/common/special_op_list.py"]="Xreki GaoWei8"
+  ["api/common/special_op_list.py"]="GaoWei8 wangchaochaohu zhangting2020"
 )
 
 LOG "[INFO] Get approval list ..."

--- a/ci/scripts/check_approval.sh
+++ b/ci/scripts/check_approval.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function LOG {
+  echo [$(basename $0):${BASH_LINENO[-2]}] $* >&2
+}
+
+LOG "[INFO] Start check approval ..."
+
+EXIT_CODE=0
+BENCHMARK_ROOT=$(cd $(dirname $0)/../../ && pwd)
+
+declare -A FILE_APPROVAL_USER_MAP
+FILE_APPROVAL_USER_MAP=(
+  ["api/common/special_op_list.py"]="Xreki GaoWei8"
+)
+
+LOG "[INFO] Get approval list ..."
+
+declare -A APPROVALED_USER_MAP
+approval_line=$(curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/benchmark/pulls/${AGILE_PULL_ID}/reviews?per_page=10000)
+[ $? -ne 0 ] && LOG "[FATAL] Get review information from github faied" && exit -1
+for user in $(echo $approval_line | jq .[].user.login)
+do
+  APPROVALED_USER_MAP[$user]="approvaled"
+  LOG "[INFO] ${user} approval this PR."
+done
+
+for file in $(git diff --name-only upstream/master)
+do
+  if [ -n "${FILE_APPROVAL_USER_MAP[$file]}" ]
+  then
+    need_approval=1
+    approval_user=""
+    for user in ${FILE_APPROVAL_USER_MAP[$file]}
+    do
+      [ -n "${APPROVALED_USER_MAP[$user]}" ] && need_approval=0 && break
+      approval_user="$user, ${approval_user}"
+    done
+    if [ $need_approval -ne 0 ]
+    then
+      EXIT_CODE=1
+      LOG "[FATAL] You must have one RD (${approval_user%,*}) approval for the ${file}"
+    fi
+  fi
+done
+
+[ $EXIT_CODE -ne 0 ] && LOG "[FATAL] Check approval failed." || LOG "[INFO] Check approval success."
+exit $EXIT_CODE

--- a/ci/scripts/check_approval.sh
+++ b/ci/scripts/check_approval.sh
@@ -31,7 +31,7 @@ FILE_APPROVAL_USER_MAP=(
 LOG "[INFO] Get approval list ..."
 
 declare -A APPROVALED_USER_MAP
-approval_line=$(curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/benchmark/pulls/${AGILE_PULL_ID}/reviews?per_page=10000)
+approval_line=$(curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/benchmark/pulls/${AGILE_PULL_ID}/reviews?per_page=10000 2> /dev/null)
 [ $? -ne 0 ] && LOG "[FATAL] Get review information from github faied" && exit -1
 for user in $(echo $approval_line | jq .[].user.login)
 do

--- a/ci/scripts/check_approval.sh
+++ b/ci/scripts/check_approval.sh
@@ -33,7 +33,7 @@ LOG "[INFO] Get approval list ..."
 declare -A APPROVALED_USER_MAP
 approval_line=$(curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/benchmark/pulls/${AGILE_PULL_ID}/reviews?per_page=10000 2> /dev/null)
 [ $? -ne 0 ] && LOG "[FATAL] Get review information from github faied" && exit -1
-for user in $(echo $approval_line | jq .[].user.login)
+for user in $(echo $approval_line | jq .[].user.login | sed 's|"||g')
 do
   APPROVALED_USER_MAP[$user]="approvaled"
   LOG "[INFO] ${user} approval this PR."
@@ -52,7 +52,7 @@ do
     done
     if [ $need_approval -ne 0 ]
     then
-      EXIT_CODE=1
+      EXIT_CODE=6
       LOG "[FATAL] You must have one RD (${approval_user%,*}) approval for the ${file}"
     fi
   fi


### PR DESCRIPTION
1. Add approval check for api/common/special_op_list.py. 
CI will fail when no reviewers approval this PR.
![image](https://user-images.githubusercontent.com/23427135/93764913-966f2c80-fc46-11ea-9022-58f81fb4c9f6.png)
When reviewer approval.
![image](https://user-images.githubusercontent.com/23427135/93766768-7f7e0980-fc49-11ea-8768-fa743a2c1b1b.png)

2. Set default value True of `backward`.