### PR TITLE
Change repeat of cumsum_1 to 100 to avoid timeout and support to collect the subclasses recursively.

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -175,6 +175,14 @@ class APIConfig(object):
         self.feed_spec = None
         self.run_tf = True
 
+    @classmethod
+    def get_all_subclasses(self):
+        all_subclasses = []
+        for subclass in self.__subclasses__():
+            all_subclasses.append(subclass)
+            all_subclasses.extend(subclass.get_all_subclasses())
+        return all_subclasses
+
     def alias_filename(self, filename):
         """
         Get the filename of alias config.

--- a/api/deploy/api_info.txt
+++ b/api/deploy/api_info.txt
@@ -14,7 +14,7 @@ conv2d,conv2d,conv2d.json,True
 conv2d_transpose,conv2d_transpose,conv2d_transpose.json,True
 cos,activation,activation.json,True
 cos_sim,cos_sim,cos_sim.json,True
-cumsum,cumsum,cumsum.json,True
+cumsum,cumsum,cumsum.json,False
 depthwise_conv2d,depthwise_conv2d,depthwise_conv2d.json,True
 dropout,dropout,dropout.json,True
 elementwise_add,elementwise,elementwise.json,True
@@ -48,7 +48,7 @@ less_than,compare,compare.json,False
 logical_and,logical,logical.json,False
 logical_not,logical_not,logical_not.json,False
 logical_or,logical,logical.json,False
-lstm,lstm,lstm.json,True
+lstm,lstm,lstm.json,False
 matmul,matmul,matmul.json,True
 mean,mean,mean.json,True
 not_equal,compare,compare.json,False

--- a/api/deploy/api_info_v2.txt
+++ b/api/deploy/api_info_v2.txt
@@ -26,9 +26,8 @@ data_norm,data_norm,data_norm.json,True
 depthwise_conv2d,depthwise_conv2d,depthwise_conv2d.json,True
 depthwise_conv_transpose2d,depthwise_conv_transpose2d,depthwise_conv_transpose2d.json,True
 diag,diag,diag.json,False
-divide,divide,divide.json,True
+divide,divide,elementwise.json,True
 dropout,dropout,dropout.json,True
-elementwise_sub,elementwise_with_axis,elementwise.json,True
 embedding,embedding,embedding.json,True
 equal,compare,compare.json,False
 equal_all,equal_all,equal_all.json,False
@@ -109,6 +108,7 @@ sqrt,activation,activation.json,True
 square,activation,activation.json,True
 squeeze,squeeze,squeeze.json,True
 stack,stack,stack.json,True
+subtract,elementwise_with_axis,elementwise.json,True
 sum,reduce,reduce.json,True
 switch_case,switch_case,switch_case.json,True
 tanh,activation,activation.json,True

--- a/api/deploy/collect_api_info.py
+++ b/api/deploy/collect_api_info.py
@@ -21,8 +21,6 @@ import importlib
 
 package_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(package_path)
-sys.path.append(os.path.join(package_path, "tests"))
-sys.path.append(os.path.join(package_path, "tests_v2"))
 
 from common import api_param, special_op_list
 
@@ -43,11 +41,11 @@ def collect_subclass_dict(test_cases_dict):
     """
     Collect the test cases which declares a subclass of APIConfig.
     """
-    subclass_list = api_param.APIConfig.__subclasses__()
+    subclass_list = api_param.APIConfig.get_all_subclasses()
     subclass_dict = {}
-    for item in subclass_list:
-        config = item()
-        subclass_dict[config.name] = item.__name__
+    for subclass in subclass_list:
+        config = subclass()
+        subclass_dict[config.name] = subclass.__name__
     return subclass_dict
 
 
@@ -137,4 +135,5 @@ if __name__ == '__main__':
     assert args.test_module_name in [
         "tests", "tests_v2"
     ], "Please set test_module_name to \"tests\" or \"tests_v2\"."
+    sys.path.append(os.path.join(package_path, args.test_module_name))
     main(args)

--- a/api/tests/configs/cumsum.json
+++ b/api/tests/configs/cumsum.json
@@ -41,5 +41,6 @@
             "type": "Variable"
         }
     },
-    "atol": 0.1
+    "atol": 0.1,
+    "repeat": 100
 }]

--- a/api/tests_v2/configs/cumsum.json
+++ b/api/tests_v2/configs/cumsum.json
@@ -25,5 +25,6 @@
             "type": "Variable"
         }
     },
-    "atol": 0.1
+    "atol": 0.1,
+    "repeat": 100
 }]


### PR DESCRIPTION
- 减少cumsum_1的repeat次数，避免测试时timeout。
- collect_api_info.py中无法获取DivideConfig类，因此需为APIConfig实现一个静态类，递归地收集所有层次的subclass的信息。

https://github.com/PaddlePaddle/benchmark/blob/95272d6edd12787442607c3283fc458f77c1ba4a/api/deploy/collect_api_info.py#L46