### PR TITLE
Change dropout to test the CI.

### DIFF
--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -155,7 +155,7 @@ def _check_shape(name, output1, output2, i):
                     i, str(output1.shape), str(output2.shape)))
         else:
             print(
-                "---- The %d-th output's shape is compatible (same after squeezed/permuted), %s vs %s."
+                "---- Warning: The %d-th output's shape is compatible (same after squeezed/permuted), %s vs %s."
                 % (i, str(output1.shape), str(output2.shape)))
         return output1_squeezed, output2_squeezed
     return output1, output2
@@ -215,7 +215,7 @@ def check_outputs(list1,
                     output2,
                     tf.python.framework.indexed_slices.IndexedSlicesValue):
                 print(
-                    "Warning: The type of tensorflow output is IndexedSlicesValue,"
+                    "---- Warning: The type of tensorflow output is IndexedSlicesValue,"
                     "Skip all check, It will be fixed later.")
                 continue
 
@@ -280,13 +280,15 @@ def check_outputs(list1,
             print(
                 "---- Warning: The output is not consistent, but %s is in the white list."
                 % name)
-        elif not consistent:
-            print("Error: The output is not consistent!")
-        print(json.dumps(status))
-        if not consistent:
-            sys.exit(1)
-    else:
-        print(json.dumps(status))
+            print(json.dumps(status))
+            return
+        else:
+            print("Error: The output is not consistent!!!\n")
+
+    # Make sure the json result is the last line.
+    print(json.dumps(status))
+    if not consistent:
+        sys.exit(1)
 
 
 def print_benchmark_result(result, log_level=0, config_params=None):

--- a/api/tests_v2/configs/dropout.json
+++ b/api/tests_v2/configs/dropout.json
@@ -13,6 +13,10 @@
             "dtype": "float32",
             "shape": "[-1L, 36864L]",
             "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
         }
     },
     "repeat": 2000
@@ -31,6 +35,10 @@
             "dtype": "float32",
             "shape": "[-1L, 16L, -1L, -1L]",
             "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
         }
     },
     "repeat": 2000
@@ -49,6 +57,10 @@
             "dtype": "float32",
             "shape": "[-1L, 35L, 1500L]",
             "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
         }
     },
     "repeat": 2000
@@ -67,6 +79,10 @@
             "dtype": "float32",
             "shape": "[-1L, 16L, -1L, -1L]",
             "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
         }
     }
 }]

--- a/api/tests_v2/configs/elementwise.json
+++ b/api/tests_v2/configs/elementwise.json
@@ -75,6 +75,7 @@
             "type": "Variable"
         }
     },
+    "atol": 1E-5,
     "repeat": 5000
 }, {
     "op": "elementwise",

--- a/api/tests_v2/dropout.py
+++ b/api/tests_v2/dropout.py
@@ -19,7 +19,7 @@ class PDDropout(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         result = paddle.nn.functional.dropout(
-            x=x, p=config.p, mode=config.mode)
+            x=x, p=config.p, axis=config.axis, mode=config.mode)
 
         self.feed_vars = [x]
         self.fetch_vars = [result]


### PR DESCRIPTION
- 修复check_outputs中对于随机性OP的处理逻辑。随机性OP的执行结果。当前的代码，随机性OP即使加入了RANDOM_OPS_LIST，CI依旧会挂，CI log如下：
```
2020-10-26 12:07:27 ---- Warning: The 0-th output (shape: (16, 36864), data type: float32) has diff. The maximum diff is 2.000000e+00, offset is 504454: 0.0 vs 1.9999995. atol is 1.00e-06.
2020-10-26 12:07:27 ---- Warning: The 1-th output (shape: (16, 36864), data type: float32) has diff. The maximum diff is 2.000000e+00, offset is 4: 0.0 vs 2.0. atol is 1.00e-06.
2020-10-26 12:07:27 ---- Warning: The output is not consistent, but dropout is in the white list.
2020-10-26 12:07:27 {"name": "dropout", "device": "GPU", "backward": true, "consistent": false, "num_outputs": 2, "diff": 2.0, "parameters": "x (Variable) - dtype: float32, shape: [16, 36864]\naxis (string): None\nmode (string): downscale_in_infer\np (float): 0.5\n"}
2020-10-26 12:07:27 /usr/local/lib/python3.7/site-packages/tensorflow/python/data/ops/iterator_ops.py:546: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
2020-10-26 12:07:27   class IteratorBase(collections.Iterator, trackable.Trackable,
2020-10-26 12:07:27 /usr/local/lib/python3.7/site-packages/tensorflow/python/autograph/utils/testing.py:21: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
2020-10-26 12:07:27   import imp
2020-10-26 12:07:28 [ci/scripts/run_test.sh:90] [FATAL] Failed API tests: tests_v2/dropout
2020-10-26 12:07:28 [ci/scripts/run_test.sh:115] [FATAL] ============================================
2020-10-26 12:07:28 [ci/scripts/run_test.sh:116] [FATAL] Summary problems:
2020-10-26 12:07:28 [ci/scripts/run_test.sh:122] [FATAL] There is 1 error: API test error.
2020-10-26 12:07:28 [ci/scripts/run_test.sh:124] [FATAL] ============================================
2020-10-26 12:07:28 [ci/scripts/run_test.sh:132] [FATAL] === API test error - Please fix the failed API tests accroding to fatal log:
2020-10-26 12:07:28 [ci/scripts/run_test.sh:133] [FATAL] tests_v2/dropout
```

- 调整multiply_2的atol
