### PR TITLE
fix conv names and repeat times

### DIFF
--- a/api/deploy/api_info_v2.txt
+++ b/api/deploy/api_info_v2.txt
@@ -24,7 +24,7 @@ cosine_similarity,cosine_similarity,cosine_similarity.json,True
 cumsum,cumsum,cumsum.json,False
 data_norm,data_norm,data_norm.json,True
 depthwise_conv2d,depthwise_conv2d,depthwise_conv2d.json,True
-depthwise_conv_transpose2d,depthwise_conv_transpose2d,depthwise_conv_transpose2d.json,True
+depthwise_conv2d_transpose,depthwise_conv2d_transpose,depthwise_conv2d_transpose.json,True
 diag,diag,diag.json,False
 divide,divide,elementwise.json,True
 dropout,dropout,dropout.json,True

--- a/api/deploy/api_info_v2.txt
+++ b/api/deploy/api_info_v2.txt
@@ -17,8 +17,8 @@ clip_by_norm,clip_by_norm,clip_by_norm.json,False
 concat,concat,concat.json,True
 cond,cond,cond.json,True
 conv2d,conv2d,conv2d.json,True
-conv_transpose2d,conv_transpose2d,conv_transpose2d.json,True
-conv_transpose3d,conv_transpose3d,conv_transpose3d.json,True
+conv2d_transpose,conv2d_transpose,conv2d_transpose.json,True
+conv3d_transpose,conv3d_transpose,conv3d_transpose.json,True
 cos,activation,activation.json,True
 cosine_similarity,cosine_similarity,cosine_similarity.json,True
 cumsum,cumsum,cumsum.json,False
@@ -76,6 +76,7 @@ maximum,elementwise_with_axis,elementwise.json,True
 mean,reduce,reduce.json,True
 minimum,elementwise_with_axis,elementwise.json,True
 multiply,elementwise_with_axis,elementwise.json,True
+mv,mv,mv.json,True
 normalize,normalize,normalize.json,True
 not_equal,compare,compare.json,False
 null,null,None,False

--- a/api/tests/configs/embedding.json
+++ b/api/tests/configs/embedding.json
@@ -48,7 +48,7 @@
             "value": "[37007, 1024]"
         }
     },
-    "repeat": 10000
+    "repeat": 50000
 }, {
     "op": "embedding",
     "param_info": {

--- a/api/tests/configs/embedding.json
+++ b/api/tests/configs/embedding.json
@@ -48,7 +48,7 @@
             "value": "[37007, 1024]"
         }
     },
-    "repeat": 1000000
+    "repeat": 850000
 }, {
     "op": "embedding",
     "param_info": {

--- a/api/tests/configs/embedding.json
+++ b/api/tests/configs/embedding.json
@@ -48,7 +48,7 @@
             "value": "[37007, 1024]"
         }
     },
-    "repeat": 50000
+    "repeat": 1000000
 }, {
     "op": "embedding",
     "param_info": {
@@ -74,7 +74,7 @@
             "value": "[10000, 1500]"
         }
     },
-    "repeat": 50000
+    "repeat": 100000
 }, {
     "op": "embedding",
     "param_info": {

--- a/api/tests/configs/embedding.json
+++ b/api/tests/configs/embedding.json
@@ -47,7 +47,8 @@
             "type": "list",
             "value": "[37007, 1024]"
         }
-    }
+    },
+    "repeat": 10000
 }, {
     "op": "embedding",
     "param_info": {
@@ -73,7 +74,7 @@
             "value": "[10000, 1500]"
         }
     },
-    "repeat": 20000
+    "repeat": 50000
 }, {
     "op": "embedding",
     "param_info": {

--- a/api/tests/configs/reshape.json
+++ b/api/tests/configs/reshape.json
@@ -23,7 +23,7 @@
             "type": "Variable"
         }
     },
-    "repeat": 5000
+    "repeat": 10000
 }, {
     "op": "reshape",
     "param_info": {

--- a/api/tests/configs/reshape.json
+++ b/api/tests/configs/reshape.json
@@ -23,7 +23,7 @@
             "type": "Variable"
         }
     },
