### PR TITLE
Add Transpose to OP Benchmark

### DIFF
--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -21,6 +21,7 @@ import contextlib
 import importlib
 import logging
 import numpy as np
+import sys
 
 if six.PY3:
     from . import utils

--- a/api/tests_v2/transpose.py
+++ b/api/tests_v2/transpose.py
@@ -1,0 +1,47 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import test_main
+from common_import import APIConfig
+from common_import import PaddleAPIBenchmarkBase
+from common_import import TensorflowAPIBenchmarkBase
+
+import paddle
+import tensorflow as tf
+
+class PDTranspose(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.transpose(x, config.perm)
+
+        self.feed_vars = [x]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TFTranspose(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = tf.transpose(x, config.perm)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(PDTranspose(), TFTranspose(), config=APIConfig('transpose'))
+

--- a/api/tests_v2/transpose.py
+++ b/api/tests_v2/transpose.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from common_import import test_main
-from common_import import APIConfig
-from common_import import PaddleAPIBenchmarkBase
-from common_import import TensorflowAPIBenchmarkBase
-
-import paddle
-import tensorflow as tf
+from common_import import *
 
 
 class PDTranspose(PaddleAPIBenchmarkBase):

--- a/api/tests_v2/transpose.py
+++ b/api/tests_v2/transpose.py
@@ -20,6 +20,7 @@ from common_import import TensorflowAPIBenchmarkBase
 import paddle
 import tensorflow as tf
 
+
 class PDTranspose(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
@@ -44,4 +45,3 @@ class TFTranspose(TensorflowAPIBenchmarkBase):
 
 if __name__ == '__main__':
     test_main(PDTranspose(), TFTranspose(), config=APIConfig('transpose'))
-


### PR DESCRIPTION
As the title.

Also fixed a bug that `paddle_api_benchmark.py` uses `sys.stderr.write` but did not import `sys`

This PR doesn't contain the config file `transpose.json` because I found it already existed.