### PR TITLE
Add the benchmark for top_k_v2

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -24,7 +24,7 @@ NO_BACKWARD_OPS = [
     "is_finite", "is_inf", "is_nan", "less_equal", "less_than", "logical_not",
     "logical_and", "logical_or", "not_equal", "null", "one_hot", "scale",
     "sequence_mask", "shape", "zeros_like", "unique", "floor_divide",
-    "remainder", "equal_all"
+    "remainder", "equal_all", "top_k_v2"
 ]
 
 # length of tf gradient length is different with paddle.

--- a/api/tests_v2/configs/top_k_v2.json
+++ b/api/tests_v2/configs/top_k_v2.json
@@ -1,0 +1,27 @@
+[{
+    "op": "top_k_v2",
+    "param_info": {
+        "x": {
+            "dtype": "float64",
+            "shape": "[-1L, 1000L, 2000L]",
+            "type": "Variable"
+        },
+        "k": {
+            "type": "int",
+            "value": "5"
+        }
+    }
+}, {
+    "op": "top_k_v2",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 1000L]",
+            "type": "Variable"
+        },
+        "k": {
+            "type": "int",
+            "value": "1"
+        }
+    }
+}]

--- a/api/tests_v2/top_k_v2.py
+++ b/api/tests_v2/top_k_v2.py
@@ -1,0 +1,43 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDTopKV2(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        data = self.variable(
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
+        value, indices = paddle.topk(x=data, k=config.k)
+
+        self.feed_vars = [data]
+        self.fetch_vars = [value, indices]
+        if config.backward:
+            self.append_gradients([value], [data])
+
+
+class TFTopKV2(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        data = self.variable(
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
+        value, indices = tf.math.top_k(input=data, k=config.k)
+
+        self.feed_list = [data]
+        self.fetch_list = [value, indices]
+        if config.backward:
+            self.append_gradients([value], [data])
+
+
+if __name__ == '__main__':
+    test_main(PDTopKV2(), TFTopKV2(), config=APIConfig("top_k_v2"))

--- a/api/tests_v2/top_k_v2.py
+++ b/api/tests_v2/top_k_v2.py
@@ -23,8 +23,8 @@ class PDTopKV2(PaddleAPIBenchmarkBase):
 
         self.feed_vars = [data]
         self.fetch_vars = [value, indices]
-        if config.backward:
-            self.append_gradients([value], [data])
+        #if config.backward:
+        #    self.append_gradients([value], [data])
 
 
 class TFTopKV2(TensorflowAPIBenchmarkBase):
@@ -35,8 +35,8 @@ class TFTopKV2(TensorflowAPIBenchmarkBase):
 
         self.feed_list = [data]
         self.fetch_list = [value, indices]
-        if config.backward:
-            self.append_gradients([value], [data])
+        #if config.backward:
+        #    self.append_gradients([value], [data])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
由于top_k_v2的tf中反向计算的加入问题，导致在精度对齐的时候，top_k_v2对三个输出进行对齐（除了top_k_v2本身的输出values和indices，还有反应计算的一个tensor）。该PR暂时未添加反向部分只对top_k_v2的前向进行对齐。除此之外，top_k_v2输出的indices的类型是与pytorch对齐的int64，但tf的indices是int32.