### PR TITLE
fix_detection_1009

### DIFF
--- a/scripts/static_graph_models.sh
+++ b/scripts/static_graph_models.sh
@@ -604,6 +604,17 @@ yolov3(){
     fi
 
     cd ${BENCHMARK_ROOT}/PaddleDetection
+    # 同上。防止跑单个模型情况。1498合入后可删除
+    ## test dir
+    git branch
+    # add_enable_static 暂未合入 https://github.com/PaddlePaddle/PaddleDetection/pull/1498/files
+    git checkout master
+    git reset --hard 5549e0831df602ae4deb08bd558c21c807ffcee7  # reset 到9月23的PR
+    git fetch origin pull/1498/head:add_enable_static_1498
+    git branch
+    git merge add_enable_static_1498
+    git branch
+
 
     #sh ./weights/download.sh
     mkdir -p ~/.cache/paddle/weights

--- a/scripts/static_graph_models.sh
+++ b/scripts/static_graph_models.sh
@@ -327,6 +327,14 @@ detection(){
     cd ${cur_model_path}
     ## test dir
     git branch
+    # add_enable_static 暂未合入 https://github.com/PaddlePaddle/PaddleDetection/pull/1498/files
+    git checkout master
+    git reset --hard 5549e0831df602ae4deb08bd558c21c807ffcee7  # reset 到9月23的PR
+    git fetch origin pull/1498/head:add_enable_static_1498
+    git branch
+    git merge add_enable_static_1498
+    git branch
+
     ## ls 
     ls
     ## ls tools
@@ -340,6 +348,7 @@ detection(){
     ln -s ${data_path}/COCO17/test2017 ${cur_model_path}/dataset/coco/test2017
     ln -s ${data_path}/COCO17/val2017 ${cur_model_path}/dataset/coco/val2017
     #prepare pretrain_models
+    mkdir -p ~/.cache/paddle/weights
     ln -s ${prepare_path}/detection/ResNet101_vd_pretrained ~/.cache/paddle/weights
     ln -s ${prepare_path}/detection/ResNet50_cos_pretrained ~/.cache/paddle/weights
     ln -s ${prepare_path}/detection/ResNeXt101_vd_64x4d_pretrained ~/.cache/paddle/weights
@@ -379,6 +388,17 @@ detection(){
 mask_rcnn(){
     cur_model_path=${BENCHMARK_ROOT}/PaddleDetection
     cd ${cur_model_path}
+    # 同上。防止跑单个模型情况。1498合入后可删除
+    ## test dir
+    git branch
+    # add_enable_static 暂未合入 https://github.com/PaddlePaddle/PaddleDetection/pull/1498/files
+    git checkout master
+    git reset --hard 5549e0831df602ae4deb08bd558c21c807ffcee7  # reset 到9月23的PR
+    git fetch origin pull/1498/head:add_enable_static_1498
+    git branch
+    git merge add_enable_static_1498
+    git branch
+
 
     # Install cocoapi
     if python -c "import pycocotools" >/dev/null 2>&1
@@ -402,6 +422,7 @@ mask_rcnn(){
         echo "tb_paddle installed"
     fi
     # Copy pretrained model
+    mkdir -p /root/.cache/paddle/weights
     ln -s ${prepare_path}/mask-rcnn/ResNet50_cos_pretrained  ~/.cache/paddle/weights
     cd ${cur_model_path}
     # Prepare data
@@ -585,6 +606,7 @@ yolov3(){
     cd ${BENCHMARK_ROOT}/PaddleDetection
 
     #sh ./weights/download.sh
+    mkdir -p ~/.cache/paddle/weights
     ln -s ${prepare_path}/yolov3/DarkNet53_pretrained ~/.cache/paddle/weights
     rm -rf dataset/coco
     ln -s ${data_path}/coco ./dataset/coco


### PR DESCRIPTION
 *  paddle 切换默认动态图后，detection [静态图转换PR ](https://github.com/PaddlePaddle/PaddleDetection/pull/1498)暂未合入
   先前[fetch 上述PR 后合入master](https://github.com/PaddlePaddle/benchmark/pull/625)的方式不可取
<img width="737" alt="图片" src="https://user-images.githubusercontent.com/52739577/95565275-816e0800-0a52-11eb-9042-78b9e7461dfd.png">
  在实际训练静态图时，默认分支是
<img width="442" alt="图片" src="https://user-images.githubusercontent.com/52739577/95565322-98acf580-0a52-11eb-999b-2af6abd600bd.png">
故而报错找不到train.py

 *  解决：
   在静态图detection 目录里check到master （此时会在最新commit），并reset到特定commit，再fetch 上述PR ，在本地merge到master

