### PR TITLE
Polish the script to run and summary all tests and add gelu, transpose.

### DIFF
--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -89,7 +89,12 @@ fi
 
 if [ $# -ge 7 ]; then
     OP_LIST_FILE=${7}
-else
+    if [ ! -f "${OP_LIST_FILE}" ]; then
+        echo "The specified OP_LIST_FILE (${OP_LIST_FILE}) does not exist in the filesystem!"
+        unset OP_LIST_FILE
+    fi
+fi
+if [ "${OP_LIST_FILE}" == "" ]; then
     OP_LIST_FILE=${OUTPUT_DIR}/api_info.txt
     python ${DEPLOY_DIR}/collect_api_info.py \
         --test_module_name ${TEST_MODULE_NAME} \

--- a/api/deploy/summary.py
+++ b/api/deploy/summary.py
@@ -431,6 +431,10 @@ if __name__ == '__main__':
         default=True,
         help='Whether constructing alarm email [True|False]')
     args = parser.parse_args()
+    if args.compare_framework not in ["tensorflow", "pytorch"]:
+        raise ValueError(
+            "The framework must be tensorflow or pytorch, but the framework is %s."
+            % args.compare_framework)
 
     op_result_dir = os.path.abspath(args.op_result_dir)
     assert os.path.exists(
@@ -475,11 +479,6 @@ if __name__ == '__main__':
                              args.dump_with_parameters)
 
     if args.dump_to_excel:
