### PR TITLE
Implement a default disabled() to disable the float16 configs for CPU and disable the tf's conv tests when data_format is NCHW. 

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -209,6 +209,9 @@ class APIConfig(object):
         for name, value in vars(self).items():
             # float16 is not supported for CPU.
             if not use_gpu and name.endswith("_dtype") and value == "float16":
+                print("Warning:\n"
+                      "  1. float16 is not supported for %s on CPU.\n" %
+                      (self.api_name))
                 return True
         return False
 

--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -209,9 +209,10 @@ class APIConfig(object):
         for name, value in vars(self).items():
             # float16 is not supported for CPU.
             if not use_gpu and name.endswith("_dtype") and value == "float16":
-                print("Warning:\n"
-                      "  1. float16 is not supported for %s on CPU.\n" %
-                      (self.api_name))
+                print(
+                    "Warning:\n"
+                    "  1. This config is disabled because float16 is not supported for %s on CPU.\n"
+                    % (self.api_name))
                 return True
         return False
 

--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -205,6 +205,11 @@ class APIConfig(object):
         return self.__framework
 
     def disabled(self):
+        use_gpu = os.environ.get("CUDA_VISIBLE_DEVICES", None) != ""
+        for name, value in vars(self).items():
+            # float16 is not supported for CPU.
+            if not use_gpu and name.endswith("_dtype") and value == "float16":
+                return True
         return False
 
     def init_from_json(self, filename, config_id=0, unknown_dim=16):

--- a/api/common/main.py
+++ b/api/common/main.py
@@ -19,10 +19,12 @@ import os
 import json
 import sys
 import warnings
+import collections
 import numpy as np
 
 from common import utils
 from common import api_param
+from common import special_op_list
 
 
 def _check_gpu_device(use_gpu):
@@ -167,14 +169,30 @@ def _adaptive_repeat(config, args):
             args.repeat = config.repeat
 
 
-def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
-    assert config is not None, "API config must be set."
+def _check_disabled(config, args):
     if config.disabled():
         warnings.simplefilter('always', UserWarning)
         warnings.warn("This config is disabled.")
-        return
+
+        status = collections.OrderedDict()
+        status["name"] = config.api_name
+        status["device"] = "GPU" if args.use_gpu else "CPU"
+        status["backward"] = args.backward if special_op_list.has_backward(
+            config) else False
+        status["disabled"] = True
+        status["parameters"] = config.to_string()
+        print(json.dumps(status))
+        return True
+    return False
+
+
+def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
+    assert config is not None, "API config must be set."
 
     args = parse_args()
+    if _check_disabled(config, args):
+        return
+
     _adaptive_repeat(config, args)
     config.backward = args.backward
     use_feed_fetch = True if args.task == "accuracy" else False
@@ -228,6 +246,7 @@ def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
                 tf_outputs,
                 name=config.api_name,
                 atol=config.atol,
+                use_gpu=args.use_gpu,
                 backward=pd_obj.backward,
                 config_params=config.to_string())
         else:

--- a/api/common/main.py
+++ b/api/common/main.py
@@ -171,9 +171,6 @@ def _adaptive_repeat(config, args):
 
 def _check_disabled(config, args):
     if config.disabled():
-        warnings.simplefilter('always', UserWarning)
-        warnings.warn("This config is disabled.")
-
         status = collections.OrderedDict()
         status["name"] = config.api_name
         status["device"] = "GPU" if args.use_gpu else "CPU"
@@ -249,6 +246,3 @@ def test_main_without_json(pd_obj=None, tf_obj=None, config=None):
                 use_gpu=args.use_gpu,
                 backward=pd_obj.backward,
                 config_params=config.to_string())
-        else:
-            warnings.simplefilter('always', UserWarning)
-            warnings.warn("This config is not supported by TensorFlow.")

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -181,6 +181,7 @@ def check_outputs(list1,
                   list2,
                   name,
                   atol=1E-6,
+                  use_gpu=True,
                   backward=False,
                   config_params=None):
     import tensorflow as tf
