### PR TITLE
Change batch_norm to use config.training to set training mode.

### DIFF
--- a/api/tests_v2/batch_norm.py
+++ b/api/tests_v2/batch_norm.py
@@ -75,11 +75,11 @@ class PDBatchNorm(PaddleAPIBenchmarkBase):
             x=x,
             running_mean=running_mean,
             running_var=running_var,
-            weight=scale,  # Scale
+            weight=scale,  # scale
             bias=bias,  # bias
             epsilon=config.epsilon,
             momentum=config.momentum,
-            training=False,
+            training=config.training,
             data_format=config.data_format)
 
         self.feed_vars = [x, scale, bias]


### PR DESCRIPTION
tests的batch_norm测试脚本中设置了is_test=False，即要测试的是train模式的batch_norm的性能。tests_v2的batch_norm测试脚本中，training参数写死成了False，json配置中的training参数设置的是True，脚本中应该使用config.training来设置training参数。