### PR TITLE
Add benchmark for equal_all

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -24,7 +24,7 @@ NO_BACKWARD_OPS = [
     "is_finite", "is_inf", "is_nan", "less_equal", "less_than", "logical_not",
     "logical_and", "logical_or", "not_equal", "null", "one_hot", "scale",
     "sequence_mask", "shape", "zeros_like", "unique", "floor_divide",
-    "remainder"
+    "remainder", "equal_all"
 ]
 
 # length of tf gradient length is different with paddle.

--- a/api/tests_v2/configs/equal_all.json
+++ b/api/tests_v2/configs/equal_all.json
@@ -1,0 +1,57 @@
+[{
+    "op": "equal_all",
+    "param_info": {
+        "x": {
+            "dtype": "float64",
+            "shape": "[-1L, 1000L, 2000L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float64",
+            "shape": "[-1L, 1000L, 2000L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "equal_all",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 1000L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[-1L, 1000L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "equal_all",
+    "param_info": {
+        "x": {
+            "dtype": "int32",
+            "shape": "[-1L, 1000L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "int32",
+            "shape": "[-1L, 1000L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "equal_all",
+    "param_info": {
+        "x": {
+            "dtype": "int64",
+            "shape": "[-1L, 1000L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "int64",
+            "shape": "[-1L, 1000L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/equal_all.py
+++ b/api/tests_v2/equal_all.py
@@ -31,8 +31,6 @@ class PDEqualAll(PaddleAPIBenchmarkBase):
 
         self.feed_vars = [data_x, data_y]
         self.fetch_vars = [out]
-        #if config.backward:
-        #    self.append_gradients([out], [data_x, data_y])
 
 
 if __name__ == '__main__':

--- a/api/tests_v2/equal_all.py
+++ b/api/tests_v2/equal_all.py
@@ -1,0 +1,39 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class EqualAllConfig(APIConfig):
+    def __init__(self):
+        super(EqualAllConfig, self).__init__("equal_all")
+        self.run_tf = False
+
+
+class PDEqualAll(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        data_x = self.variable(
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
+        data_y = self.variable(
+            name='y', shape=config.y_shape, dtype=config.y_dtype)
+        out = paddle.equal_all(x=data_x, y=data_y)
+
+        self.feed_vars = [data_x, data_y]
+        self.fetch_vars = [out]
+        #if config.backward:
+        #    self.append_gradients([out], [data_x, data_y])
+
+
+if __name__ == '__main__':
+    test_main(PDEqualAll(), config=EqualAllConfig())


### PR DESCRIPTION
因为equal_all OP在2.0开发时是对齐pytorch的equal，返回的结果只有一个元素值，如果所有相同位置的元素相同返回True，否则返回False；而TF中没有相同功能的API，因此无法与TF进行精度对齐。所以该PR支实现了`Paddle的PaddleAPIBenchmark`，将 `config.run_tf `设置成了 `False`。