### PR TITLE
Enhance the testing framework in dynamic mode

### DIFF
--- a/api/common/main.py
+++ b/api/common/main.py
@@ -261,7 +261,7 @@ def test_main_without_json(pd_obj=None,
         torch_config = config.to_pytorch()
         print(torch_config)
         torch_outputs, torch_stats = torch_obj.run(torch_config, args)
-        feeder_adapter = torch_obj.get_feeder()
+        feeder_adapter = torch_obj.generate_random_feeder(torch_config)
 
         if args.task == "speed":
             torch_stats["gpu_time"] = args.gpu_time

--- a/api/common/paddle_dynamic_api_benchmark.py
+++ b/api/common/paddle_dynamic_api_benchmark.py
@@ -167,8 +167,8 @@ class PaddleDynamicAPIBenchmarkBase(object):
         self._reset()
         self._feed_spec = feeder.copy_feed_spec(config.feed_spec)
         self._need_fetch = args.task == "accuracy"
-        # feeder_adapter is a list and need to be improved.
-        self._feed_values = feeder_adapter
+        if feeder_adapter:
+            self._feed_values = feeder_adapter.to_paddle()
         outputs, stats = self.run_impl(
             use_gpu=args.use_gpu,
             config=config,

--- a/api/common/paddle_dynamic_api_benchmark.py
+++ b/api/common/paddle_dynamic_api_benchmark.py
@@ -75,10 +75,7 @@ class PaddleDynamicAPIBenchmarkBase(object):
 
     @property
     def backward(self):
-        if hasattr(self, "_PaddleDynamicAPIBenchmarkBase__backward"):
-            return self._backward
-        else:
-            return False
+        return self._backward
 
     def layers(self, api_name, module_name=None, **kwargs):
         def _import_func(paddle_module_name, api_name):
@@ -110,11 +107,13 @@ class PaddleDynamicAPIBenchmarkBase(object):
         return result
 
     def append_gradients(self, targets, inputs):
+        gradients = paddle.grad(outputs=targets, inputs=inputs)
         self._backward = True
-        loss = paddle.sum(targets)
-        loss.backward()
-        for var in inputs:
-            self.fetch_list.append(var.grad)
+        if isinstance(gradients, list):
+            for grad in gradients:
+                self.fetch_list.append(grad)
+        else:
+            self.fetch_list.append(gradients)
 
     def run_impl(self,
                  use_gpu,

--- a/api/common/pytorch_api_benchmark.py
+++ b/api/common/pytorch_api_benchmark.py
@@ -76,7 +76,7 @@ class PytorchAPIBenchmarkBase(object):
             self._feed_dict[name] = var
 
             if value is None:
-                self._feed_list.append(feed_value)
+                self._generated_feed_values.append(feed_value)
         else:
             var = self._feed_dict[name]
         return var
@@ -112,8 +112,9 @@ class PytorchAPIBenchmarkBase(object):
         result = self._layers_function(**kwargs)
         return result
 
-    def get_feeder(self):
-        return self._feed_list
+    def generate_random_feeder(self, config):
+        return feeder.FeederAdapter("pytorch", config.feed_spec,
+                                    self._generated_feed_values)
 
     def append_gradients(self, targets, inputs):
         if not isinstance(inputs, list):
@@ -194,8 +195,8 @@ class PytorchAPIBenchmarkBase(object):
         self.feed_list = None
         self.fetch_list = None
         self._feed_spec = None
-        self._feed_list = []
+        self._generated_feed_values = []
+        self._feed_dict = {}
         self._backward = False
         self._status = BEFORE_RUN
-        self._feed_dict = {}
         self._layers_function = None

--- a/api/dynamic_tests_v2/linear.py
+++ b/api/dynamic_tests_v2/linear.py
@@ -1,0 +1,78 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class LinearConfig(APIConfig):
+    def __init__(self):
+        super(LinearConfig, self).__init__('linear')
+        self.feed_spec = [
+            {
+                "range": [-1, 1]
+            },  # x
+            {
+                "range": [-1, 1],
+                "permute": [1, 0]
+            },  # weight
+            {
+                "range": [-1, 1]
+            }  # bias
+        ]
+
+    def to_pytorch(self):
+        torch_config = super(LinearConfig, self).to_pytorch()
+        torch_config.weight_shape = [
+            self.weight_shape[1], self.weight_shape[0]
+        ]
+        return torch_config
+
+
+class PDLinear(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name="weight",
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+        bias = self.variable(
+            name="bias", shape=config.bias_shape, dtype=config.bias_dtype)
+        result = paddle.nn.functional.linear(x=x, weight=weight, bias=bias)
+
+        self.feed_list = [x, weight, bias]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight, bias])
+
+
+class TorchLinear(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name="weight",
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+        bias = self.variable(
+            name="bias", shape=config.bias_shape, dtype=config.bias_dtype)
+        result = torch.nn.functional.linear(input=x, weight=weight, bias=bias)
+
+        self.feed_list = [x, weight, bias]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight, bias])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDLinear(), torch_obj=TorchLinear(), config=LinearConfig())