-        if args.compare_framework not in ["tensorflow", "pytorch"]:
-            raise ValueError(
-                "The framework must be tensorflow or pytorch, but the framework is %s."
-                % args.compare_framework)
-
         import write_excel
 
         write_excel.dump_excel(benchmark_result_list, op_result_dir,

--- a/api/deploy/write_excel.py
+++ b/api/deploy/write_excel.py
@@ -129,11 +129,6 @@ def dump_excel(benchmark_result_list,
         output_path = "op_benchmark_summary-%s.xlsx" % timestamp
         print("Output path is not specified, use %s." % output_path)
 
-    if compare_framework not in ["paddle", "tensorflow", "pytorch"]:
-        raise ValueError(
-            "The framework must be one of paddle, tensorflow, pytorch, but framework is %s."
-            % compare_framework)
-
     wb = xlw.Workbook(output_path)
     align = wb.add_format({"align": "left"})
     title_format = wb.add_format({

--- a/api/dynamic_tests_v2/common_import.py
+++ b/api/dynamic_tests_v2/common_import.py
@@ -28,9 +28,7 @@ except ImportError:
 package_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(package_path)
 
-from common.paddle_api_benchmark import PaddleAPIBenchmarkBase
 from common.paddle_dynamic_api_benchmark import PaddleDynamicAPIBenchmarkBase
-from common.tensorflow_api_benchmark import TensorflowAPIBenchmarkBase
 from common.pytorch_api_benchmark import PytorchAPIBenchmarkBase
 from common.api_param import APIConfig
 from common.main import test_main, test_main_without_json
@@ -46,12 +44,24 @@ def unsqueeze_short(short, long):
     For example: short is [16, 2048] and long is [16, 2048, 7, 7],
     it will return [16, 2048, 1, 1].
     """
-    short_extend = np.ones([len(long)], dtype=np.int32).tolist()
+    # Extend short with 0s.
+    short_extend_zeros = np.zeros([len(long)], dtype=np.int32).tolist()
     start = 0
     for value in short:
         for i in range(start, len(long)):
             if long[i] == value:
-                short_extend[i] = value
+                short_extend_zeros[i] = value
                 start = i
                 break
+    # Remove the 0s on the front and change 0s on the middle to 1s, [0, M, 0, N] -> [M, 1, N]
+    short_extend = []
+    first_nonzero_idx = -1
+    for i in range(len(short_extend_zeros)):
+        if first_nonzero_idx == -1 and short_extend_zeros[i] != 0:
+            first_nonzero_idx = i
+        if first_nonzero_idx > -1:
+            if short_extend_zeros[i] == 0:
+                short_extend.append(1)
+            else:
+                short_extend.append(short_extend_zeros[i])
     return short_extend

--- a/api/dynamic_tests_v2/cross_entropy.py
+++ b/api/dynamic_tests_v2/cross_entropy.py
@@ -1,0 +1,85 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class CrossEntropyConfig(APIConfig):
+    def __init__(self):
+        super(CrossEntropyConfig, self).__init__("cross_entropy")
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(CrossEntropyConfig, self).init_from_json(filename, config_id,
+                                                       unknown_dim)
+        input_rank = len(self.input_shape)
+        self.num_classes = self.input_shape[input_rank - 1]
+        self.feed_spec = [
+            {
+                "range": [0, 1]
+            },  # input
+            {
+                "range": [0, self.num_classes]
+            }  # label
+        ]
+
+
+class PDCrossEntropy(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        input = self.variable(
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
+        label = self.variable(
+            name="label",
+            shape=config.label_shape,
+            dtype=config.label_dtype,
+            stop_gradient=True)
+        result = paddle.nn.functional.cross_entropy(
+            input=input,
+            label=label,
+            weight=None,
+            ignore_index=config.ignore_index,
+            reduction=config.reduction,
+            soft_label=config.soft_label,
+            axis=config.axis)
+
+        self.feed_list = [input, label]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [input])
+
+
+class TorchCrossEntropy(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        input = self.variable(
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
+        label = self.variable(
+            name='label', shape=config.label_shape, dtype=config.label_dtype)
+        result = torch.nn.functional.cross_entropy(
+            input=input,
+            target=label,
+            weight=None,
+            size_average=None,
+            ignore_index=config.ignore_index,
+            reduction=config.reduction)
+
+        self.feed_list = [input, label]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [input])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDCrossEntropy(),
+        torch_obj=TorchCrossEntropy(),
+        config=CrossEntropyConfig())

--- a/api/dynamic_tests_v2/gelu.py
+++ b/api/dynamic_tests_v2/gelu.py
@@ -1,0 +1,47 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class GeluConfig(APIConfig):
+    def __init__(self):
+        super(GeluConfig, self).__init__("gelu")
+        self.feed_spec = {"range": [-1, 1]}
+
+
+class PDGelu(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.nn.functional.gelu(x=x, approximate=config.approximate)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchGelu(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.gelu(input=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(pd_dy_obj=PDGelu(), torch_obj=TorchGelu(), config=GeluConfig())

--- a/api/dynamic_tests_v2/ones_like.py
+++ b/api/dynamic_tests_v2/ones_like.py
@@ -1,0 +1,40 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDOnesLike(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.ones_like(x=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+class TorchOnesLike(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.ones_like(input=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDOnesLike(),
+        torch_obj=TorchOnesLike(),
+        config=APIConfig("ones_like"))

--- a/api/dynamic_tests_v2/transpose.py
+++ b/api/dynamic_tests_v2/transpose.py
@@ -1,0 +1,67 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class TransposeConfig(APIConfig):
+    def __init__(self):
+        super(TransposeConfig, self).__init__("transpose")
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(TransposeConfig, self).init_from_json(filename, config_id,
+                                                    unknown_dim)
+        changed_dims = []
+        for i in range(len(self.perm)):
+            if self.perm[i] != i:
+                changed_dims.append(i)
+
+        if len(changed_dims) != 2:
+            print(
+                "Warning:\n"
+                "  1. transpose is only supported to swap two dimensions in pytorch.\n"
+            )
+            self.run_torch = False
+        else:
+            self.dim0 = changed_dims[0]
+            self.dim1 = changed_dims[1]
+
+
+class PDTranspose(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.transpose(x, config.perm)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchTranspose(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.transpose(input=x, dim0=config.dim0, dim1=config.dim1)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDTranspose(),
+        torch_obj=TorchTranspose(),
+        config=TransposeConfig())

--- a/api/run_op_benchmark.sh
+++ b/api/run_op_benchmark.sh
@@ -2,27 +2,37 @@
 
 OP_BENCHMARK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")" && pwd )"
 
-test_module_name=${1:-"tests"}
+test_module_name=${1:-"tests"}  # "tests", "tests_v2", "dynamic_tests_v2"
 gpu_ids=${2:-"0"}
 
-timestamp=`date '+%Y%m%d-%H%M%S'`
-if [ ${test_module_name} = "tests" ]; then
-    log_dir_name="logs"
-elif [ ${test_module_name} = "tests_v2" ]; then
-    log_dir_name="logs_v2"
-else
-    echo "Please set test_module_name to \"tests\" or \"tests_v2\""
+if [ ${test_module_name} != "tests" ] && [ ${test_module_name} != "tests_v2" ] && [ ${test_module_name} != "dynamic_tests_v2" ]; then
+    echo "Please set test_module_name to \"tests\", \"tests_v2\" or \"dynamic_tests_v2\"!"
     exit
 fi
-output_dir=${OP_BENCHMARK_ROOT}/${log_dir_name}/${timestamp}
-if [ ! -d ${OP_BENCHMARK_ROOT}/${log_dir_name} ]; then
-    mkdir -p ${OP_BENCHMARK_ROOT}/${log_dir_name}
+
+OUTPUT_ROOT=${OP_BENCHMARK_ROOT}/logs
+if [ ! -d ${OUTPUT_ROOT} ]; then
+    mkdir -p ${OUTPUT_ROOT}
 fi
+
+timestamp=`date '+%Y%m%d-%H%M%S'`
+output_dir=${OUTPUT_ROOT}/${test_module_name}/${timestamp}
 if [ ! -d ${output_dir} ]; then
     mkdir -p ${output_dir}
 fi
 
+if [ ${test_module_name} = "tests" ]; then
+    config_dir=${OP_BENCHMARK_ROOT}/tests/configs
+else
+    config_dir=${OP_BENCHMARK_ROOT}/tests_v2/configs
+fi
+
+if [ "${test_module_name}" == "dynamic_tests_v2" ]; then
+    testing_mode="dynamic"
+else
+    testing_mode="static"
+fi
+
 tests_dir=${OP_BENCHMARK_ROOT}/${test_module_name}
-config_dir=${OP_BENCHMARK_ROOT}/${test_module_name}/configs
-log_path=${OP_BENCHMARK_ROOT}/${log_dir_name}/log_${timestamp}.txt
-bash ${OP_BENCHMARK_ROOT}/deploy/main_control.sh ${tests_dir} ${config_dir} ${output_dir} ${gpu_ids} "both" "both" > ${log_path} 2>&1 &
+log_path=${OUTPUT_ROOT}/log_${test_module_name}_${timestamp}.txt
+bash ${OP_BENCHMARK_ROOT}/deploy/main_control.sh ${tests_dir} ${config_dir} ${output_dir} ${gpu_ids} "both" "both" "none" "both" "${testing_mode}" > ${log_path} 2>&1 &

--- a/api/tests_v2/bert_base/cross_entropy.json
+++ b/api/tests_v2/bert_base/cross_entropy.json
@@ -1,0 +1,31 @@
+[{
+    "op": "cross_entropy",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "ignore_index": {
+            "type": "int",
+            "value": "-100"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 30522L]",
+            "type": "Variable"
+        },
+        "label": {
+            "dtype": "int64",
+            "shape": "[32L, 128L, 1L]",
+            "type": "Variable"
+        },
+        "reduction": {
+            "type": "string",
+            "value": "none"
+        },
+        "soft_label": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}]

--- a/api/tests_v2/bert_base/dropout.json
+++ b/api/tests_v2/bert_base/dropout.json
@@ -1,0 +1,133 @@
+[{
+    "config_id": 0,
+    "op": "dropout",
+    "param_info": {
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "config_id": 1,
+    "op": "dropout",
+    "param_info": {
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "config_id": 2,
+    "op": "dropout",
+    "param_info": {
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 12L, 128L, 128L]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "config_id": 3,
+    "op": "dropout",
+    "param_info": {
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 12L, 128L, 128L]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "config_id": 4,
+    "op": "dropout",
+    "param_info": {
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "config_id": 5,
+    "op": "dropout",
+    "param_info": {
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}]

--- a/api/tests_v2/bert_base/elementwise.json
+++ b/api/tests_v2/bert_base/elementwise.json
@@ -1,0 +1,267 @@
+[{
+    "config_id": "0",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "1",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "2",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "3",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "4",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 12L, 128L, 128L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[32L, 1L, 1L, 128L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "5",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 12L, 128L, 128L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[32L, 1L, 1L, 128L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "6",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "7",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "8",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "9",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "10",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 2L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[2L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "11",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 2L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[2L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "12",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 30522L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[30522L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": "13",
+    "op": "elementwise",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 30522L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[30522L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/bert_base/gelu.json
+++ b/api/tests_v2/bert_base/gelu.json
@@ -1,0 +1,53 @@
+[{
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/bert_base/layer_norm.json
+++ b/api/tests_v2/bert_base/layer_norm.json
@@ -1,0 +1,27 @@
+[{
+    "op": "layer_norm",
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "layer_norm",
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/bert_base/linear.json
+++ b/api/tests_v2/bert_base/linear.json
@@ -1,0 +1,121 @@
+[{
+    "config_id": 0,
+    "op": "linear",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "weight": {
+            "dtype": "float32",
+            "shape": "[768L, 768L]",
+            "type": "Variable"
+        },
+        "bias": {
+            "dtype": "float32",
+            "shape": "[768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 1,
+    "op": "linear",
+    "param_info": {
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "weight": {
+            "dtype": "float16",
+            "shape": "[768L, 768L]",
+            "type": "Variable"
+        },
+        "bias": {
+            "dtype": "float16",
+            "shape": "[768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 2,
+    "op": "linear",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "weight": {
+            "dtype": "float32",
+            "shape": "[768L, 3072L]",
+            "type": "Variable"
+        },
+        "bias": {
+            "dtype": "float32",
+            "shape": "[3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 3,
+    "op": "linear",
+    "param_info": {
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "weight": {
+            "dtype": "float16",
+            "shape": "[768L, 3072L]",
+            "type": "Variable"
+        },
+        "bias": {
+            "dtype": "float16",
+            "shape": "[3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 4,
+    "op": "linear",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        },
+        "weight": {
+            "dtype": "float32",
+            "shape": "[3072L, 768L]",
+            "type": "Variable"
+        },
+        "bias": {
+            "dtype": "float32",
+            "shape": "[768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 5,
+    "op": "linear",
+    "param_info": {
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        },
+        "weight": {
+            "dtype": "float16",
+            "shape": "[3072L, 768L]",
+            "type": "Variable"
+        },
+        "bias": {
+            "dtype": "float16",
+            "shape": "[768L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/bert_base/matmul.json
+++ b/api/tests_v2/bert_base/matmul.json
@@ -1,0 +1,369 @@
+[{
+    "config_id": 0,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[768L, 768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 1,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[768L, 768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 2,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "True"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 12L, 128L, 64L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[32L, 12L, 128L, 64L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 3,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "True"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 12L, 128L, 64L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[32L, 12L, 128L, 64L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 4,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 12L, 128L, 128L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[32L, 12L, 128L, 64L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 5,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 12L, 128L, 128L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[32L, 12L, 128L, 64L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 6,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[768L, 3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 7,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[768L, 3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 8,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[3072L, 768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 9,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[3072L, 768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 10,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[768L, 768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 11,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[768L, 768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 12,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[768L, 2L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 13,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[768L, 2L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 14,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "True"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[30522L, 768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 15,
+    "op": "matmul",
+    "param_info": {
+        "transpose_x": {
+            "type": "bool",
+            "value": "False"
+        },
+        "transpose_y": {
+            "type": "bool",
+            "value": "True"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float16",
+            "shape": "[30522L, 768L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/bert_base/ones_like.json
+++ b/api/tests_v2/bert_base/ones_like.json
@@ -1,0 +1,89 @@
+[{
+    "config_id": 0,
+    "op": "ones_like",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 10000
+}, {
+    "config_id": 1,
+    "op": "ones_like",
+    "param_info": {
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 10000
+}, {
+    "config_id": 2,
+    "op": "ones_like",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 12L, 128L, 128L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 10000
+}, {
+    "config_id": 3,
+    "op": "ones_like",
+    "param_info": {
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 12L, 128L, 128L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 10000
+}, {
+    "config_id": 4,
+    "op": "ones_like",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 10000
+}, {
+    "config_id": 5,
+    "op": "ones_like",
+    "param_info": {
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 3072L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 10000
+}, {
+    "config_id": 6,
+    "op": "ones_like",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 30522L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 10000
+}, {
+    "config_id": 7,
+    "op": "ones_like",
+    "param_info": {
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 30522L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 10000
+}]

--- a/api/tests_v2/bert_base/softmax.json
+++ b/api/tests_v2/bert_base/softmax.json
@@ -1,0 +1,27 @@
+[{
+    "op": "softmax",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 12L, 128L, 128L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "softmax",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 12L, 128L, 128L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/bert_base/transpose.json
+++ b/api/tests_v2/bert_base/transpose.json
@@ -1,0 +1,53 @@
+[{
+    "op": "transpose",
+    "param_info": {
+        "perm": {
+            "type": "list",
+            "value": "[0, 2, 1, 3]"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 128L, 12L, 64L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "transpose",
+    "param_info": {
+        "perm": {
+            "type": "list",
+            "value": "[0, 2, 1, 3]"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 12L, 64L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "transpose",
+    "param_info": {
+        "perm": {
+            "type": "list",
+            "value": "[0, 2, 1, 3]"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32L, 12L, 128L, 64L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "transpose",
+    "param_info": {
+        "perm": {
+            "type": "list",
+            "value": "[0, 2, 1, 3]"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 12L, 128L, 64L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/common_import.py
+++ b/api/tests_v2/common_import.py
@@ -47,12 +47,24 @@ def unsqueeze_short(short, long):
     For example: short is [16, 2048] and long is [16, 2048, 7, 7],
     it will return [16, 2048, 1, 1].
     """
-    short_extend = np.ones([len(long)], dtype=np.int32).tolist()
+    # Extend short with 0s.
+    short_extend_zeros = np.zeros([len(long)], dtype=np.int32).tolist()
     start = 0
     for value in short:
         for i in range(start, len(long)):
             if long[i] == value:
-                short_extend[i] = value
+                short_extend_zeros[i] = value
                 start = i
                 break
+    # Remove the 0s on the front and change 0s on the middle to 1s, [0, M, 0, N] -> [M, 1, N]
+    short_extend = []
+    first_nonzero_idx = -1
+    for i in range(len(short_extend_zeros)):
+        if first_nonzero_idx == -1 and short_extend_zeros[i] != 0:
+            first_nonzero_idx = i
+        if first_nonzero_idx > -1:
+            if short_extend_zeros[i] == 0:
+                short_extend.append(1)
+            else:
+                short_extend.append(short_extend_zeros[i])
     return short_extend


### PR DESCRIPTION
- 2.0的elementwise API不支持设置axis，原op测试脚本中会先对短的shape进行unsqueeze。比如X是[M, N]、Y是[N]时，Y会被unsqueeze成[1, N]。这两种配置下，paddle会选择不同的kernel来执行，且Y是[1, N]比[N]慢一倍。这个PR修改了unsqueeze_short逻辑，在这种情况下避免对Y进行unsqueeze。
- 补充bert模型里面的gelu、transpose测试脚本。
- 新增cross_entropy的测试脚本，但是目前还不能正确地运行。
- 上传bert-base中的op配置，方便大家测试。