### PR TITLE
fix bug of remove alias in paddle

### DIFF
--- a/api/tests_v2/expand_as.py
+++ b/api/tests_v2/expand_as.py
@@ -19,9 +19,8 @@ from common_import import *
 class PDExpandAs(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
-        y = paddle.fill_constant(shape=config.y_shape,
-                                 dtype=config.y_dtype,
-                                 value=0.0)
+        y = paddle.full(
+            shape=config.y_shape, dtype=config.y_dtype, fill_value=0.0)
         y.stop_gradient = True
         result = paddle.expand_as(x=x, y=y)
 

--- a/api/tests_v2/while_loop.py
+++ b/api/tests_v2/while_loop.py
@@ -60,8 +60,8 @@ class PDWhileLoop(PaddleAPIBenchmarkBase):
             shape=config.alias.x_shape[:-1] + config.alias.weight_shape[-1:],
             dtype=config.alias.x_dtype)
         result.stop_gradient = False
-        _, _, _, results = paddle.nn.while_loop(cond, body,
-                                                [i, loop_len, x, result])
+        _, _, _, results = paddle.static.nn.while_loop(
+            cond, body, [i, loop_len, x, result])
         self.feed_vars = [x]
         self.fetch_vars = [results]
         if config.backward:


### PR DESCRIPTION
修复因为paddle删除部分alias导致的脚本运行错误。

- case已使用的正确别名

- 删除paddle.nn.while_loop

- 删除paddle.fill_constant