--- a/api/dynamic_tests_v2/matmul.py
+++ b/api/dynamic_tests_v2/matmul.py
@@ -1,0 +1,54 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class MatmulConfig(APIConfig):
+    def __init__(self):
+        super(MatmulConfig, self).__init__("matmul")
+        self.feed_spec = [{"range": [-1, 1]}, {"range": [-1, 1]}]
+
+
+class PDMatmul(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
+        result = paddle.matmul(
+            x=x,
+            y=y,
+            transpose_x=config.transpose_x,
+            transpose_y=config.transpose_y)
+
+        self.feed_list = [x, y]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, y])
+
+
+class TorchMatmul(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
+        result = torch.matmul(input=x, other=y)
+
+        self.feed_list = [x, y]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, y])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDMatmul(), torch_obj=TorchMatmul(), config=MatmulConfig())

--- a/api/tests/configs/layer_norm.json
+++ b/api/tests/configs/layer_norm.json
@@ -1,10 +1,6 @@
 [{
     "op": "layer_norm",
     "param_info": {
-        "act": {
-            "type": "string",
-            "value": "None"
-        },
         "begin_norm_axis": {
             "type": "int",
             "value": "2"
@@ -15,7 +11,7 @@
         },
         "input": {
             "dtype": "float32",
-            "shape": "[-1L, -1L, 768L]",
+            "shape": "[-1L, 128L, 768L]",
             "type": "Variable"
         },
         "scale": {

--- a/api/tests/layer_norm.py
+++ b/api/tests/layer_norm.py
@@ -31,7 +31,7 @@ class PDLayerNorm(PaddleAPIBenchmarkBase):
             shift=config.shift,
             begin_norm_axis=config.begin_norm_axis,
             epsilon=config.epsilon,
-            act=config.act)
+            act=None)
 
         self.feed_vars = [data]
         self.fetch_vars = [result]

--- a/api/tests_v2/configs/layer_norm.json
+++ b/api/tests_v2/configs/layer_norm.json
@@ -11,5 +11,5 @@
             "type": "Variable"
         }
     },
-    "atol": 1e-4
+    "atol": 1e-5
 }]