-    "repeat": 10000
+    "repeat": 30000
 }, {
     "op": "reshape",
     "param_info": {

--- a/api/tests/fc.py
+++ b/api/tests/fc.py
@@ -53,7 +53,7 @@ class PDFC(PaddleAPIBenchmarkBase):
                 initializer=fluid.initializer.ConstantInitializer(0.5)),
             bias_attr=fluid.ParamAttr(
                 initializer=fluid.initializer.ConstantInitializer(0.1)),
-            act=config.act)
+            act=None)
 
         self.feed_vars = [input]
         self.fetch_vars = [result]
@@ -71,12 +71,12 @@ class TFFC(TensorflowAPIBenchmarkBase):
                 num_outputs=config.size,
                 weights_initializer=tf.constant_initializer(0.5),
                 biases_initializer=tf.constant_initializer(0.1),
-                activation_fn=config.act)
+                activation_fn=None)
         else:
             result = tf.compat.v1.layers.dense(
                 inputs=input,
                 units=config.size,
-                activation=config.act,
+                activation=None,
                 use_bias=True,
                 kernel_initializer=tf.constant_initializer(0.5),
                 bias_initializer=tf.constant_initializer(0.1))

--- a/api/tests_v2/configs/conv2d_transpose.json
+++ b/api/tests_v2/configs/conv2d_transpose.json
@@ -1,5 +1,5 @@
 [{
-    "op": "conv_transpose2d",
+    "op": "conv2d_transpose",
     "param_info": {
         "data_format": {
             "type": "string",
@@ -41,7 +41,7 @@
     },
     "atol": 1E-4
 }, {
-    "op": "conv_transpose2d",
+    "op": "conv2d_transpose",
     "param_info": {
         "data_format": {
             "type": "string",
@@ -83,7 +83,7 @@
     },
     "atol": 1E-3
 }, {
-    "op": "conv_transpose2d",
+    "op": "conv2d_transpose",
     "param_info": {
         "data_format": {
             "type": "string",
@@ -124,7 +124,7 @@
         }
     }
 }, {
-    "op": "conv_transpose2d",
+    "op": "conv2d_transpose",
     "param_info": {
         "data_format": {
             "type": "string",
@@ -166,7 +166,7 @@
     },
     "atol": 1E-4
 }, {
-    "op": "conv_transpose2d",
+    "op": "conv2d_transpose",
     "param_info": {
         "data_format": {
             "type": "string",

--- a/api/tests_v2/configs/conv3d_transpose.json
+++ b/api/tests_v2/configs/conv3d_transpose.json
@@ -1,5 +1,5 @@
 [{
-    "op": "conv_transpose3d",
+    "op": "conv3d_transpose",
     "param_info": {
         "act": {
             "type": "string",

--- a/api/tests_v2/configs/depthwise_conv2d_transpose.json
+++ b/api/tests_v2/configs/depthwise_conv2d_transpose.json
@@ -1,5 +1,5 @@
 [{
-    "op": "depthwise_conv_transpose2d",
+    "op": "depthwise_conv2d_transpose",
     "param_info": {
         "data_format": {
             "type": "string",

--- a/api/tests_v2/configs/embedding.json
+++ b/api/tests_v2/configs/embedding.json
@@ -42,7 +42,7 @@
             "value": "0"
         }
     },
-    "repeat": 10000
+    "repeat": 50000
 }, {
     "op": "embedding",
     "param_info": {

--- a/api/tests_v2/configs/embedding.json
+++ b/api/tests_v2/configs/embedding.json
@@ -41,7 +41,8 @@
             "type": "int",
             "value": "0"
         }
-    }
+    },
+    "repeat": 10000
 }, {
     "op": "embedding",
     "param_info": {
@@ -64,7 +65,7 @@
             "value": "None"
         }
     },
-    "repeat": 20000
+    "repeat": 50000
 }, {
     "op": "embedding",
     "param_info": {

--- a/api/tests_v2/configs/embedding.json
+++ b/api/tests_v2/configs/embedding.json
@@ -42,7 +42,7 @@
             "value": "0"
         }
     },
-    "repeat": 50000
+    "repeat": 1000000
 }, {
     "op": "embedding",
     "param_info": {
@@ -65,7 +65,7 @@
             "value": "None"
         }
     },
-    "repeat": 50000
+    "repeat": 100000
 }, {
     "op": "embedding",
     "param_info": {

--- a/api/tests_v2/configs/embedding.json
+++ b/api/tests_v2/configs/embedding.json
@@ -42,7 +42,7 @@
             "value": "0"
         }
     },
-    "repeat": 1000000
+    "repeat": 850000
 }, {
     "op": "embedding",
     "param_info": {

--- a/api/tests_v2/configs/reshape.json
+++ b/api/tests_v2/configs/reshape.json
@@ -11,7 +11,7 @@
             "type": "Variable"
         }
     },
-    "repeat": 10000
+    "repeat": 30000
 }, {
     "op": "reshape",
     "param_info": {

--- a/api/tests_v2/configs/reshape.json
+++ b/api/tests_v2/configs/reshape.json
@@ -11,7 +11,7 @@
             "type": "Variable"
         }
     },
-    "repeat": 5000
+    "repeat": 10000
 }, {
     "op": "reshape",
     "param_info": {

--- a/api/tests_v2/conv2d_transpose.py
+++ b/api/tests_v2/conv2d_transpose.py
@@ -16,12 +16,12 @@ from common_import import *
 from conv2d import Conv2dConfig
 
 
-class ConvTranspose2dConfig(Conv2dConfig):
+class Conv2dTransposeConfig(Conv2dConfig):
     def __init__(self):
-        super(ConvTranspose2dConfig, self).__init__("conv_transpose2d")
+        super(Conv2dTransposeConfig, self).__init__("conv2d_transpose")
 
     def init_from_json(self, filename, config_id=0, unknown_dim=2):
-        super(ConvTranspose2dConfig, self).init_from_json(filename, config_id,
+        super(Conv2dTransposeConfig, self).init_from_json(filename, config_id,
                                                           unknown_dim)
         self.filter_shape = [
             self.num_channels // self.groups, self.num_filters,
@@ -43,7 +43,7 @@ class ConvTranspose2dConfig(Conv2dConfig):
 
     def to_tensorflow(self):
         assert self.output_size is not None
-        tf_config = super(ConvTranspose2dConfig, self).to_tensorflow()
+        tf_config = super(Conv2dTransposeConfig, self).to_tensorflow()
         tf_config.filter_shape = [
             self.filter_size[0], self.filter_size[1], self.num_filters,
             self.num_channels // self.groups
@@ -71,13 +71,13 @@ class ConvTranspose2dConfig(Conv2dConfig):
         return "VALID" if padding == [0, 0] else "SAME"
 
 
-class PDConvTranspose2d(PaddleAPIBenchmarkBase):
+class PDConv2dTranspose(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
         weight = self.variable(
             name="weight", shape=config.filter_shape, dtype=config.x_dtype)
 
-        result = paddle.nn.functional.conv_transpose2d(
+        result = paddle.nn.functional.conv2d_transpose(
             x=x,
             weight=weight,
             bias=None,
@@ -95,7 +95,7 @@ class PDConvTranspose2d(PaddleAPIBenchmarkBase):
             self.append_gradients(result, [x, weight])
 
 
-class TFConvTranspose2d(TensorflowAPIBenchmarkBase):
+class TFConv2dTranspose(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
         input = self.variable(
             name='input', shape=config.x_shape, dtype=config.x_dtype)
@@ -118,6 +118,6 @@ class TFConvTranspose2d(TensorflowAPIBenchmarkBase):
 
 if __name__ == '__main__':
     test_main(
-        PDConvTranspose2d(),
-        TFConvTranspose2d(),
-        config=ConvTranspose2dConfig())
+        PDConv2dTranspose(),
+        TFConv2dTranspose(),
+        config=Conv2dTransposeConfig())

--- a/api/tests_v2/conv3d_transpose.py
+++ b/api/tests_v2/conv3d_transpose.py
@@ -15,9 +15,9 @@
 from common_import import *
 
 
-class ConvTranspose3dConfig(APIConfig):
+class Conv3dTransposeConfig(APIConfig):
     def __init__(self):
-        super(ConvTranspose3dConfig, self).__init__("conv_transpose3d")
+        super(Conv3dTransposeConfig, self).__init__("conv3d_transpose")
         self.feed_spec = [
             {
                 "range": [-1, 1]
@@ -29,7 +29,7 @@ class ConvTranspose3dConfig(APIConfig):
         ]
 
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
-        super(ConvTranspose3dConfig, self).init_from_json(filename, config_id,
+        super(Conv3dTransposeConfig, self).init_from_json(filename, config_id,
                                                           unknown_dim)
         if isinstance(self.padding, int):
             self.padding = [self.padding, self.padding, self.padding]
@@ -67,7 +67,7 @@ class ConvTranspose3dConfig(APIConfig):
 
     def to_tensorflow(self):
         assert self.output_size is not None
-        tf_config = super(ConvTranspose3dConfig, self).to_tensorflow()
+        tf_config = super(Conv3dTransposeConfig, self).to_tensorflow()
         tf_config.filter_shape = [
             self.filter_size[0], self.filter_size[1], self.filter_size[2],
             self.num_channels // self.groups, self.num_filters
@@ -103,7 +103,7 @@ class ConvTranspose3dConfig(APIConfig):
         return "VALID" if padding == [0, 0, 0] else "SAME"
 
 
-class PDConvTranspose3d(PaddleAPIBenchmarkBase):
+class PDConv3dTranspose(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         input = self.variable(
             name='input', shape=config.input_shape, dtype=config.input_dtype)
@@ -125,7 +125,7 @@ class PDConvTranspose3d(PaddleAPIBenchmarkBase):
             self.append_gradients(result, [input, filter])
 
 
-class TFConvTranspose3d(TensorflowAPIBenchmarkBase):
+class TFConv3dTranspose(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
         input = self.variable(
             name='input', shape=config.input_shape, dtype=config.input_dtype)
@@ -148,6 +148,6 @@ class TFConvTranspose3d(TensorflowAPIBenchmarkBase):
 
 if __name__ == '__main__':
     test_main(
-        PDConvTranspose3d(),
-        TFConvTranspose3d(),
-        config=ConvTranspose3dConfig())
+        PDConv3dTranspose(),
+        TFConv3dTranspose(),
+        config=Conv3dTransposeConfig())

--- a/api/tests_v2/depthwise_conv2d_transpose.py
+++ b/api/tests_v2/depthwise_conv2d_transpose.py
@@ -15,10 +15,10 @@
 from common_import import *
 
 
-class DepthwiseConvTranspose2dConfig(APIConfig):
+class DepthwiseConv2dTransposeConfig(APIConfig):
     def __init__(self):
-        super(DepthwiseConvTranspose2dConfig,
-              self).__init__("depthwise_conv_transpose2d")
+        super(DepthwiseConv2dTransposeConfig,
+              self).__init__("depthwise_conv2d_transpose2d")
         self.feed_spec = [
             {
                 "range": [-1, 1]
@@ -29,7 +29,7 @@ class DepthwiseConvTranspose2dConfig(APIConfig):
         ]
 
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
-        super(DepthwiseConvTranspose2dConfig, self).init_from_json(
+        super(DepthwiseConv2dTransposeConfig, self).init_from_json(
             filename, config_id, unknown_dim)
         if isinstance(self.padding, int):
             self.padding = [self.padding, self.padding]
@@ -50,14 +50,14 @@ class DepthwiseConvTranspose2dConfig(APIConfig):
         self.run_tf = False
 
 
-class PDDepthwiseConvTranspose2d(PaddleAPIBenchmarkBase):
+class PDDepthwiseConv2dTranspose(PaddleAPIBenchmarkBase):
     def build_program(self, config):
         input = self.variable(
             name='input', shape=config.input_shape, dtype=config.input_dtype)
         filter = self.variable(
             name='filter', shape=config.filter_shape, dtype=config.input_dtype)
 
-        result = paddle.nn.functional.conv_transpose2d(
+        result = paddle.nn.functional.conv2d_transpose(
             x=input,
             weight=filter,
             output_size=config.output_size,
@@ -75,4 +75,4 @@ class PDDepthwiseConvTranspose2d(PaddleAPIBenchmarkBase):
 
 if __name__ == '__main__':
     test_main(
-        PDDepthwiseConvTranspose2d(), config=DepthwiseConvTranspose2dConfig())
+        PDDepthwiseConv2dTranspose(), config=DepthwiseConv2dTransposeConfig())

--- a/api/tests_v2/depthwise_conv2d_transpose.py
+++ b/api/tests_v2/depthwise_conv2d_transpose.py
@@ -18,7 +18,7 @@ from common_import import *
 class DepthwiseConv2dTransposeConfig(APIConfig):
     def __init__(self):
         super(DepthwiseConv2dTransposeConfig,
-              self).__init__("depthwise_conv2d_transpose2d")
+              self).__init__("depthwise_conv2d_transpose")
         self.feed_spec = [
             {
                 "range": [-1, 1]


### PR DESCRIPTION
做了如下修改：
1. conv_transpose2d-> conv2d_transpose。
2. conv_transpose3d-> conv3d_transpose。
3. depthwise_conv_transpose2d-> depthwise_conv2d_transpose
4. embedding_1/embedding_2/reshape_0 配置增加repeat次数。

- embedding_1，再增加repeat次数，反向会超时:
```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   94.02%  2.88333s    850001  3.3920us  2.8800us  13.536us  void paddle::operators::LookupTableV2<float, int=256, int=4, int=80, bool=1>(float*, paddle::operators::LookupTableV2<float, int=256, int=4, int=80, bool=1> const *, long const *, long, long, long, long)
                    5.98%  183.26ms         9  20.362ms  1.7600us  183.23ms  [CUDA memcpy HtoD]

percent: 0.94; gpu_time: 2883.3300 ms; calls: 850001; function: void paddle::operators::LookupTableV2<float, int=256, int=4, int=80, bool=1>(float*, paddle::operators::LookupTableV2<float, int=256, int=4, int=80, bool=1> const *, long const *, long, long, long, long)
total gpu_time: 3066.7198 ms
```

- embedding_2:

```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   98.45%  1.19147s    100001  11.914us  11.136us  18.432us  void paddle::operators::LookupTableV2<float, int=256, int=4, int=80, bool=0>(float*, paddle::operators::LookupTableV2<float, int=256, int=4, int=80, bool=0> const *, long const *, long, long, long, long)
                    1.55%  18.754ms         9  2.0838ms  1.7280us  18.723ms  [CUDA memcpy HtoD]
```

- reshape_0
```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   99.42%  23.7851s     30001  792.81us  784.86us  803.26us  [CUDA memcpy DtoD]
                    0.58%  139.82ms         8  17.478ms  2.6550us  139.79ms  [CUDA memcpy HtoD]

percent: 0.99; gpu_time: 23785.1000 ms; calls: 30001; function: [CUDA memcpy DtoD]
total gpu_time: 23923.8584 ms
```

## 报错

- CPU float16 报错

- conv2d_transpose,depthwise_conv2d_transpose develop编译的包可以通过，但是ci下载的包无法调用。
```
[paddle][depthwise_conv2d_transpose] depthwise_conv2d_transpose {
  atol: 0.0001
  run_tf: False
  data_format: NCHW
  dilation: 1
  filter_size: [4, 4]
  groups: 128
  num_filters: 128
  output_size: [16, 16]
  padding: [1, 1]
  stride: 2
  input_shape: [16, 256, 8, 8]
  input_dtype: float32
  num_channels: 256
  filter_shape: [256, 1, 4, 4]
}
{"framework": "paddle", "version": "0.0.0", "name": "depthwise_conv2d_transpose", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.09326277946939272, "wall_time": 0.0456622668675014, "total_include_wall_time": 0.13892504633689412, "gpu_time": 0.06541599678456592}, "parameters": "input (Variable) - dtype: float32, shape: [16, 256, 8, 8]\ndata_format (string): NCHW\ndilation (int): 1\nfilter_size (int): 4\ngroups (int): 128\nnum_filters (int): 128\noutput_size (list): [16, 16]\npadding (list): [1, 1]\nstride (int): 2\n"}
```