### PR TITLE
TF AvgPoolingOp only supports NHWC on device type CPU

### DIFF
--- a/api/tests/pool2d.py
+++ b/api/tests/pool2d.py
@@ -31,6 +31,13 @@ class Pool2dConfig(APIConfig):
         if not self.global_pooling and not isinstance(
                 self.pool_padding, str) and self.pool_padding != [0, 0]:
             self.run_tf = False
+        if not use_gpu(
+        ) and self.pool_type == 'avg' and self.data_format != 'NHWC':
+            self.run_tf = False
+            print(
+                "Warning:\n"
+                "  Tensorflow's AvgPoolingOp only supports NHWC on device type CPU.\n"
+            )
 
     def to_tensorflow(self):
         tf_config = super(Pool2dConfig, self).to_tensorflow()


### PR DESCRIPTION
```
tensorflow.python.framework.errors_impl.InvalidArgumentError: Default AvgPoolingGradOp only supports NHWC on device type CPU
	 [[node gradients/avg_pool_grad/AvgPoolGrad (defined at /benchmark/api/common/tensorflow_api_benchmark.py:247) ]]
```
api/tests目录下存在问题，但tests_v2目录下已修改正确。
![image](https://user-images.githubusercontent.com/6836917/98783600-ccee4a00-2434-11eb-91af-5963f2ab1f19.png)
log中可以正确打印出warning