### PR TITLE
fix cumsum repeat iteration

### DIFF
--- a/api/common/main.py
+++ b/api/common/main.py
@@ -165,7 +165,7 @@ def _is_tensorflow_enabled(args, config):
 def _adaptive_repeat(config, args):
     if args.task == "speed" and args.allow_adaptive_repeat and hasattr(
             config, "repeat"):
-        if args.use_gpu and args.repeat < config.repeat:
+        if args.use_gpu:
             args.repeat = config.repeat
 
 


### PR DESCRIPTION
原来更新repeat的逻辑，是config的repeat大小设置大于命令行的repeat设置才更新。
cumsum_1的config repeat=100, 全量脚本的repeat设置为1000，所以全量脚本跑cumsum时，repeat没有更新。