### PR TITLE
Simplify the benchmark framework of dynamic apis

### DIFF
--- a/api/common/launch.py
+++ b/api/common/launch.py
@@ -59,7 +59,7 @@ def _parse_nvprof_logs(logs):
         if "GPU activities:" in line:
             line_from = i - 1
         if line_from is not None and "API calls:" in line:
-            line_to = i - 1
+            line_to = i
     if line_from is not None and line_to is not None:
         for i in range(line_from, line_to):
             print(logs[i])

--- a/api/common/main.py
+++ b/api/common/main.py
@@ -272,8 +272,8 @@ def test_main_without_json(pd_obj=None,
 
     if _is_paddle_enabled(args, config) and args.testing_mode == "dynamic":
         assert pd_dy_obj is not None, "Paddle dynamic object is None."
-        pd_dy_outputs, pd_dy_stats = paddle_dynamic_api_benchmark.run(
-            pd_dy_obj, config, args, feeder_adapter)
+        pd_dy_outputs, pd_dy_stats = pd_dy_obj.run(config, args,
+                                                   feeder_adapter)
 
         if args.task == "speed":
             pd_dy_stats["gpu_time"] = args.gpu_time

--- a/api/common/main.py
+++ b/api/common/main.py
@@ -259,8 +259,7 @@ def test_main_without_json(pd_obj=None,
     if _is_torch_enabled(args, config):
         assert torch_obj is not None, "Pytorch object is None."
         torch_config = config
-        torch_outputs, torch_stats = pytorch_api_benchmark.run(
-            torch_obj, torch_config, args)
+        torch_outputs, torch_stats = torch_obj.run(torch_config, args)
         feeder_adapter = torch_obj.get_feeder()
 
         if args.task == "speed":

--- a/api/common/paddle_dynamic_api_benchmark.py
+++ b/api/common/paddle_dynamic_api_benchmark.py
@@ -37,34 +37,29 @@ except Exception as e:
     sys.stderr.write(
         "Cannot import paddle.fluid, maybe paddle is not installed.\n")
 
+BEFORE_RUN = 0
+IN_RUN = 1
+AFTER_RUN = 2
+
 
 @six.add_metaclass(abc.ABCMeta)
 class PaddleDynamicAPIBenchmarkBase(object):
     def __init__(self):
         self.name = self.__class__.__name__
-        self.fetch_list = None
-        self.run_gpu = False
-        self.__backward = False
-        try:
-            import torch
-        except Exception as e:
-            sys.stderr.write(
-                "Cannot import pytorch, maybe pytorch is not installed.\n")
 
+    @abc.abstractmethod
     def build_graph(self, config=None):
         pass
 
-    def run_graph(self, config=None):
-        pass
-
     def variable(self, name, shape, dtype, value=None):
-        assert shape is not None
-
-        feed_value = feeder.generate_random_data(
-            shape, dtype, range=None, value=value)
-        paddle.disable_static()
-        var = paddle.to_tensor(feed_value, stop_gradient=False)
-        #print(var.stop_gradient)
+        if self.__status == BEFORE_RUN:
+            assert shape is not None
+            feed_value = feeder.generate_random_data(
+                shape, dtype, range=None, value=value)
+            var = paddle.to_tensor(feed_value, stop_gradient=False)
+            self.__feed_dict[name] = var
+        else:
+            var = self.__feed_dict[name]
         return var
 
     @property
@@ -107,61 +102,72 @@ class PaddleDynamicAPIBenchmarkBase(object):
         for var in inputs:
             self.fetch_list.append(var.grad)
 
+    def run_impl(self,
+                 use_gpu,
+                 config,
+                 repeat=1,
+                 check_output=False,
+                 profiler="none",
+                 feeder_adapter=None):
+        if feeder_adapter is not None:
+            # to be implement.
+            self.feed_list = []
+            for i in range(len(feeder_adapter)):
+                var = paddle.to_tensor(feeder_adapter[i], stop_gradient=False)
+                self.feed_list.append(var)
 
-def run_impl(paddle_obj,
-             use_gpu,
-             config,
-             repeat=1,
-             check_output=False,
-             profiler="none",
-             feeder_adapter=None):
+        def _run_main_iter():
+            self.build_graph(config=config)
+            if use_gpu:
+                paddle.fluid._cuda_synchronize(paddle.fluid.CUDAPlace(0))
 
-    runtimes = []
-    fetches = []
-    outputs = []
-    if feeder_adapter is not None:
+            outputs = None
+            if self.__need_fetch:
+                outputs = []
+                for var in self.fetch_list:
+                    if isinstance(var, np.ndarray):
+                        outputs.append(var)
+                    else:
+                        outputs.append(var.numpy())
+            return outputs
+
+        # warmup run
+        _run_main_iter()
+
+        runtimes = []
+        fetches = []
+
+        self.__status = IN_RUN
+        for i in range(repeat):
+            begin = time.time()
+            outputs = _run_main_iter()
+            runtimes.append(time.time() - begin)
+
+        self.__status = AFTER_RUN
+        stats = {
+            "framework": "paddle",
+            "version": paddle.__version__,
+            "name": self.name,
+            "device": "GPU" if use_gpu else "CPU",
+            "backward": self.__backward,
+            "total": runtimes
+        }
+        return outputs, stats
+
+    def run(self, config, args, feeder_adapter=None):
         paddle.disable_static()
-        paddle_obj.feed_list = []
-        for i in range(len(feeder_adapter)):
-            var = paddle.to_tensor(feeder_adapter[i], stop_gradient=False)
-            paddle_obj.feed_list.append(var)
-    else:
-        paddle_obj.build_graph(config=config)
-    for i in range(repeat):
-        if use_gpu:
-            begin = time.time()
-            paddle_obj.run_graph(config=config)
-            runtimes.append(time.time() - begin)
-        else:
-            begin = time.time()
-            paddle_obj.run_graph(config=config)
-            runtimes.append(time.time() - begin)
-    for var in paddle_obj.fetch_list:
-        if isinstance(var, np.ndarray):
-            outputs.append(var)
-        else:
-            outputs.append(var.numpy())
+        self.name = config.api_name
 
-    stats = {
-        "framework": "paddle",
-        "version": paddle.__version__,
-        "name": paddle_obj.name,
-        "device": "GPU" if use_gpu else "CPU",
-        "backward": paddle_obj.backward,
-        "total": runtimes
-    }
-    return outputs, stats
-
-
-def run(paddle_obj, config, args, feeder_adapter):
-    paddle_obj.name = config.api_name
-
-    outputs, stats = run_impl(
-        paddle_obj=paddle_obj,
-        use_gpu=args.use_gpu,
-        config=config,
-        repeat=args.repeat,
-        check_output=args.check_output,
-        profiler=args.profiler,
-        feeder_adapter=feeder_adapter)
-    return outputs, stats
+        self.fetch_list = None
+        self.__need_fetch = args.task == "accuracy"
+        self.__backward = False
+        self.__status = BEFORE_RUN
+        self.__feed_dict = {}
+        outputs, stats = self.run_impl(
+            use_gpu=args.use_gpu,
+            config=config,
+            repeat=args.repeat,
+            check_output=args.check_output,
+            profiler=args.profiler,
+            feeder_adapter=feeder_adapter)
+        return outputs, stats

--- a/api/common/paddle_dynamic_api_benchmark.py
+++ b/api/common/paddle_dynamic_api_benchmark.py
@@ -46,6 +46,9 @@ AFTER_RUN = 2
 class PaddleDynamicAPIBenchmarkBase(object):
     def __init__(self):
         self.name = self.__class__.__name__
+        self.feed_list = None
+        self.fetch_list = None
+        self.__status = BEFORE_RUN
 
     @abc.abstractmethod
     def build_graph(self, config=None):
@@ -158,6 +161,7 @@ class PaddleDynamicAPIBenchmarkBase(object):
         paddle.disable_static()
         self.name = config.api_name
 
+        self.feed_list = None
         self.fetch_list = None
         self.__need_fetch = args.task == "accuracy"
         self.__backward = False

--- a/api/dynamic_tests_v2/abs.py
+++ b/api/dynamic_tests_v2/abs.py
@@ -32,19 +32,18 @@ class PaddleAbs(PaddleDynamicAPIBenchmarkBase):
         self.feed_list = [x]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, self.feed_list)
+            self.append_gradients(result, [x])
 
 
 class TorchAbs(PytorchAPIBenchmarkBase):
     def build_graph(self, config):
-        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
-        self.feed_list = [x]
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.abs(x=x)
 
-    def run_graph(self, config):
-        result = torch.abs(x=self.feed_list[0])
+        self.feed_list = [x]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, self.feed_list)
+            self.append_gradients(result, [x])
 
 
 if __name__ == '__main__':

