### PR TITLE
add lstm tests

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -24,7 +24,7 @@ NO_BACKWARD_OPS = [
     "is_finite", "is_inf", "is_nan", "less_equal", "less_than", "logical_not",
     "logical_and", "logical_or", "not_equal", "null", "one_hot", "scale",
     "sequence_mask", "shape", "zeros_like", "unique", "floor_divide",
-    "remainder", "equal_all", "top_k_v2"
+    "remainder", "equal_all", "top_k_v2", "lstm"
 ]
 
 # length of tf gradient length is different with paddle.

--- a/api/tests_v2/lstm.py
+++ b/api/tests_v2/lstm.py
@@ -43,8 +43,8 @@ class PDLstm(PaddleAPIBenchmarkBase):
 
         self.feed_vars = [input]
         self.fetch_vars = [rnn_out]
-        if config.backward:
-            self.append_gradients(rnn_out, [input])
+        #if config.backward:
+        #    self.append_gradients(rnn_out, [input])
 
 
 class TFLstm(TensorflowAPIBenchmarkBase):

--- a/api/tests_v2/lstm.py
+++ b/api/tests_v2/lstm.py
@@ -1,0 +1,66 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class LstmConfig(APIConfig):
+    def __init__(self):
+        super(LstmConfig, self).__init__("lstm")
+        self.run_tf = False
+
+
+class PDLstm(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        input = self.variable(
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
+
+        init_h = fluid.layers.fill_constant(
+            shape=config.init_h_shape, dtype=config.init_h_dtype, value=0.0)
+        init_c = fluid.layers.fill_constant(
+            shape=config.init_c_shape, dtype=config.init_c_dtype, value=0.0)
+
+        rnn_out, last_h, last_c = fluid.layers.lstm(
+            input=input,
+            init_h=init_h,
+            init_c=init_c,
+            max_len=config.max_len,
+            hidden_size=config.hidden_size,
+            num_layers=config.num_layers,
+            dropout_prob=0.2,
+            is_bidirec=config.is_bidirec)
+
+        self.feed_vars = [input]
+        self.fetch_vars = [rnn_out]
+        if config.backward:
+            self.append_gradients(rnn_out, [input])
+
+
+class TFLstm(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        input = self.variable(
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
+
+        init_h = tf.constant(
+            shape=config.init_h_shape,
+            dtype=tf.as_dtype(config.init_h_dtype),
+            value=0.0)
+        init_c = tf.constant(
+            shape=config.init_c_shape,
+            dtype=tf.as_dtype(config.init_c_dtype),
+            value=0.0)
+
+
+if __name__ == '__main__':
+    test_main(PDLstm(), TFLstm(), config=LstmConfig())

--- a/api/tests_v2/lstm.py
+++ b/api/tests_v2/lstm.py
@@ -26,12 +26,12 @@ class PDLstm(PaddleAPIBenchmarkBase):
         input = self.variable(
             name="input", shape=config.input_shape, dtype=config.input_dtype)
 
-        init_h = fluid.layers.fill_constant(
+        init_h = paddle.fluid.layers.fill_constant(
             shape=config.init_h_shape, dtype=config.init_h_dtype, value=0.0)
-        init_c = fluid.layers.fill_constant(
+        init_c = paddle.fluid.layers.fill_constant(
             shape=config.init_c_shape, dtype=config.init_c_dtype, value=0.0)
 
-        rnn_out, last_h, last_c = fluid.layers.lstm(
+        rnn_out, last_h, last_c = paddle.fluid.layers.lstm(
             input=input,
             init_h=init_h,
             init_c=init_c,


### PR DESCRIPTION
add lstm tests

- lstm目前2.0接口使用class类，框架暂不支持。待新的LSTM添加paddle.nn.functional接口后换成新的接口测试。因此暂时保留老版本的layers接口。

- tensorflow和目前layers接口不能对齐。目前kernel正确使用方式是支持padding数据，但是使用老接口不支持此功能，因此暂时不能与TF对齐。

- 怀疑因为新的c++ kernel增加了多个中间过程的输入输出，所以反向计算会出现问题。暂时去除反向。