### PR TITLE
Add an elementwise config from bert-base model.

### DIFF
--- a/api/tests_v2/configs/elementwise.json
+++ b/api/tests_v2/configs/elementwise.json
@@ -1,4 +1,5 @@
 [{
+    "config_id": 0,
     "op": "elementwise",
     "param_info": {
         "axis": {
@@ -19,6 +20,7 @@
     "atol": 1E-5,
     "repeat": 5000
 }, {
+    "config_id": 1,
     "op": "elementwise",
     "param_info": {
         "axis": {
@@ -39,6 +41,7 @@
     "atol": 1E-5,
     "repeat": 5000
 }, {
+    "config_id": 2,
     "op": "elementwise",
     "param_info": {
         "axis": {
@@ -58,6 +61,7 @@
     },
     "repeat": 5000
 }, {
+    "config_id": 3,
     "op": "elementwise",
     "param_info": {
         "axis": {
@@ -78,6 +82,7 @@
     "atol": 1E-5,
     "repeat": 5000
 }, {
+    "config_id": 4,
     "op": "elementwise",
     "param_info": {
         "axis": {
@@ -98,6 +103,7 @@
     "atol": 1E-3,
     "repeat": 5000
 }, {
+    "config_id": 5,
     "op": "elementwise",
     "param_info": {
         "axis": {
@@ -117,6 +123,7 @@
     },
     "repeat": 5000
 }, {
+    "config_id": 6,
     "op": "elementwise",
     "param_info": {
         "axis": {
@@ -136,4 +143,23 @@
     },
     "atol": 0.01,
     "repeat": 5000
+}, {
+    "config_id": 7,
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 12L, 128L, 128L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[32L, 1L, 1L, 128L]",
+            "type": "Variable"
+        }
+    }
 }]


### PR DESCRIPTION
前向测试结果如下：

- paddle
```
run command: nvprof /work/.virtualenvs_cuda10.1/paddle_py37/bin/python /work/benchmark/api/tests_v2/elementwise.py --task speed --framework paddle --json_file /work/benchmark/api/tests_v2/configs/elementwise.json --config_id 7 --check_output False --profiler none --backward False --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0 --api_name add
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   93.05%  138.60ms      1001  138.46us  138.27us  139.14us  void paddle::operators::CommonForwardBroadcastCUDAKernel<paddle::operators::AddFunctor<paddle::platform::float16, void>, paddle::platform::float16, paddle::platform::float16>(int const *, int const , int const , void const *, void const , paddle::operators::AddFunctor<paddle::platform::float16, void>*, int, int, paddle::platform::float16, bool)
                    6.95%  10.350ms      3012  3.4360us  1.6960us  5.0754ms  [CUDA memcpy HtoD]
```

- tf
```
run command: nvprof /work/.virtualenvs_cuda10.1/paddle_py37/bin/python /work/benchmark/api/tests_v2/elementwise.py --task speed --framework tf --json_file /work/benchmark/api/tests_v2/configs/elementwise.json --config_id 7 --check_output False --profiler none --backward False --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0 --api_name add
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   97.28%  37.448ms      1001  37.410us  36.352us  43.872us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<Eigen::half, int=3, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_sum_op<Eigen::half, Eigen::half>, Eigen::TensorBroadcastingOp<Eigen::array<long, unsigned long=3> const , Eigen::TensorMap<Eigen::Tensor<Eigen::half const , int=3, int=1, int>, int=16, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::array<long, unsigned long=3> const , Eigen::TensorMap<Eigen::Tensor<Eigen::half const , int=3, int=1, int>, int=16, Eigen::MakePointer> const > const > const > const , Eigen::GpuDevice>, int>(Eigen::half, int=3)
                    2.71%  1.0426ms         3  347.53us  1.7600us  1.0382ms  [CUDA memcpy HtoD]
```