### PR TITLE
Delete the config of activation whose shape is [1], because it is no use for performance improvement.

### DIFF
--- a/api/tests/configs/activation.json
+++ b/api/tests/configs/activation.json
@@ -8,13 +8,4 @@
         }
     },
     "repeat": 5000
-}, {
-    "op": "activation",
-    "param_info": {
-        "x": {
-            "dtype": "float32",
-            "shape": "[1L]",
-            "type": "Variable"
-        }
-    }
 }]

--- a/api/tests_v2/configs/activation.json
+++ b/api/tests_v2/configs/activation.json
@@ -8,13 +8,4 @@
         }
     },
     "repeat": 5000
-}, {
-    "op": "activation",
-    "param_info": {
-        "x": {
-            "dtype": "float32",
-            "shape": "[1L]",
-            "type": "Variable"
-        }
-    }
 }]


### PR DESCRIPTION
shape为[1]的activation操作，即使在网络中真实存在，也只有几us的时间，基本不会影响网络训练或预测的性能，因此删除该配置。