### PR DESCRIPTION
- 优化反向测试，以abs为例
    - paddle当前实现的nvprof
    ```
                Type  Time(%)      Time     Calls       Avg       Min       Max  Name
     GPU activities:   82.68%  1.44750s        11  131.59ms  126.28ms  172.14ms  [CUDA memcpy DtoH]
                       13.19%  230.89ms         8  28.862ms  1.7280us  230.88ms  [CUDA memcpy HtoD]
                        1.29%  22.601ms        11  2.0546ms  2.0273ms  2.0763ms  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float const , float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const , Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_sign_op<float const , bool=0>, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const > const , Eigen::GpuDevice>, int>(float, int=1)
                        1.12%  19.530ms        10  1.9530ms  1.9499ms  1.9559ms  void axpy_kernel_val<float, float>(cublasAxpyParamsVal<float, float, float>)
                        0.87%  15.275ms        11  1.3886ms  1.3818ms  1.3959ms  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_abs_op<float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, int>(float, int=1)
                        0.46%  8.0159ms        11  728.71us  719.74us  734.24us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorBroadcastingOp<Eigen::array<int, unsigned long=1> const , Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                        0.39%  6.7897ms        11  617.24us  615.45us  618.72us  void cub::DeviceReduceKernel<cub::DeviceReducePolicy<float, int, cub::Sum>::Policy600, cub::TransformInputIterator<float, paddle::operators::IdentityFunctor<float>, float const *, long>, float*, int, cub::Sum>(int, cub::Sum, cub::DeviceReducePolicy<float, int, cub::Sum>::Policy600, cub::GridEvenShare<cub::Sum>, float)
                        0.00%  35.296us        11  3.2080us  2.9440us  4.5120us  void cub::DeviceReduceSingleTileKernel<cub::DeviceReducePolicy<float, int, cub::Sum>::Policy600, float*, float*, int, cub::Sum, float>(int, cub::Sum, cub::DeviceReducePolicy<float, int, cub::Sum>::Policy600, float*, float*)
                        0.00%  14.304us        11  1.3000us  1.1520us  1.8880us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                        0.00%  6.8160us         4  1.7040us  1.6000us  1.9520us  [CUDA memset]
    ```

    - 该PR优化后paddle的nvprof
    ```
                Type  Time(%)      Time     Calls       Avg       Min       Max  Name
     GPU activities:   80.44%  187.49ms         8  23.436ms  1.7280us  187.47ms  [CUDA memcpy HtoD]
                        9.72%  22.647ms        11  2.0588ms  2.0272ms  2.0773ms  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float const , float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const , Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_sign_op<float const , bool=0>, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const > const , Eigen::GpuDevice>, int>(float, int=1)
                        6.56%  15.297ms        11  1.3907ms  1.3866ms  1.3945ms  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_abs_op<float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, int>(float, int=1)
                        3.27%  7.6262ms        11  693.29us  689.15us  698.53us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                        0.00%  7.0720us         4  1.7680us  1.5680us  1.9840us  [CUDA memset]
    ```

     - pytorch当前的nvprof
    ```
                 Type  Time(%)      Time     Calls       Avg       Min       Max  Name
     GPU activities:   75.66%  215.23ms         1  215.23ms  215.23ms  215.23ms  [CUDA memcpy HtoD]
                        6.69%  19.040ms        10  1.9040ms  1.9035ms  1.9044ms  void at::native::vectorized_elementwise_kernel<int=4, at::native::AddFunctor<float>, at::detail::Array<char*, int=3>>(int, float, at::native::AddFunctor<float>)
                        5.09%  14.477ms        11  1.3161ms  1.3146ms  1.3200ms  void at::native::unrolled_elementwise_kernel<at::native::MulFunctor<float>, at::detail::Array<char*, int=3>, OffsetCalculator<int=2, unsigned int>, OffsetCalculator<int=1, unsigned int>, at::native::memory::LoadWithoutCast, at::native::memory::StoreWithoutCast>(int, float, at::native::MulFunctor<float>, char*, int=3, at::detail::Array<char*, int=3>, int=2)
                        5.07%  14.414ms        11  1.3104ms  1.3090ms  1.3158ms  void at::native::vectorized_elementwise_kernel<int=4, at::native::AbsFunctor<float>, at::detail::Array<char*, int=2>>(int, float, at::native::AbsFunctor<float>)
                        5.06%  14.383ms        11  1.3076ms  1.3071ms  1.3089ms  _ZN2at6native29vectorized_elementwise_kernelILi4EZZZNS0_16sign_kernel_cudaERNS_14TensorIteratorEENKUlvE_clEvENKUlvE2_clEvEUlfE_NS_6detail5ArrayIPcLi2EEEEEviT0_T1_
                        2.43%  6.9088ms        11  628.08us  626.72us  629.66us  _ZN2at6native13reduce_kernelILi512ELi1ENS0_8ReduceOpIfNS0_14func_wrapper_tIfZNS0_11sum_functorIfffEclERNS_14TensorIteratorEEUlffE_EEjfLi4EEEEEvT1_
                        0.01%  20.832us        11  1.8930us  1.6960us  2.4320us  [CUDA memset]
                        0.01%  14.912us        11  1.3550us  1.3120us  1.7600us  void at::native::vectorized_elementwise_kernel<int=4, at::native::FillFunctor<float>, at::detail::Array<char*, int=1>>(int, float, at::native::FillFunctor<float>)
    ```

    - 优化后pytorch的nvprof
    ```
                Type  Time(%)      Time     Calls       Avg       Min       Max  Name
     GPU activities:   63.54%  103.35ms         1  103.35ms  103.35ms  103.35ms  [CUDA memcpy HtoD]
                       12.88%  20.945ms        11  1.9041ms  1.9032ms  1.9049ms  void at::native::vectorized_elementwise_kernel<int=4, at::native::MulFunctor<float>, at::detail::Array<char*, int=3>>(int, float, at::native::MulFunctor<float>)
                        8.87%  14.420ms        11  1.3109ms  1.3102ms  1.3120ms  _ZN2at6native29vectorized_elementwise_kernelILi4EZZZNS0_16sign_kernel_cudaERNS_14TensorIteratorEENKUlvE_clEvENKUlvE2_clEvEUlfE_NS_6detail5ArrayIPcLi2EEEEEviT0_T1_
                        8.86%  14.414ms        11  1.3104ms  1.3093ms  1.3148ms  void at::native::vectorized_elementwise_kernel<int=4, at::native::AbsFunctor<float>, at::detail::Array<char*, int=2>>(int, float, at::native::AbsFunctor<float>)
                        5.86%  9.5285ms        11  866.23us  865.95us  867.84us  void at::native::vectorized_elementwise_kernel<int=4, at::native::FillFunctor<float>, at::detail::Array<char*, int=1>>(int, float, at::native::FillFunctor<float>)
    ```

- 强化feeder设置，支持输入数据的permute（linear中用到）
- 添加几个测试脚本：linear、matmul

**待解决问题：**

- 反向测试时，paddle和pytorch都会有个fill_constant op，pytorch可以消除，但是paddle还没找到合适的方法。
- pytorch反向测试，当前的方案不支持target是一个list的情况。