### PR TITLE
add softmax dynamic tests

### DIFF
--- a/api/dynamic_tests_v2/softmax.py
+++ b/api/dynamic_tests_v2/softmax.py
@@ -1,0 +1,44 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PaddleSoftmax(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.nn.functional.softmax(x=x, axis=config.axis)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchSoftmax(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.softmax(input=x, dim=config.axis)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PaddleSoftmax(),
+        torch_obj=TorchSoftmax(),
+        config=APIConfig("softmax"))


### PR DESCRIPTION
softmax 准确度log：

```
---- Initialize APIConfig from /home/gaowei/tests/benchmark/api/tests_v2/configs/softmax.json, config_id = 0.

{"name": "softmax", "device": "GPU", "backward": true, "consistent": true, "num_outputs": 2, "diff": 5.654449131142769e-10, "parameters": "x (Variable) - dtype: float32, shape: [16, 1000]\naxis (int): -1\n"}
```