### PR TITLE
add unique API

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -22,7 +22,8 @@ NO_BACKWARD_OPS = [
     "clip_by_norm", "cumsum", "equal", "feed", "fetch", "fill_constant",
     "greater_equal", "greater_than", "increment", "isfinite", "less_equal",
     "less_than", "logical_not", "logical_and", "logical_or", "not_equal",
-    "null", "one_hot", "scale", "sequence_mask", "shape", "zeros_like"
+    "null", "one_hot", "scale", "sequence_mask", "shape", "zeros_like",
+    "unique"
 ]
 
 NO_NEED_ARGS = {
@@ -50,4 +51,3 @@ ALIAS_OP_MAP = {
     "hierarchical_sigmoid": "hsigmoid",
     "sample_logits": "sampled_softmax_with_cross_entropy"
 }
-

--- a/api/tests_v2/configs/unique.json
+++ b/api/tests_v2/configs/unique.json
@@ -1,0 +1,59 @@
+[{
+    "op": "unique",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[100L, 100L]",
+            "type": "Variable"
+        },
+        "return_index": {
+            "type": "bool",
+            "value": "True"
+        },
+        "return_inverse": {
+            "type": "bool",
+            "value": "True"
+        },
+        "return_counts": {
+            "type": "bool",
+            "value": "True"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "dtype": {
+            "type": "string",
+            "value": "int64"
+        }
+    }
+}, {
+    "op": "unique",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[4L, 50L, 30L]",
+            "type": "Variable"
+        },
+        "return_index": {
+            "type": "bool",
+            "value": "True"
+        },
+        "return_inverse": {
+            "type": "bool",
+            "value": "True"
+        },
+        "return_counts": {
+            "type": "bool",
+            "value": "True"
+        },
+        "axis": {
+            "type": "int",
+            "value": "1"
+        },
+        "dtype": {
+            "type": "string",
+            "value": "int64"
+        }
+    }
+}]

--- a/api/tests_v2/unique.py
+++ b/api/tests_v2/unique.py
@@ -15,6 +15,12 @@
 from common_import import *
 
 
+class UniqueConfig(APIConfig):
+    def __init__(self):
+        super(UniqueConfig, self).__init__("unique")
+        self.run_tf = False
+
+
 class PDUnique(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
@@ -25,10 +31,13 @@ class PDUnique(PaddleAPIBenchmarkBase):
             return_counts=config.return_counts,
             axis=config.axis,
             dtype=config.dtype)
-
+        if isinstance(result, tuple):
+            result = list(result)
+        else:
+            result = [result]
         self.feed_vars = [x]
-        self.fetch_vars = [result]
+        self.fetch_vars = result
 
 
 if __name__ == '__main__':
-    test_main(PDUnique(), None, config=APIConfig("unique"))
+    test_main(pd_obj=PDUnique(), config=UniqueConfig())

--- a/api/tests_v2/unique.py
+++ b/api/tests_v2/unique.py
@@ -1,0 +1,34 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDUnique(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.unique(
+            x=x,
+            return_index=config.return_index,
+            return_inverse=config.return_inverse,
+            return_counts=config.return_counts,
+            axis=config.axis,
+            dtype=config.dtype)
+
+        self.feed_vars = [x]
+        self.fetch_vars = [result]
+
+
+if __name__ == '__main__':
+    test_main(PDUnique(), None, config=APIConfig("unique"))


### PR DESCRIPTION
- 只添加了Paddle的API，因为该接口不能与TF对齐：
该接口默认返回值是会排序的，输出元素按升序排序
![image](https://user-images.githubusercontent.com/26615455/93981717-e66b0200-fdb2-11ea-97a0-7ce55a531d8d.png)
但是TF的返回值不排序，也就是文档中所说的：输出中元素的顺序就是该元素在x中出现的顺序
![image](https://user-images.githubusercontent.com/26615455/93982122-6e510c00-fdb3-11ea-9d6b-415d8995b711.png)

- 该OP没有反向