@@ -267,6 +268,7 @@ def check_outputs(list1,
 
     status = collections.OrderedDict()
     status["name"] = name
+    status["device"] = "GPU" if use_gpu else "CPU"
     status["backward"] = backward
     status["consistent"] = consistent
     status["num_outputs"] = num_outputs

--- a/api/deploy/op_benchmark_unit.py
+++ b/api/deploy/op_benchmark_unit.py
@@ -59,6 +59,7 @@ class OpBenchmarkUnit(object):
     def __init__(self, case_detail):
         self.case_name = case_detail["name"]
         self.op_type = parse_op_type(self.case_name)
+        self.disabled = case_detail.get("disabled", False)
 
         if case_detail.get("parameters", None):
             parameters = api_param.parse_string(case_detail["parameters"])

--- a/api/tests/common_import.py
+++ b/api/tests/common_import.py
@@ -36,3 +36,7 @@ from common.paddle_api_benchmark import PaddleAPIBenchmarkBase
 from common.tensorflow_api_benchmark import TensorflowAPIBenchmarkBase
 from common.api_param import APIConfig
 from common.main import test_main, test_main_without_json
+
+
+def use_gpu():
+    return os.environ.get("CUDA_VISIBLE_DEVICES", None) != ""

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -30,17 +30,22 @@ class Conv2dConfig(APIConfig):
 
     def disabled(self):
         if self.input_dtype == "float16" and self.use_cudnn == False:
+            print(
+                "Warning:\n"
+                "  1. This config is disabled because float16 is not supported for %s when use_cudnn is False.\n"
+                % (self.api_name))
             return True
         return super(Conv2dConfig, self).disabled()
 
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
         super(Conv2dConfig, self).init_from_json(filename, config_id,
                                                  unknown_dim)
-        if use_gpu and self.data_format == "NCHW":
+        if not use_gpu() and self.data_format == "NCHW":
             print(
                 "Warning:\n"
-                "  1. The tf's conv ops currently only supports the NHWC tensor "
-                "format on the CPU. Please add a rule to support it.\n")
+                "  1. tf is disabled because the tf's conv ops currently only "
+                "supports the NHWC tensor format on the CPU. Please add a rule "
+                "to support it.\n")
             self.run_tf = False
 
         if isinstance(self.padding, int):

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -31,7 +31,7 @@ class Conv2dConfig(APIConfig):
     def disabled(self):
         if self.input_dtype == "float16" and self.use_cudnn == False:
             return True
-        return False
+        return super(Conv2dConfig, self).disabled()
 
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
         super(Conv2dConfig, self).init_from_json(filename, config_id,

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -36,6 +36,13 @@ class Conv2dConfig(APIConfig):
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
         super(Conv2dConfig, self).init_from_json(filename, config_id,
                                                  unknown_dim)
+        if use_gpu and self.data_format == "NCHW":
+            print(
+                "Warning:\n"
+                "  1. The tf's conv ops currently only supports the NHWC tensor "
+                "format on the CPU. Please add a rule to support it.\n")
+            self.run_tf = False
+
         if isinstance(self.padding, int):
             self.padding = [self.padding, self.padding]
         if self.data_format == "NCHW":

--- a/api/tests/conv2d_transpose.py
+++ b/api/tests/conv2d_transpose.py
@@ -35,9 +35,10 @@ class Conv2dTransposeConfig(Conv2dConfig):
                 str) and self.padding != [0, 0] and self.padding != [1, 1]:
             print(
                 "Warning:\n"
-                "  1. The argument padding of tf's conv2d_transpose must be a "
-                "string and the value is \"SAME\" or \"VALID\". Please add rule "
-                "to convert this kind of padding to string.\n")
+                "  1. tf is disabled becuase the argument padding of tf's "
+                "conv2d_transpose must be a string and the value is \"SAME\" "
+                "or \"VALID\". Please add rule to convert this kind of padding to string.\n"
+            )
             self.run_tf = False
 
     def to_tensorflow(self):

--- a/api/tests/conv2d_transpose.py
+++ b/api/tests/conv2d_transpose.py
@@ -33,6 +33,11 @@ class Conv2dTransposeConfig(Conv2dConfig):
         if not isinstance(
                 self.padding,
                 str) and self.padding != [0, 0] and self.padding != [1, 1]:
+            print(
+                "Warning:\n"
+                "  1. The argument padding of tf's conv2d_transpose must be a "
+                "string and the value is \"SAME\" or \"VALID\". Please add rule "
+                "to convert this kind of padding to string.\n")
             self.run_tf = False
 
     def to_tensorflow(self):