--- a/api/dynamic_tests_v2/abs.py
+++ b/api/dynamic_tests_v2/abs.py
@@ -27,10 +27,9 @@ class AbsConfig(APIConfig):
 class PaddleAbs(PaddleDynamicAPIBenchmarkBase):
     def build_graph(self, config):
         x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
-        self.feed_list = [x]
+        result = paddle.abs(x=x)
 
-    def run_graph(self, config):
-        result = paddle.abs(x=self.feed_list[0])
+        self.feed_list = [x]
         self.fetch_list = [result]
         if config.backward:
             self.append_gradients(result, self.feed_list)

--- a/api/dynamic_tests_v2/activation.py
+++ b/api/dynamic_tests_v2/activation.py
@@ -1,0 +1,59 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class ActivationConfig(APIConfig):
+    def __init__(self):
+        super(ActivationConfig, self).__init__('activation')
+        self.api_name = 'cos'
+        self.api_list = {
+            'sqrt': 'sqrt',
+            'cos': 'cos',
+            'exp': 'exp',
+            'sin': 'sin',
+            'sinh': 'sinh',
+            'square': 'square',
+            'tanh': 'tanh'
+        }
+
+
+class PDActivation(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = self.layers(config.api_name, x=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchActivation(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = self.layers(config.api_name, x=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDActivation(),
+        torch_obj=TorchActivation(),
+        config=ActivationConfig())

--- a/api/dynamic_tests_v2/cast.py
+++ b/api/dynamic_tests_v2/cast.py
@@ -1,0 +1,46 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class CastConfig(APIConfig):
+    def __init__(self):
+        super(CastConfig, self).__init__('cast')
+        self.feed_spec = {"range": [-10, 10]}
+
+
+class PDCast(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.cast(x=x, dtype=config.dtype)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+class TorchCast(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        if config.dtype == "float16":
+            result = x.to(torch.float16)
+        else:
+            assert False, "Not supported yet!"
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(pd_dy_obj=PDCast(), torch_obj=TorchCast(), config=CastConfig())

--- a/api/dynamic_tests_v2/relu.py
+++ b/api/dynamic_tests_v2/relu.py
@@ -1,0 +1,51 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class ReluConfig(APIConfig):
+    def __init__(self):
+        super(ReluConfig, self).__init__("relu")
+        self.feed_spec = {"range": [-1, 1]}
+        # self.api_list = {'relu': 'relu', 'relu6': 'relu6'}
+        # relu belongs to activation op series which only has one variable
+        # thus relu can reuse activation parameters 
+        self.alias_name = "activation"
+
+
+class PDRelu(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.nn.functional.relu(x=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchRelu(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.relu(input=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(pd_dy_obj=PDRelu(), torch_obj=TorchRelu(), config=ReluConfig())


### PR DESCRIPTION
- 简化动态图API的测试框架，使得动态图可以沿用静态图的测试代码，只需要实现一个`build_graph`函数。
- 增加几个测试脚本：cast、relu、activation
- 修复launch.py中，解析nvprof log中GPU Activities的bug，该bug导致GPU Activities log少打印了一行