### PR TITLE
Add relu6 and softplus

### DIFF
--- a/api/tests_v2/relu6.py
+++ b/api/tests_v2/relu6.py
@@ -1,0 +1,52 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class Relu6Config(APIConfig):
+    def __init__(self):
+        super(Relu6Config, self).__init__("relu6")
+        self.feed_spec = {"range": [-1, 1]}
+        # relu6 belongs to activation op series which only has one variable
+        # thus abs can reuse activation parameters 
+        self.alias_config = APIConfig("activation")
+
+
+class PDRelu6(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(
+            name='x', shape=config.alias.x_shape, dtype=config.alias.x_dtype)
+        out = paddle.nn.functional.relu6(x=x)
+
+        self.feed_vars = [x]
+        self.fetch_vars = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+class TFRelu6(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(
+            name='x', shape=config.alias.x_shape, dtype=config.alias.x_dtype)
+        out = tf.nn.relu6(features=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+if __name__ == '__main__':
+    test_main(PDRelu6(), TFRelu6(), config=Relu6Config())

--- a/api/tests_v2/softplus.py
+++ b/api/tests_v2/softplus.py
@@ -1,0 +1,52 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class SoftplusConfig(APIConfig):
+    def __init__(self):
+        super(SoftplusConfig, self).__init__("softplus")
+        self.feed_spec = {"range": [-1, 1]}
+        # softplus belongs to activation op series which only has one variable
+        # thus abs can reuse activation parameters 
+        self.alias_config = APIConfig("activation")
+
+
+class PDSoftplus(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(
+            name='x', shape=config.alias.x_shape, dtype=config.alias.x_dtype)
+        out = paddle.nn.functional.softplus(x=x)
+
+        self.feed_vars = [x]
+        self.fetch_vars = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+class TFSoftplus(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(
+            name='x', shape=config.alias.x_shape, dtype=config.alias.x_dtype)
+        out = tf.math.softplus(features=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+if __name__ == '__main__':
+    test_main(PDSoftplus(), TFSoftplus(), config=SoftplusConfig())


### PR DESCRIPTION
 add relu6 and softplus

relu6:
[tensorflow][relu6] relu6 {
  run_tf: True
  alias_config: [tensorflow][activation] activation {
    x_shape: [16, 128, 257, 257]
    x_dtype: float32
  }
  repeat: 5000
  atol: 1e-06
}
[paddle][relu6] relu6 {
  run_tf: True
  alias_config: [paddle][activation] activation {
    x_shape: [16, 128, 257, 257]
    x_dtype: float32
  }
  repeat: 5000
  atol: 1e-06
}
{"name": "relu6", "backward": true, "consistent": true, "num_outputs": 2, "diff": 0.0, "parameters": "x (Variable) - dtype: float32, shape: [16, 128, 257, 257]\n"}

softplus:
[tensorflow][softplus] softplus {
  run_tf: True
  alias_config: [tensorflow][activation] activation {
    x_shape: [16, 128, 257, 257]
    x_dtype: float32
  }
  repeat: 5000
  atol: 1e-06
}
[paddle][softplus] softplus {
  run_tf: True
  alias_config: [paddle][activation] activation {
    x_shape: [16, 128, 257, 257]
    x_dtype: float32
  }
  repeat: 5000
  atol: 1e-06
}
{"name": "softplus", "backward": true, "consistent": true, "num_outputs": 2, "diff": 2.384185791015625e-07, "parameters": "x (Variable) - dtype: float32, shape: [16, 128, 257, 257]\n"}