--- a/api/tests/elementwise.py
+++ b/api/tests/elementwise.py
@@ -36,6 +36,10 @@ class ElementwiseConfig(APIConfig):
         if self.api_name in [
                 "elementwise_max", "elementwise_min", "elementwise_pow"
         ] and self.x_dtype == "float16":
+            print(
+                "Warning:\n"
+                "  1. This config is disabled because float16 is not supported for %s.\n"
+                % (self.api_name))
             return True
         return super(ElementwiseConfig, self).disabled()
 

--- a/api/tests/elementwise.py
+++ b/api/tests/elementwise.py
@@ -37,7 +37,7 @@ class ElementwiseConfig(APIConfig):
                 "elementwise_max", "elementwise_min", "elementwise_pow"
         ] and self.x_dtype == "float16":
             return True
-        return False
+        return super(ElementwiseConfig, self).disabled()
 
     def to_tensorflow(self):
         tf_config = super(ElementwiseConfig, self).to_tensorflow()

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -17,6 +17,11 @@ task=${3:-"accuracy"} # "accuracy" or "speed"
 
 framework="paddle"  # "paddle" or "tensorflow"
 filename="${OP_BENCHMARK_ROOT}/tests/configs/${name}.json"
+if [ "$CUDA_VISIBLE_DEVICES" = "" ]; then
+    use_gpu=False
+else
+    use_gpu=True
+fi
 
 run_args="--task ${task} \
           --framework ${framework} \
@@ -25,7 +30,7 @@ run_args="--task ${task} \
           --check_output False \
           --profiler none \
           --backward True \
-          --use_gpu True \
+          --use_gpu ${use_gpu} \
           --repeat 1 \
           --allow_adaptive_repeat False \
           --log_level 0"

--- a/api/tests_v2/batch_norm.py
+++ b/api/tests_v2/batch_norm.py
@@ -22,9 +22,14 @@ class BatchNormConfig(APIConfig):
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
         super(BatchNormConfig, self).init_from_json(filename, config_id,
                                                     unknown_dim)
-        # TFBatchNorm does not have data_format param, it only support NHWC format.
+        # tf's batch_norm does not have data_format param, it only support NHWC format.
         if self.data_format == "NCHW":
+            print(
+                "Warning:\n"
+                "  1. tf's batch_norm does not have data_format param, it only support NHWC format.\n"
+            )
             self.run_tf = False
+
         if len(self.x_shape) == 4:
             if self.data_format == "NCHW":
                 self.num_channels = self.x_shape[1]

--- a/api/tests_v2/common_import.py
+++ b/api/tests_v2/common_import.py
@@ -37,6 +37,10 @@ from common.api_param import APIConfig
 from common.main import test_main, test_main_without_json
 
 
