### PR TITLE
Move 1.8 tests to 2.0 tests 

### DIFF
--- a/api/tests_v2/configs/logical.json
+++ b/api/tests_v2/configs/logical.json
@@ -1,0 +1,37 @@
+[{
+    "op": "logical",
+    "param_info": {
+        "out": {
+            "type": "string",
+            "value": "None"
+        },
+        "x": {
+            "dtype": "bool",
+            "shape": "[-1L, 1785L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "bool",
+            "shape": "[-1L, 1785L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "logical",
+    "param_info": {
+        "out": {
+            "type": "string",
+            "value": "None"
+        },
+        "x": {
+            "dtype": "bool",
+            "shape": "[1L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "bool",
+            "shape": "[1L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/configs/logical_not.json
+++ b/api/tests_v2/configs/logical_not.json
@@ -1,0 +1,14 @@
+[{
+    "op": "logical_not",
+    "param_info": {
+        "out": {
+            "type": "string",
+            "value": "None"
+        },
+        "x": {
+            "dtype": "bool",
+            "shape": "[1L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/configs/reduce.json
+++ b/api/tests_v2/configs/reduce.json
@@ -1,16 +1,16 @@
 [{
     "op": "reduce",
     "param_info": {
-        "dim": {
+        "axis": {
             "type": "list",
             "value": "[2, 3]"
         },
-        "input": {
+        "x": {
             "dtype": "float32",
             "shape": "[-1L, 2048L, 33L, 33L]",
             "type": "Variable"
         },
-        "keep_dim": {
+        "keepdim": {
             "type": "bool",
             "value": "True"
         }
@@ -20,16 +20,16 @@
 }, {
     "op": "reduce",
     "param_info": {
-        "dim": {
+        "axis": {
             "type": "list",
             "value": "[1]"
         },
-        "input": {
+        "x": {
             "dtype": "float32",
             "shape": "[-1L, 8L, 128L]",
             "type": "Variable"
         },
-        "keep_dim": {
+        "keepdim": {
             "type": "bool",
             "value": "False"
         }
@@ -37,16 +37,16 @@
 }, {
     "op": "reduce",
     "param_info": {
-        "dim": {
+        "axis": {
             "type": "list",
             "value": "[0]"
         },
-        "input": {
+        "x": {
             "dtype": "float32",
             "shape": "[-1L, -1L, 1L, 1L]",
             "type": "Variable"
         },
-        "keep_dim": {
+        "keepdim": {
             "type": "bool",
             "value": "False"
         }
@@ -54,16 +54,16 @@
 }, {
     "op": "reduce",
     "param_info": {
-        "dim": {
+        "axis": {
             "type": "string",
             "value": "None"
         },
-        "input": {
+        "x": {
             "dtype": "float32",
             "shape": "[30522L, 1024L]",
             "type": "Variable"
         },
-        "keep_dim": {
+        "keepdim": {
             "type": "bool",
             "value": "False"
         }

--- a/api/tests_v2/configs/softmax_with_cross_entropy.json
+++ b/api/tests_v2/configs/softmax_with_cross_entropy.json
@@ -65,6 +65,5 @@
             "type": "bool",
             "value": "False"
         }
-    },
-    "atol": 0.001
+    }
 }]

--- a/api/tests_v2/configs/softmax_with_cross_entropy.json
+++ b/api/tests_v2/configs/softmax_with_cross_entropy.json
@@ -65,5 +65,6 @@
             "type": "bool",
             "value": "False"
         }
-    }
+    },
+    "atol": 0.001
 }]

--- a/api/tests_v2/configs/squeeze.json
+++ b/api/tests_v2/configs/squeeze.json
@@ -1,11 +1,11 @@
 [{
     "op": "squeeze",
     "param_info": {
-        "axes": {
+        "axis": {
             "type": "list",
             "value": "[1]"
         },
-        "input": {
+        "x": {
             "dtype": "float32",
             "shape": "[-1L, 1L, 512L]",
             "type": "Variable"

--- a/api/tests_v2/logical.py
+++ b/api/tests_v2/logical.py
@@ -1,0 +1,49 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class LogicalConfig(APIConfig):
+    def __init__(self):
+        super(LogicalConfig, self).__init__('logical')
+        self.api_name = 'logical_and'
+        self.api_list = {
+            'logical_and': 'logical_and',
+            'logical_or': 'logical_or'
+        }
+
+
+class PDLogical(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
+        result = self.layers(config.api_name, x=x, y=y)
+
+        self.feed_vars = [x, y]
+        self.fetch_vars = [result]
+
+
+class TFLogical(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
+        result = self.layers(config.api_name, x=x, y=y)
+
+        self.feed_list = [x, y]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(PDLogical(), TFLogical(), config=LogicalConfig())

--- a/api/tests_v2/logical_not.py
+++ b/api/tests_v2/logical_not.py
@@ -1,0 +1,39 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDLogicalNot(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        data = self.variable(
+            name='data', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.logical_not(x=data)
+
+        self.feed_vars = [data]
+        self.fetch_vars = [result]
+
+
+class TFLogicalNot(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        data = self.variable(
+            name='data', shape=config.x_shape, dtype=config.x_dtype)
+        result = tf.math.logical_not(x=data)
+
+        self.feed_list = [data]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(PDLogicalNot(), TFLogicalNot(), config=APIConfig("logical_not"))

--- a/api/tests_v2/reduce.py
+++ b/api/tests_v2/reduce.py
@@ -21,21 +21,18 @@ class ReduceConfig(APIConfig):
         self.feed_spec = {"range": [-1, 1]}
         self.api_name = 'reduce_mean'
         self.api_list = {
-            'reduce_mean': 'reduce_mean',
-            'reduce_sum': 'reduce_sum',
-            'reduce_prod': 'reduce_prod'
+            'mean': 'reduce_mean',
+            'sum': 'reduce_sum',
+            'prod': 'reduce_prod'
         }
 
 
 class PDReduce(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         data = self.variable(
-            name='input', shape=config.input_shape, dtype=config.input_dtype)
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
         result = self.layers(
-            config.api_name,
-            input=data,
-            dim=config.dim,
-            keep_dim=config.keep_dim)
+            config.api_name, x=data, axis=config.axis, keepdim=config.keepdim)
 
         self.feed_vars = [data]
         self.fetch_vars = [result]
@@ -46,12 +43,12 @@ class PDReduce(PaddleAPIBenchmarkBase):
 class TFReduce(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
         data = self.variable(
-            name='input', shape=config.input_shape, dtype=config.input_dtype)
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
         result = self.layers(
             config.api_name,
             input_tensor=data,
-            axis=config.dim,
-            keepdims=config.keep_dim)
+            axis=config.axis,
+            keepdims=config.keepdim)
 
         self.feed_list = [data]
         self.fetch_list = [result]

--- a/api/tests_v2/reduce.py
+++ b/api/tests_v2/reduce.py
@@ -1,0 +1,63 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class ReduceConfig(APIConfig):
+    def __init__(self):
+        super(ReduceConfig, self).__init__('reduce')
+        self.feed_spec = {"range": [-1, 1]}
+        self.api_name = 'reduce_mean'
+        self.api_list = {
+            'reduce_mean': 'reduce_mean',
+            'reduce_sum': 'reduce_sum',
+            'reduce_prod': 'reduce_prod'
+        }
+
+
+class PDReduce(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        data = self.variable(
+            name='input', shape=config.input_shape, dtype=config.input_dtype)
+        result = self.layers(
+            config.api_name,
+            input=data,
+            dim=config.dim,
+            keep_dim=config.keep_dim)
+
+        self.feed_vars = [data]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [data])
+
+
+class TFReduce(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        data = self.variable(
+            name='input', shape=config.input_shape, dtype=config.input_dtype)
+        result = self.layers(
+            config.api_name,
+            input_tensor=data,
+            axis=config.dim,
+            keepdims=config.keep_dim)
+
+        self.feed_list = [data]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [data])
+
+
+if __name__ == '__main__':
+    test_main(PDReduce(), TFReduce(), config=ReduceConfig())

--- a/api/tests_v2/scale.py
+++ b/api/tests_v2/scale.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/tests_v2/scale.py
+++ b/api/tests_v2/scale.py
@@ -1,0 +1,38 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDScale(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.scale(
+            x=x, scale=config.scale, bias=0.0, bias_after_scale=True, act=None)
+
+        self.feed_vars = [x]
+        self.fetch_vars = [result]
+
+
+class TFScale(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = tf.scalar_mul(scalar=config.scale, x=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(PDScale(), TFScale(), config=APIConfig("scale"))

--- a/api/tests_v2/shape.py
+++ b/api/tests_v2/shape.py
@@ -1,0 +1,39 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDShape(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        data = self.variable(
+            name='data', shape=config.input_shape, dtype=config.input_dtype)
+        result = paddle.shape(input=data)
+
+        self.feed_vars = [data]
+        self.fetch_vars = [result]
+
+
+class TFShape(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        data = self.variable(
+            name='data', shape=config.input_shape, dtype=config.input_dtype)
+        result = tf.shape(input=data)
+
+        self.feed_list = [data]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(PDShape(), TFShape(), config=APIConfig("shape"))

--- a/api/tests_v2/softmax_with_cross_entropy.py
+++ b/api/tests_v2/softmax_with_cross_entropy.py
@@ -1,0 +1,90 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class SoftmaxWithCrossEntropyConfig(APIConfig):
+    def __init__(self):
+        super(SoftmaxWithCrossEntropyConfig,
+              self).__init__("softmax_with_cross_entropy")
+        self.atol = 1e-3
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(SoftmaxWithCrossEntropyConfig, self).init_from_json(
+            filename, config_id, unknown_dim)
+        logits_rank = len(self.logits_shape)
+        self.num_classes = self.logits_shape[logits_rank - 1]
+        self.feed_spec = [
+            {
+                "range": [0, 1]
+            },  # input
+            {
+                "range": [0, self.num_classes]
+            }  # label
+        ]
+        if self.label_dtype == 'float32' or self.label_dtype == 'float64':
+            self.run_tf = False
+
+    def to_tensorflow(self):
+        tf_config = super(SoftmaxWithCrossEntropyConfig, self).to_tensorflow()
+        label_rank = len(tf_config.label_shape)
+        if tf_config.label_shape[label_rank - 1] == 1:
+            tf_config.label_shape = tf_config.label_shape[0:label_rank - 1]
+        return tf_config
+
+
+class PDSoftmaxWithCrossEntropy(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        logits = self.variable(
+            name='logits',
+            shape=config.logits_shape,
+            dtype=config.logits_dtype)
+        label = self.variable(
+            name="label",
+            shape=config.label_shape,
+            dtype=config.label_dtype,
+            stop_gradient=True)
+        result = paddle.nn.functional.softmax_with_cross_entropy(
+            logits=logits, label=label, soft_label=config.soft_label)
+
+        self.feed_vars = [logits, label]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [logits])
+
+
+class TFSoftmaxWithCrossEntropy(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        logits = self.variable(
+            name='logits',
+            shape=config.logits_shape,
+            dtype=config.logits_dtype)
+        label = self.variable(
+            name='label', shape=config.label_shape, dtype=config.label_dtype)
+        onehot_label = tf.one_hot(indices=label, depth=config.num_classes)
+        result = tf.compat.v1.losses.softmax_cross_entropy(
+            logits=logits, onehot_labels=onehot_label, reduction='none')
+
+        self.feed_list = [logits, label]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [logits])
+
+
+if __name__ == '__main__':
+    test_main(
+        PDSoftmaxWithCrossEntropy(),
+        TFSoftmaxWithCrossEntropy(),
+        config=SoftmaxWithCrossEntropyConfig())

--- a/api/tests_v2/softsign.py
+++ b/api/tests_v2/softsign.py
@@ -1,0 +1,53 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class SoftsignConfig(APIConfig):
+    def __init__(self):
+        super(SoftsignConfig, self).__init__("softsign")
+        self.alias_config = APIConfig("activation")
+
+
+class PDSoftsign(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        data = self.variable(
+            name='data',
+            shape=config.alias.x_shape,
+            dtype=config.alias.x_dtype)
+        result = paddle.nn.functional.softsign(x=data)
+
+        self.feed_vars = [data]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [data])
+
+
+class TFSoftsign(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        data = self.variable(
+            name='data',
+            shape=config.alias.x_shape,
+            dtype=config.alias.x_dtype)
+        result = tf.nn.softsign(features=data)
+
+        self.feed_list = [data]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [data])
+
+
+if __name__ == '__main__':
+    test_main(PDSoftsign(), TFSoftsign(), config=SoftsignConfig())

--- a/api/tests_v2/squeeze.py
+++ b/api/tests_v2/squeeze.py
@@ -1,0 +1,43 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDSqueeze(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        data = self.variable(
+            name='data', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.squeeze(x=data, axis=config.axis)
+
+        self.feed_vars = [data]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [data])
+
+
+class TFSqueeze(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        data = self.variable(
+            name='data', shape=config.x_shape, dtype=config.x_dtype)
+        result = tf.squeeze(input=data, axis=config.axis)
+
+        self.feed_list = [data]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [data])
+
+
+if __name__ == '__main__':
+    test_main(PDSqueeze(), TFSqueeze(), config=APIConfig("squeeze"))


### PR DESCRIPTION
## 迁移的脚本 
- logical:  logical_and, logical_or
- logical_not
-  reduce:  reduce_mean, reduce_sum, reduce_prod
- scale
- shape 
- softmax_with_cross_entropy 
- softsign
- squeeze
