### PR TITLE
fix topk bugs

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -25,6 +25,9 @@ NO_BACKWARD_OPS = [
     "null", "one_hot", "scale", "sequence_mask", "shape", "zeros_like"
 ]
 
+# length of tf gradient length is different with paddle.
+BACKWARD_CHECK_DIFF_OPS = ["TFTopK"]
+
 NO_NEED_ARGS = {
     "batch_norm": ["moving_mean_name", "moving_variance_name"],
     "embedding": ["is_distributed"]
@@ -50,4 +53,3 @@ ALIAS_OP_MAP = {
     "hierarchical_sigmoid": "hsigmoid",
     "sample_logits": "sampled_softmax_with_cross_entropy"
 }
-

--- a/api/common/tensorflow_api_benchmark.py
+++ b/api/common/tensorflow_api_benchmark.py
@@ -20,6 +20,7 @@ import time
 import abc, six
 import importlib
 import numpy as np
+from . import special_op_list
 
 if six.PY3:
     from . import utils
@@ -247,8 +248,11 @@ class TensorflowAPIBenchmarkBase(object):
         self.__backward = True
         # print("Gradients: ", gradients)
         if isinstance(gradients, list):
-            for grad in gradients:
-                self.fetch_list.append(grad)
+            grad_length = len(gradients)
+            if self.name in special_op_list.BACKWARD_CHECK_DIFF_OPS:
+                grad_length -= 1
+            for i in range(grad_length):
+                self.fetch_list.append(gradients[i])
         else:
             self.fetch_list.append(gradients)
 

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -26,7 +26,7 @@ run_args="--task ${task} \
           --config_id ${config_id} \
           --check_output False \
           --profiler none \
-          --backward False \
+          --backward True \
           --use_gpu True \
           --repeat 1 \
           --allow_adaptive_repeat False \


### PR DESCRIPTION
- 修复topk反向计算问题。

- 分析：paddle反向计算结果为2个tensor，tf的反向计算结果为3个tensor，多出了一个全0 tesnor。