### PR TITLE
add bernoulli test

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -24,7 +24,7 @@ NO_BACKWARD_OPS = [
     "is_finite", "is_inf", "is_nan", "less_equal", "less_than", "logical_not",
     "logical_and", "logical_or", "not_equal", "null", "one_hot", "scale",
     "sequence_mask", "shape", "zeros_like", "unique", "floor_divide",
-    "remainder", "equal_all"
+    "remainder", "equal_all", "bernoulli",
 ]
 
 # length of tf gradient length is different with paddle.

--- a/api/tests_v2/bernoulli.py
+++ b/api/tests_v2/bernoulli.py
@@ -1,0 +1,47 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+import tensorflow_probability as tfp
+
+
+
+class BernoulliConfig(APIConfig):
+    def __init__(self):
+        super(BernoulliConfig, self).__init__('bernoulli')
+        self.feed_spec = {"range": [-10, 10]}
+
+
+class PDBernoulli(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        data = self.variable(
+            name='data', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.bernoulli(x=data)
+
+        self.feed_vars = [data]
+        self.fetch_vars = [result]
+
+
+class TFBernoulli(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        data = self.variable(
+            name='data', shape=config.x_shape, dtype=config.x_dtype)
+        b = tfp.distributions.Bernoulli(probs=data)
+        result = b.sample()
+        self.feed_list = [data]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(PDBernoulli(), TFBernoulli(), config=BernoulliConfig())

--- a/api/tests_v2/bernoulli.py
+++ b/api/tests_v2/bernoulli.py
@@ -20,7 +20,7 @@ import tensorflow_probability as tfp
 class BernoulliConfig(APIConfig):
     def __init__(self):
         super(BernoulliConfig, self).__init__('bernoulli')
-        self.feed_spec = {"range": [-10, 10]}
+        self.feed_spec = {"range": [0, 1]}
 
 
 class PDBernoulli(PaddleAPIBenchmarkBase):

--- a/api/tests_v2/bernoulli.py
+++ b/api/tests_v2/bernoulli.py
@@ -16,7 +16,6 @@ from common_import import *
 import tensorflow_probability as tfp
 
 
-
 class BernoulliConfig(APIConfig):
     def __init__(self):
         super(BernoulliConfig, self).__init__('bernoulli')

--- a/api/tests_v2/configs/bernoulli.json
+++ b/api/tests_v2/configs/bernoulli.json
@@ -1,0 +1,43 @@
+[{
+    "op": "bernoulli",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 1785L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "bernoulli",
+    "param_info": {
+        "x": {
+            "dtype": "float64",
+            "shape": "[-1L, 1785L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "bernoulli",
+    "param_info": {
+        "dtype": {
+            "type": "string",
+            "value": "float32"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 1L, 513L, 513L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 5000
+}, {
+    "op": "bernoulli",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[30522L, 1024L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 5000
+}]

--- a/api/tests_v2/configs/bernoulli.json
+++ b/api/tests_v2/configs/bernoulli.json
@@ -6,7 +6,8 @@
             "shape": "[-1L, 1785L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "bernoulli",
     "param_info": {
@@ -15,14 +16,11 @@
             "shape": "[-1L, 1785L]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "bernoulli",
     "param_info": {
-        "dtype": {
-            "type": "string",
-            "value": "float32"
-        },
         "x": {
             "dtype": "float32",
             "shape": "[-1L, 1L, 513L, 513L]",


### PR DESCRIPTION
As the title

Result of lcoal run:

```
Backward is not surported for bernoulli in Paddle. It is actually running the forward test.
---- The 0-the output's data type is different, float32 vs int32.
---- The 0-th output (shape: (16, 1785), data type: float32) has diff. The maximum diff is 1.000000e+00, offset is 1: 1.0 vs 0. atol is 1.00e-06.
The output is not consistent.
{"name": "bernoulli", "backward": false, "consistent": false, "num_outputs": 1, "diff": 1.0, "parameters": "x (Variable) - dtype: float32, shape: [16, 1785]\n"}
```

1. The `dtype` diff is by design. Paddle returns the same dtype as input, while Tensorflow always returns int32.
2. The `value` diff is possible since it is a random number related API.