### PR TITLE
lookup_table don't support float16 on CPU

### DIFF
--- a/api/tests/embedding.py
+++ b/api/tests/embedding.py
@@ -33,6 +33,15 @@ class EmbeddingConfig(APIConfig):
         if self.is_sparse or self.padding_idx is not None:
             self.run_tf = False
 
+    def disabled(self):
+        if self.dtype == "float16" and not use_gpu():
+            print(
+                "Warning:\n"
+                "  1. This config is disabled because float16 is not supported for %s on CPU.\n"
+                % (self.api_name))
+            return True
+        return super(EmbeddingConfig, self).disabled()
+
 
 class PDEmbedding(PaddleAPIBenchmarkBase):
     def build_program(self, config):


### PR DESCRIPTION
```
----------------------
Error Message Summary:
----------------------
Error: op lookup_table_v2 does not have kernel for data_type[::paddle::platform::float16]:data_layout[ANY_LAYOUT]:place[CPUPlace]:library_type[PLAIN] at (/paddle/paddle/fluid/framework/operator.cc:1081)
  [operator < lookup_table_v2 > error]
```
CI日志中能正确打出warning
![image](https://user-images.githubusercontent.com/6836917/98789312-1773c480-243d-11eb-9679-2dc7317a2e1b.png)
