### PR TITLE
add histogram 2.0 test

### DIFF
--- a/api/tests_v2/configs/histogram.json
+++ b/api/tests_v2/configs/histogram.json
@@ -1,0 +1,85 @@
+[{
+  "op": "histogram",
+  "param_info": {
+      "input": {
+        "dtype": "int32",
+        "shape": "[-1L, 64L]",
+        "type": "Variable"
+      },
+      "bins": {
+          "type": "int32",
+          "value": "100"
+      },
+      "min": {
+        "type": "int32",
+        "value": "0"
+      },
+      "max": {
+        "type": "int32",
+        "value": "0"
+      }
+  }
+},{
+  "op": "histogram",
+  "param_info": {
+      "input": {
+        "dtype": "int64",
+        "shape": "[-1L, 64L]",
+        "type": "Variable"
+      },
+      "bins": {
+          "type": "int32",
+          "value": "100"
+      },
+      "min": {
+        "type": "int32",
+        "value": "0"
+      },
+      "max": {
+        "type": "int32",
+        "value": "0"
+      }
+  }
+},{
+  "op": "histogram",
+  "param_info": {
+      "input": {
+        "dtype": "float32",
+        "shape": "[-1L, 64L]",
+        "type": "Variable"
+      },
+      "bins": {
+          "type": "int32",
+          "value": "100"
+      },
+      "min": {
+        "type": "int32",
+        "value": "0"
+      },
+      "max": {
+        "type": "int32",
+        "value": "0"
+      }
+  }
+},{
+  "op": "histogram",
+  "param_info": {
+      "input": {
+        "dtype": "float64",
+        "shape": "[-1L, 64L]",
+        "type": "Variable"
+      },
+      "bins": {
+          "type": "int32",
+          "value": "100"
+      },
+      "min": {
+        "type": "int32",
+        "value": "0"
+      },
+      "max": {
+        "type": "int32",
+        "value": "0"
+      }
+  }
+}]

--- a/api/tests_v2/histogram.py
+++ b/api/tests_v2/histogram.py
@@ -1,0 +1,36 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class HistogramConfig(APIConfig):
+    def __init__(self):
+        super(HistogramConfig, self).__init__("histogram")
+        self.run_tf = False
+
+
+class PDHistogram(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        input = self.variable(name='input', shape=config.input_shape, dtype=config.input_dtype)
+        out = paddle.histogram(input=input, bins=config.bins, min=config.min, max=config.max)
+
+        self.feed_vars = [input]
+        self.fetch_vars = [out]
+        if config.backward:
+            self.append_gradients(out, [input])
+
+
+if __name__ == '__main__':
+    test_main(pd_obj=PDHistogram(), config=HistogramConfig())


### PR DESCRIPTION
add histogram 2.0 test

paddle.histogram 开发的时候对照的是torch.histc，计算方式也等同于numpy.histogram和matlab.histc (可以参考 https://www.cnblogs.com/qinduanyinghua/p/12105979.html)；

然而TensorFlow中tf.summary.histogram的定义也相同，但是返回值是True/False，直方图的结果需要通过tf.summary.FileWriter写入文件，然后用tensorboard命令载入改文件之后进行图形化显示，具体例子可以参考
https://github.com/tensorflow/tensorboard/blob/master/docs/r1/histograms.md

所以无法直接将 paddle.histogram 和 tf.summary.histogram的性能进行对比，这个PR只实现了Paddle的PaddleAPIBenchmark，将config.run_tf设置成了False。