+def use_gpu():
+    return os.environ.get("CUDA_VISIBLE_DEVICES", None) != ""
+
+
 def unsqueeze_short(short, long):
     """
     Unsqueeze the short shape to the same length of the long's.

--- a/api/tests_v2/conv2d.py
+++ b/api/tests_v2/conv2d.py
@@ -31,11 +31,12 @@ class Conv2dConfig(APIConfig):
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
         super(Conv2dConfig, self).init_from_json(filename, config_id,
                                                  unknown_dim)
-        if use_gpu and self.data_format == "NCHW":
+        if not use_gpu() and self.data_format == "NCHW":
             print(
                 "Warning:\n"
-                "  1. The tf's conv ops currently only supports the NHWC tensor "
-                "format on the CPU. Please add a rule to support it.\n")
+                "  1. tf is disabled because the tf's conv ops currently only "
+                "supports the NHWC tensor format on the CPU. Please add a rule "
+                "to support it.\n")
             self.run_tf = False
 
         if isinstance(self.padding, int):

--- a/api/tests_v2/conv2d.py
+++ b/api/tests_v2/conv2d.py
@@ -31,6 +31,12 @@ class Conv2dConfig(APIConfig):
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
         super(Conv2dConfig, self).init_from_json(filename, config_id,
                                                  unknown_dim)
+        if use_gpu and self.data_format == "NCHW":
+            print(
+                "The tf's conv2d op currently only supports the NHWC tensor format on the CPU. Please add a rule to support it."
+            )
+            self.run_tf = False
+
         if isinstance(self.padding, int):
             self.padding = [self.padding, self.padding]
         if self.data_format == "NCHW":

--- a/api/tests_v2/conv2d.py
+++ b/api/tests_v2/conv2d.py
@@ -33,8 +33,9 @@ class Conv2dConfig(APIConfig):
                                                  unknown_dim)
         if use_gpu and self.data_format == "NCHW":
             print(
-                "The tf's conv2d op currently only supports the NHWC tensor format on the CPU. Please add a rule to support it."
-            )
+                "Warning:\n"
+                "  1. The tf's conv ops currently only supports the NHWC tensor "
+                "format on the CPU. Please add a rule to support it.\n")
             self.run_tf = False
 
         if isinstance(self.padding, int):

--- a/api/tests_v2/conv_transpose2d.py
+++ b/api/tests_v2/conv_transpose2d.py
@@ -35,9 +35,10 @@ class ConvTranspose2dConfig(Conv2dConfig):
                 str) and self.padding != [0, 0] and self.padding != [1, 1]:
             print(
                 "Warning:\n"
-                "  1. The argument padding of tf's conv2d_transpose must be a "
-                "string and the value is \"SAME\" or \"VALID\". Please add rule "
-                "to convert this kind of padding to string.\n")
+                "  1. tf is disabled because the argument padding of tf's "
+                "conv2d_transpose must be a string and the value is \"SAME\" "
+                "or \"VALID\". Please add rule to convert this kind of padding to string.\n"
+            )
             self.run_tf = False
 
     def to_tensorflow(self):

--- a/api/tests_v2/conv_transpose2d.py
+++ b/api/tests_v2/conv_transpose2d.py
@@ -34,8 +34,10 @@ class ConvTranspose2dConfig(Conv2dConfig):
                 self.padding,
                 str) and self.padding != [0, 0] and self.padding != [1, 1]:
             print(
-                "The argument padding of tf's conv2d_transpose must be a string and the value is \"SAME\" or \"VALID\". Please add rule to convert this kind of padding to string."
-            )
+                "Warning:\n"
+                "  1. The argument padding of tf's conv2d_transpose must be a "
+                "string and the value is \"SAME\" or \"VALID\". Please add rule "
+                "to convert this kind of padding to string.\n")
             self.run_tf = False
 
     def to_tensorflow(self):

--- a/api/tests_v2/conv_transpose2d.py
+++ b/api/tests_v2/conv_transpose2d.py
@@ -57,6 +57,9 @@ class ConvTranspose2dConfig(APIConfig):
         if not isinstance(
                 self.padding,
                 str) and self.padding != [0, 0] and self.padding != [1, 1]:
+            print(
+                "The argument padding of tf's conv2d_transpose must be a string and the value is \"SAME\" or \"VALID\". Please add rule to convert this kind of padding to string."
+            )
             self.run_tf = False
 
         if self.data_format == "NCHW":

--- a/api/tests_v2/elementwise.py
+++ b/api/tests_v2/elementwise.py
@@ -24,6 +24,10 @@ class ElementwiseConfig(APIConfig):
 
     def disabled(self):
         if self.api_name in ["pow"] and self.x_dtype == "float16":
+            print(
+                "Warning:\n"
+                "  1. This config is disabled because float16 is not supported for %s.\n"
+                % (self.api_name))
             return True
         return super(ElementwiseConfig, self).disabled()
 

--- a/api/tests_v2/elementwise.py
+++ b/api/tests_v2/elementwise.py
@@ -25,7 +25,7 @@ class ElementwiseConfig(APIConfig):
     def disabled(self):
         if self.api_name in ["pow"] and self.x_dtype == "float16":
             return True
-        return False
+        return super(ElementwiseConfig, self).disabled()
 
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
         super(ElementwiseConfig, self).init_from_json(filename, config_id,

--- a/api/tests_v2/elementwise_with_axis.py
+++ b/api/tests_v2/elementwise_with_axis.py
@@ -33,7 +33,7 @@ class ElementwiseWithAxisConfig(APIConfig):
         if self.api_name in ["maximum", "minimum"
                              ] and self.x_dtype == "float16":
             return True
-        return False
+        return super(ElementwiseWithAxisConfig, self).disabled()
 
     def to_tensorflow(self):
         tf_config = super(ElementwiseWithAxisConfig, self).to_tensorflow()

--- a/api/tests_v2/elementwise_with_axis.py
+++ b/api/tests_v2/elementwise_with_axis.py
@@ -32,6 +32,10 @@ class ElementwiseWithAxisConfig(APIConfig):
     def disabled(self):
         if self.api_name in ["maximum", "minimum"
                              ] and self.x_dtype == "float16":
+            print(
+                "Warning:\n"
+                "  1. This config is disabled because float16 is not supported for %s.\n"
+                % (self.api_name))
             return True
         return super(ElementwiseWithAxisConfig, self).disabled()
 

--- a/api/tests_v2/remainder.py
+++ b/api/tests_v2/remainder.py
@@ -24,7 +24,9 @@ class RemainderConfig(APIConfig):
         self.alias_name = "elementwise"
 
     def disabled(self):
-        return True if self.x_dtype == "float16" else False
+        if self.x_dtype == "float16":
+            return True
+        return super(RemainderConfig, self).disabled()
 
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
         super(RemainderConfig, self).init_from_json(filename, config_id,

--- a/api/tests_v2/remainder.py
+++ b/api/tests_v2/remainder.py
@@ -25,6 +25,10 @@ class RemainderConfig(APIConfig):
 
     def disabled(self):
         if self.x_dtype == "float16":
+            print(
+                "Warning:\n"
+                "  1. This config is disabled because float16 is not supported for %s.\n"
+                % (self.api_name))
             return True
         return super(RemainderConfig, self).disabled()
 

--- a/api/tests_v2/run.sh
+++ b/api/tests_v2/run.sh
@@ -17,6 +17,11 @@ task=${3:-"accuracy"} # "accuracy" or "speed"
 
 framework="paddle"  # "paddle" or "tensorflow"
 filename="${OP_BENCHMARK_ROOT}/tests_v2/configs/${name}.json"
+if [ "$CUDA_VISIBLE_DEVICES" = "" ]; then
+    use_gpu=False
+else
+    use_gpu=True
+fi
 
 run_args="--task ${task} \
           --framework ${framework} \
@@ -25,7 +30,7 @@ run_args="--task ${task} \
           --check_output False \
           --profiler none \
           --backward True \
-          --use_gpu True \
+          --use_gpu ${use_gpu} \
           --repeat 1 \
           --allow_adaptive_repeat False \
           --log_level 0"


### PR DESCRIPTION
- Paddle op的CPU kernel都不支持`float16`数据类型，因此：
    - 为基类APIConfig实现一个默认的disable()函数，CPU测试时disable所有float16的配置。
    - disable的配置也输出一个json字符串，便于summary脚本中过滤disable的配置
    - 修改后输出如下：

    ```
    ---- Initialize APIConfig from /work/benchmark/api/tests_v2/configs/accuracy.json, config_id = 0.

    Warning:
      1. This config is disabled because float16 is not supported for accuracy on CPU.

    {"name": "accuracy", "device": "CPU", "backward": false, "disabled": true, "parameters": "input (Variable) - dtype: float16, shape: [16, 3]\nlabel (Variable) - dtype: int64, shape: [16, 1]\ntotal (Variable) - dtype: int64, shape: []\ncorrect (string): None\nk (int): 1\n"}
    ```

- tf的conv类的op，CPU运行时都不支持NCHW，因此标记`run_tf=False`。输出如下：
```
Warning:
  1. tf is disabled because the tf's conv ops currently only supports the NHWC tensor format on the CPU. Please add a rule to support it.

[paddle][conv2d] conv2d {
  atol: 0.01
  run_tf: False
  data_format: NCHW
  dilation: 1
  filter_size: [3, 3]
  groups: 1
  num_filters: 512
  padding: [1, 1]
  stride: 1
  x_shape: [16, 512, 7, 7]
  x_dtype: float32
  num_channels: 512
  weight_shape: [512, 512, 3, 3]
}
Gradients:  [var x@GRAD : fluid.VarType.LOD_TENSOR.shape(16, 512, 7, 7).astype(VarType.FP32), var weight@GRAD : fluid.VarType.LOD_TENSOR.shape(512, 512, 3, 3).astype(VarType.FP32)]
```

