### PR TITLE
fix cumsum, slice, softmax_with_cross_entropy tests

### DIFF
--- a/api/tests/cumsum.py
+++ b/api/tests/cumsum.py
@@ -32,6 +32,8 @@ class PDCumsum(PaddleAPIBenchmarkBase):
 
         self.feed_vars = [x]
         self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
 
 
 class TFCumsum(TensorflowAPIBenchmarkBase):
@@ -45,6 +47,8 @@ class TFCumsum(TensorflowAPIBenchmarkBase):
 
         self.feed_list = [x]
         self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
 
 
 if __name__ == '__main__':

--- a/api/tests/slice.py
+++ b/api/tests/slice.py
@@ -21,18 +21,20 @@ class SliceConfig(APIConfig):
 
     def to_tensorflow(self):
         tf_config = super(SliceConfig, self).to_tensorflow()
+        tf_config.begin = []
+        tf_config.size = []
+        for i in range(len(self.input_shape)):
+            tf_config.begin.append(0)
+            tf_config.size.append(self.input_shape[i])
         if len(self.starts) < len(self.input_shape):
-            tf_config.begin = []
-            tf_config.size = []
-            for i in range(len(self.input_shape)):
-                tf_config.begin.append(0)
-                tf_config.size.append(self.input_shape[i])
             for c, i in enumerate(self.axes):
                 tf_config.begin[i] = self.starts[c]
                 tf_config.size[i] = self.ends[c] - self.starts[c]
         else:
             for j in range(len(self.starts)):
-                tf_config.size[j] = self.ends[j] - self.starts[j]
+                tf_config.begin[i] = self.starts[j]
+                if self.ends[j] - self.starts[j] < self.input_shape[j]:
+                    tf_config.size[j] = self.ends[j] - self.starts[j]
         return tf_config
 
 

--- a/api/tests/softmax_with_cross_entropy.py
+++ b/api/tests/softmax_with_cross_entropy.py
@@ -35,6 +35,9 @@ class SoftmaxWithCrossEntropyConfig(APIConfig):
             }  # label
         ]
 
+        if self.label_dtype == 'float32' or self.label_dtype == 'float64':
+            self.run_tf = False
+
     def to_tensorflow(self):
         tf_config = super(SoftmaxWithCrossEntropyConfig, self).to_tensorflow()
         label_rank = len(tf_config.label_shape)


### PR DESCRIPTION
fix cumsum, slice, softmax_with_cross_entropy 1.8 tests

- cumsum 第0个配置 报错
   ``` AssertionError: If backward is not surported for cumsum, please add the 'cumsum' to NO_BACKWARD_OPS in 
    api/common/special_op_list.py.```

- slice 第3/4个配置 报错
    ```AttributeError: 'SliceConfig' object has no attribute 'size'```

- softmax_with_cross_entropy 第0个配置 报错
```TypeError: Value passed to parameter 'indices' has DataType float32 not in list of allowed values: uint8, int32, int64```