### PR TITLE
fix conv3d_transpose api name

### DIFF
--- a/api/tests_v2/conv3d_transpose.py
+++ b/api/tests_v2/conv3d_transpose.py
@@ -110,7 +110,7 @@ class PDConv3dTranspose(PaddleAPIBenchmarkBase):
         filter = self.variable(
             name='filter', shape=config.filter_shape, dtype=config.input_dtype)
 
-        result = paddle.nn.functional.conv_transpose3d(
+        result = paddle.nn.functional.conv3d_transpose(
             x=input,
             weight=filter,
             output_size=config.output_size,


### PR DESCRIPTION
修复conv3d_transpose 名称改变导致的脚本运行错误。
本地执行可通过：
```
Gradients:  [var input@GRAD : fluid.VarType.LOD_TENSOR.shape(16, 3, 8, 8, 8).astype(VarType.FP32), var filter@GRAD : fluid.VarType.LOD_TENSOR.shape(3, 6, 3, 3, 3).astype(VarType.FP32)]
{"framework": "paddle", "version": "0.0.0", "name": "conv3d_transpose", "device": "GPU", "backward": true, "speed": {"repeat": 1, "begin": 0, "end": 1, "total": 0.2689361572265625, "wall_time": 0.06937980651855469, "total_include_wall_time": 0.3383159637451172, "gpu_time": 0.42686056458511545}, "parameters": "input (Variable) - dtype: float32, shape: [16, 3, 8, 8, 8]\nact (string): None\ndata_format (string): NCDHW\ndilation (int): 1\nfilter_size (int): 3\ngroups (string): None\nnum_filters (int): 6\noutput_size (list): [10, 10, 10]\npadding (int): 0\nstride (int): 1\nuse_cudnn (bool): True\n"}
```