### PR TITLE
Add interpolate 2.0 test

### DIFF
--- a/api/tests_v2/configs/interpolate.json
+++ b/api/tests_v2/configs/interpolate.json
@@ -1,0 +1,146 @@
+[{
+    "op": "interpolate",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "False"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NHWC"
+        },
+        "interp_mode": {
+            "type": "string",
+            "value": "BILINEAR"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 512L, 64L, 64L]",
+            "type": "Variable"
+        },
+        "size": {
+            "type": "list",
+            "value": "[128L,128L]"
+        },
+        "scale": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "op": "interpolate",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NHWC"
+        },
+        "interp_mode": {
+            "type": "string",
+            "value": "NEAREST"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 64L, 64L, 64L]",
+            "type": "Variable"
+        },
+        "size": {
+            "type": "list",
+            "value": "[128L, 128L]"
+        },
+        "scale": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "op": "interpolate",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "False"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NHWC"
+        },
+        "interp_mode": {
+            "type": "string",
+            "value": "BILINEAR"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 64L, 64L, 64L]",
+            "type": "Variable"
+        },
+        "size": {
+            "type": "list",
+            "value": "[64L, 64L]"
+        },
+        "scale": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "op": "interpolate",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NHWC"
+        },
+        "interp_mode": {
+            "type": "string",
+            "value": "TRILINEAR"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 64L, 64L, 64L]",
+            "type": "Variable"
+        },
+        "size": {
+            "type": "list",
+            "value": "[8L,8L]"
+        },
+        "scale": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "op": "interpolate",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NHWC"
+        },
+        "interp_mode": {
+            "type": "string",
+            "value": "BICUBIC"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 64L, 64L, 64L]",
+            "type": "Variable"
+        },
+        "size": {
+            "type": "list",
+            "value": "[8L,8L]"
+        },
+        "scale": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}]

--- a/api/tests_v2/interpolate.py
+++ b/api/tests_v2/interpolate.py
@@ -1,0 +1,40 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class InterpolateConfig(APIConfig):
+    def __init__(self):
+        super(InterpolateConfig, self).__init__("interpolate")
+        self.run_tf = False
+
+
+class PDInterpolate(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode=config.interp_mode,
+            align_corners=config.align_corners,
+            data_format=config.data_format)
+        self.feed_vars = [x]
+        self.fetch_vars = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+if __name__ == '__main__':
+    test_main(PDInterpolate(), config=InterpolateConfig())


### PR DESCRIPTION
因为 interpolate OP，在2.0开发时完全对齐 Pytorch 计算方式，而 TF 与 torch 在计算差值时使用了不同的计算公式。因此没有办法与TF精度对齐，该PR只实现了Paddle的PaddleAPIBenchmark，将config.run_tf设置成了False。

torch scale计算：
https://github.com/pytorch/pytorch/blob/7183fd20f853446a9a9c0cf076eb683b00f3f3d1/aten/src/ATen/native/UpSample.h#L234
tf scale计算：https://github.com/tensorflow/tensorflow/blob/e8598ce0454c440fca64e4ebc4aeedfa7afd5c97/tensorflow/core/kernels/image/resize_bilinear_op_test.cc#L101