### PR TITLE
Add config for Paddle repo op benchmark ci

### DIFF
--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -137,6 +137,7 @@ function print_detail_status() {
     else
         printf "  [%s][%d-%d][%s] %-120s ...... %s\n" "${gpu_id}" ${config_id} ${case_id} "${timestamp}" "${print_str}" "${run_status}"
     fi
+    [ "$BENCHMARK_PRINT_FAIL_LOG" == "1" ] && cat ${logfile}
 }
 
 function print_finished_task_detail() {

--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -1,0 +1,21 @@
+# Paddle repo file name -> op name
+declare -A PADDLE_FILENAME_OP_MAP
+PADDLE_FILENAME_OP_MAP=(
+  ["activation_op.cu"]="leaky_relu elu sqrt square pow exp abs log"
+  ["interpolate_op.cu"]="bilinear_interp nearest_interp trilinear_interp bicubic_interp linear_interp"
+)
+
+# Benchmark repo name -> op name
+declare -A BENCHMARK_APINAME_OP_MAP
+BENCHMARK_APINAME_OP_MAP=(
+  ["argmin"]="arg_min"
+  ["argmax"]="arg_max"
+  ["cos_sim"]="cosine_similarity"
+  ["elementwise_max"]="maximum"
+  ["elementwise_min"]="minimum"
+  ["bilinear_interp"]="interp_bilinear"
+  ["nearest_interp"]="interp_nearest"
+  ["trilinear_interp"]="interp_trilinear"
+  ["bicubic_interp"]="interp_bicubic"
+  ["linear_interp"]="interp_linear"
+)


### PR DESCRIPTION
1. 添加`ci/scripts/op_benchmark.config`作为映射配置，其中
- `PADDLE_FILENAME_OP_MAP`表示从Paddle源文件到op的映射；
- `BENCHMARK_APINAME_OP_MAP`表示从op到benchmark测试api的映射；
2. 在`api/deploy/main_control.sh`添加打印失败日志逻辑，用于Paddle repo op性能测试流水线打印运行失败的日志；