### PR TITLE
Using CUDA_VISIBLE_DEVICES=0 while there is not a default ID number.

### DIFF
--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export CUDA_VISIBLE_DEVICES="0"   # Set to "" if testing CPU
+[ -z "$CUDA_VISIBLE_DEVICES" ] && export CUDA_VISIBLE_DEVICES="0"   # Set to "" if testing CPU
 #export GLOG_vmodule=operator=4
 #export LD_LIBRARY_PATH=/work/cudnn/cudnn-7.6.5/lib64:${LD_LIBRARY_PATH}
 

--- a/api/tests_v2/run.sh
+++ b/api/tests_v2/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export CUDA_VISIBLE_DEVICES="0"   # Set to "" if testing CPU
+[ -z "$CUDA_VISIBLE_DEVICES" ] && export CUDA_VISIBLE_DEVICES="0"   # Set to "" if testing CPU
 #export GLOG_vmodule=operator=4
 #export LD_LIBRARY_PATH=/work/cudnn/cudnn-7.6.5/lib64:${LD_LIBRARY_PATH}
 

--- a/ci/scripts/run_test.sh
+++ b/ci/scripts/run_test.sh
@@ -115,7 +115,7 @@ function summary_problems(){
     LOG "[FATAL] Summary problems:"
     if [ $check_style_code -ne 0 -a $run_api_code -ne 0 ]
     then
-      LOG "[FATAL] There are 1 errors: Code style error and API test error."
+      LOG "[FATAL] There are 2 errors: Code style error and API test error."
     else
       [ $check_style_code -ne 0 ] && LOG "[FATAL] There is 1 error: Code style error."
       [ $run_api_code -ne 0 ] && LOG "[FATAL] There is 1 error: API test error."

--- a/ci/scripts/run_test.sh
+++ b/ci/scripts/run_test.sh
@@ -29,6 +29,7 @@ LOG "[INFO] Start run op benchmark test ..."
 BENCHMARK_ROOT=$(cd $(dirname $0)/../.. && pwd)
 
 function prepare_env(){
+  LOG "[INFO] Device Id: ${CUDA_VISIBLE_DEVICES}"
   # Update pip
   LOG "[INFO] Update pip ..."
   python -m pip install --upgrade pip > /dev/null


### PR DESCRIPTION
- 多卡机器资源中，GPU使用分配的设备，没有分配时使用默认“0”：
`[ -z "$CUDA_VISIBLE_DEVICES" ] && export CUDA_VISIBLE_DEVICES="0"`
- 顺带修复错误信息中小问题；