### PR TITLE
Add benchmark for affine grid op

### DIFF
--- a/api/tests_v2/affine_grid.py
+++ b/api/tests_v2/affine_grid.py
@@ -1,0 +1,39 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class AffineGridConfig(APIConfig):
+    def __init__(self):
+        super(AffineGridConfig, self).__init__("affine_grid")
+        self.run_tf = False
+
+
+class PDAffineGrid(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        theta = self.variable(
+            name='theta', shape=config.theta_shape, dtype=config.theta_dtype)
+        out = paddle.nn.functional.affine_grid(
+            theta,
+            out_shape=config.out_shape,
+            align_corners=config.align_corners)
+        self.feed_vars = [theta]
+        self.fetch_vars = [out]
+        if config.backward:
+            self.append_gradients(out, [theta])
+
+
+if __name__ == '__main__':
+    test_main(PDAffineGrid(), config=AffineGridConfig())

--- a/api/tests_v2/configs/affine_grid.json
+++ b/api/tests_v2/configs/affine_grid.json
@@ -1,0 +1,37 @@
+[{
+    "op": "affine_grid",
+    "param_info": {
+        "theta": {
+            "dtype": "float32",
+            "shape": "[32, 2, 3]",
+            "type": "Variable"
+        },
+        "out_shape": {
+            "type": "list",
+            "value": "[32, 3, 128, 128]"
+        },
+        "align_corners": {
+            "type": "bool",
+            "value": "True"
+        }
+    },
+    "repeat": 5000
+}, {
+    "op": "affine_grid",
+    "param_info": {
+        "theta": {
+            "dtype": "float32",
+            "shape": "[32, 2, 3]",
+            "type": "Variable"
+        },
+        "out_shape": {
+            "type": "list",
+            "value": "[32, 3, 128, 128]"
+        },
+        "align_corners": {
+            "type": "bool",
+            "value": "False"
+        }
+    },
+    "repeat": 5000
+}]


### PR DESCRIPTION
affine_grid在tensorflow中没有官方的实现。
affine_grid主要被用在STN中，在tensorflow的STN实现中，一般是用小op组装得到的affine_grid，例如： https://github.com/kevinzakka/spatial-transformer-network/blob/master/stn/transformer.py#L95