### PR TITLE
Fix main_control.sh run blocking error.

### DIFF
--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -238,7 +238,7 @@ function execute_one_case() {
                         for device_id in ${!DEVICE_TASK_PID_MAP[*]}
                         do
                             task_pid=${DEVICE_TASK_PID_MAP[$device_id]}
-                            if [ $task_pid -eq 0 -o -z "$(ps -opid | grep $task_pid)" ]
+                            if [ $task_pid -eq 0 -o -z "$(ps -opid | grep -w $task_pid)" ]
                             then
                                 gpu_id=$device_id
                                 finished_task_pid=$task_pid
@@ -327,7 +327,7 @@ function run_all_cases() {
             if [ $task_pid -eq 0 ]
             then
                 unset DEVICE_TASK_PID_MAP[$device_id]
-            elif [ -z "$(ps -opid | grep $task_pid)" ]
+            elif [ -z "$(ps -opid | grep -w $task_pid)" ]
             then
                 print_finished_task_detail $task_pid $(date +%s%N)
                 unset DEVICE_TASK_PID_MAP[$device_id]


### PR DESCRIPTION
`ps -opid | grep $task_pid`用来判断任务是否执行完成，当任务pid属于`ps -opid`中当前bash进程pid的子符串，如：

任务pid为312，当前bash进程pid为3127

那么这个判断就出现了错误，可以在grep时添加`-w`参数来完全匹配任务pid，从而避免上述问题。