### PR TITLE
Refine the error of while_loop in backward calculation

### DIFF
--- a/api/tests/while_loop.py
+++ b/api/tests/while_loop.py
@@ -58,7 +58,7 @@ class PDWhileLoop(PaddleAPIBenchmarkBase):
         self.feed_vars = [input]
         self.fetch_vars = [results]
         if config.backward:
-            self.append_gradients(results, [input])
+            self.append_gradients([results, input], [input])
 
 
 class TFWhileLoop(TensorflowAPIBenchmarkBase):

--- a/api/tests/while_loop.py
+++ b/api/tests/while_loop.py
@@ -53,12 +53,13 @@ class PDWhileLoop(PaddleAPIBenchmarkBase):
         result = fluid.layers.zeros(
             shape=[config.alias.input_shape[0], config.alias.size],
             dtype=config.alias.input_dtype)
+        result.stop_gradient = False
         _, _, _, results = fluid.layers.while_loop(
             cond, body, [i, loop_len, input, result])
         self.feed_vars = [input]
         self.fetch_vars = [results]
         if config.backward:
-            self.append_gradients([results, input], [input])
+            self.append_gradients(results, [input])
 
 
 class TFWhileLoop(TensorflowAPIBenchmarkBase):

--- a/api/tests_v2/while_loop.py
+++ b/api/tests_v2/while_loop.py
@@ -59,12 +59,13 @@ class PDWhileLoop(PaddleAPIBenchmarkBase):
         result = paddle.zeros(
             shape=[config.alias.x_shape[0], config.alias.weight_shape[-1]],
             dtype=config.alias.x_dtype)
+        result.stop_gradient = False
         _, _, _, results = paddle.nn.while_loop(cond, body,
                                                 [i, loop_len, x, result])
         self.feed_vars = [x]
         self.fetch_vars = [results]
         if config.backward:
-            self.append_gradients([results, x], [x])
+            self.append_gradients(results, [x])
 
 
 class TFWhileLoop(TensorflowAPIBenchmarkBase):

--- a/api/tests_v2/while_loop.py
+++ b/api/tests_v2/while_loop.py
@@ -57,7 +57,7 @@ class PDWhileLoop(PaddleAPIBenchmarkBase):
         i = paddle.zeros(shape=[1], dtype='int64')
         loop_len = paddle.ones(shape=[1], dtype='int64')
         result = paddle.zeros(
-            shape=[config.alias.x_shape[0], config.alias.weight_shape[-1]],
+            shape=config.alias.x_shape[:-1] + config.alias.weight_shape[-1:],
             dtype=config.alias.x_dtype)
         result.stop_gradient = False
         _, _, _, results = paddle.nn.while_loop(cond, body,
@@ -98,7 +98,7 @@ class TFWhileLoop(TensorflowAPIBenchmarkBase):
         i = tf.constant(0)
         loop_len = tf.constant(1)
         result = tf.zeros(
-            shape=[config.alias.x_shape[0], config.size],
+            shape=config.alias.x_shape[:-1] + config.alias.weight_shape[-1:],
             dtype=config.alias.x_dtype)
         _, _, _, results = tf.while_loop(cond, body,
                                          [i, loop_len, input, result])

--- a/api/tests_v2/while_loop.py
+++ b/api/tests_v2/while_loop.py
@@ -64,7 +64,7 @@ class PDWhileLoop(PaddleAPIBenchmarkBase):
         self.feed_vars = [x]
         self.fetch_vars = [results]
         if config.backward:
-            self.append_gradients(results, [x])
+            self.append_gradients([results, x], [x])
 
 
 class TFWhileLoop(TensorflowAPIBenchmarkBase):


### PR DESCRIPTION
Refine the error of while_loop in backward calculation. More information please refer to [icafe427](http://newicafe.baidu.com/v5/issue/paddle-perf-427/show).