### PR TITLE
Add run script of all op in test_v2

### DIFF
--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -5,6 +5,7 @@ function print_usage() {
     echo "    bash ${0} json_config_dir output_dir gpu_id cpu|gpu|both speed|accuracy|both op_list_file"
     echo ""
     echo "Arguments:"
+    echo "  test_dir                - the directory of tests"
     echo "  json_config_dir         - the directory of json configs"
     echo "  output_dir              - the output directory"
     echo "  gpu_id (optional)       - the GPU id. Only one GPU can be specified."
@@ -17,6 +18,7 @@ function print_arguments() {
     echo "Arguments:"
     echo "  $*"
     echo ""
+    echo "test_dir        : ${TEST_DIR}"
     echo "json_config_dir : ${JSON_CONFIG_DIR}"
     echo "output_dir      : ${OUTPUT_DIR}" 
     echo "gpu_ids         : ${GPU_IDS}"
@@ -30,7 +32,6 @@ export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH
 
 OP_BENCHMARK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/../" && pwd )"
 DEPLOY_DIR="${OP_BENCHMARK_ROOT}/deploy"
-TEST_DIR="${OP_BENCHMARK_ROOT}/tests"
 export PYTHONPATH=${OP_BENCHMARK_ROOT}:${PYTHONPATH}
 
 if [ $# -lt 2 ]; then
@@ -38,13 +39,14 @@ if [ $# -lt 2 ]; then
     exit
 fi
 
-JSON_CONFIG_DIR=${1}
-OUTPUT_DIR=${2}
+TEST_DIR=${1}
+JSON_CONFIG_DIR=${2}
+OUTPUT_DIR=${3}
 if [ ! -d ${OUTPUT_DIR} ]; then
     mkdir -p ${OUTPUT_DIR}
 fi
 
-GPU_IDS=${3:-"0"}
+GPU_IDS=${4:-"0"}
 GPU_IDS_ARRAY=(${GPU_IDS//,/ })
 NUM_GPU_DEVICES=${#GPU_IDS_ARRAY[*]}
 if [ ${NUM_GPU_DEVICES} -le 0 ]; then
@@ -53,21 +55,21 @@ if [ ${NUM_GPU_DEVICES} -le 0 ]; then
 fi
 
 DEVICE_SET=("gpu" "cpu")
-if [ $# -ge 4 ]; then
-    if [[ ${4} == "cpu" || ${4} == "gpu" ]]; then
-        DEVICE_SET=(${4})
+if [ $# -ge 5 ]; then
+    if [[ ${5} == "cpu" || ${5} == "gpu" ]]; then
+        DEVICE_SET=(${5})
     fi
 fi
 
 TASK_SET=("speed" "accuracy")
-if [ $# -ge 5 ]; then
-    if [[ ${5} == "speed" || ${5} == "accuracy" ]]; then
-        TASK_SET=(${5})
+if [ $# -ge 6 ]; then
+    if [[ ${6} == "speed" || ${6} == "accuracy" ]]; then
+        TASK_SET=(${6})
     fi
 fi
 
-if [ $# -ge 6 ]; then
-    OP_LIST_FILE=${6}
+if [ $# -ge 7 ]; then
+    OP_LIST_FILE=${7}
 else
     OP_LIST_FILE=${OUTPUT_DIR}/api_info.txt
     python ${DEPLOY_DIR}/collect_api_info.py --info_file ${OP_LIST_FILE}

--- a/api/tests_v2/isfinite_nan_inf_v2.py
+++ b/api/tests_v2/isfinite_nan_inf_v2.py
@@ -15,9 +15,9 @@
 from common_import import *
 
 
-class IsFiniteNanInfV2Config(APIConfig):
+class IsfiniteNanInfV2Config(APIConfig):
     def __init__(self):
-        super(IsFiniteNanInfV2Config, self).__init__("isfinite_nan_inf_v2")
+        super(IsfiniteNanInfV2Config, self).__init__("isfinite_nan_inf_v2")
         self.api_name = 'isfinite'
         self.api_list = {
             'isfinite': 'is_finite',
@@ -26,7 +26,7 @@ class IsFiniteNanInfV2Config(APIConfig):
         }
 
 
-class PDIsFiniteNanInfV2(PaddleAPIBenchmarkBase):
+class PDIsfiniteNanInfV2(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         out = self.layers(config.api_name, x=x)
@@ -35,7 +35,7 @@ class PDIsFiniteNanInfV2(PaddleAPIBenchmarkBase):
         self.fetch_vars = [out]
 
 
-class TFIsFiniteNanInfV2(TensorflowAPIBenchmarkBase):
+class TFIsfiniteNanInfV2(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         out = self.layers(config.api_name, x=x)
@@ -46,6 +46,6 @@ class TFIsFiniteNanInfV2(TensorflowAPIBenchmarkBase):
 
 if __name__ == '__main__':
     test_main(
-        PDIsFiniteNanInfV2(),
-        TFIsFiniteNanInfV2(),
-        config=IsFiniteNanInfV2Config())
+        PDIsfiniteNanInfV2(),
+        TFIsfiniteNanInfV2(),
+        config=IsfiniteNanInfV2Config())


### PR DESCRIPTION
main_control.sh脚本增加test_dir参数，可以选择op脚本的测试路径

- bash main_control.sh test_dir  json_config_dir  output_dir gpu_id  cpu|gpu|both  speed|accuracy|both  op_list_file

collect_api_info.py 收集支持op，参数信息

-  python collect_api_info.py --info_dir=tests_v2  --info_file=op_info_v2.txt  --support_api_file=op_list_v2.txt