### PR TITLE
lstm only runs on GPU

### DIFF
--- a/api/tests/lstm.py
+++ b/api/tests/lstm.py
@@ -20,6 +20,15 @@ class LstmConfig(APIConfig):
         super(LstmConfig, self).__init__("lstm")
         self.run_tf = False
 
+    def disabled(self):
+        if not use_gpu():
+            print(
+                "Warning:\n"
+                "  1. lstm is disabled because it is only supported run on GPU, now is CPU.\n"
+            )
+            return True
+        return super(LstmConfig, self).disabled()
+
 
 class PDLstm(PaddleAPIBenchmarkBase):
     def build_program(self, config):

--- a/api/tests_v2/lstm.py
+++ b/api/tests_v2/lstm.py
@@ -20,6 +20,15 @@ class LstmConfig(APIConfig):
         super(LstmConfig, self).__init__("lstm")
         self.run_tf = False
 
+    def disabled(self):
+        if not use_gpu():
+            print(
+                "Warning:\n"
+                "  1. lstm is disabled because it is only supported run on GPU, now is CPU.\n"
+            )
+            return True
+        return super(LstmConfig, self).disabled()
+
 
 class PDLstm(PaddleAPIBenchmarkBase):
     def build_program(self, config):


### PR DESCRIPTION
[lstm只支持运行在GPU设备上](https://www.paddlepaddle.org.cn/documentation/docs/zh/api_cn/layers_cn/lstm_cn.html#lstm)
![image](https://user-images.githubusercontent.com/6836917/97157952-c5cc0880-17b3-11eb-981e-92b4a00a771a.png)
- before:
```
----------------------
Error Message Summary:
----------------------
UnimplementedError: CPU is not support for this kernel now. Will be add in the future (at /workspace/paddle/fluid/operators/cudnn_lstm_op.cc:292)
  [operator < cudnn_lstm > error]
```
- after:
```
Warning:
  1. lstm is disabled because it is only supported run on GPU, now is CPU.
```