### PR TITLE
Remove the fill_constant in backward test.

### DIFF
--- a/api/common/paddle_dynamic_api_benchmark.py
+++ b/api/common/paddle_dynamic_api_benchmark.py
@@ -124,9 +124,6 @@ class PaddleDynamicAPIBenchmarkBase(object):
         else:
             self.fetch_list.append(gradients)
 
-        self._backward_targets = targets
-        self._backward_inputs = inputs
-
     def run_impl(self,
                  use_gpu,
                  config,
@@ -201,5 +198,3 @@ class PaddleDynamicAPIBenchmarkBase(object):
         self._feed_dict = {}
         self._layers_function = None
         self._ones_like_targets = []
-        self._backward_targets = None
-        self._backward_inputs = None

--- a/api/common/pytorch_api_benchmark.py
+++ b/api/common/pytorch_api_benchmark.py
@@ -123,7 +123,11 @@ class PytorchAPIBenchmarkBase(object):
             var.grad = None
 
         if not isinstance(targets, list):
-            ones_like_targets = torch.ones_like(targets)
+            if len(self._ones_like_targets) == 0:
+                ones_like_targets = torch.ones_like(targets)
+                self._ones_like_targets.append(ones_like_targets)
+            else:
+                ones_like_targets = self._ones_like_targets[0]
             targets.backward(gradient=ones_like_targets)
             targets.retain_grad()
             self._backward = True
@@ -132,6 +136,9 @@ class PytorchAPIBenchmarkBase(object):
             assert False, "Gradients of list is not supported now!"
         for var in inputs:
             self.fetch_list.append(var.grad)
+
+        self._backward_targets = targets
+        self._backward_inputs = inputs
 
     def run_impl(self,
                  use_gpu,
@@ -200,3 +207,6 @@ class PytorchAPIBenchmarkBase(object):
         self._backward = False
         self._status = BEFORE_RUN
         self._layers_function = None
+        self._ones_like_targets = []
+        self._backward_targets = None
+        self._backward_inputs = None

--- a/api/common/pytorch_api_benchmark.py
+++ b/api/common/pytorch_api_benchmark.py
@@ -137,9 +137,6 @@ class PytorchAPIBenchmarkBase(object):
         for var in inputs:
             self.fetch_list.append(var.grad)
 
-        self._backward_targets = targets
-        self._backward_inputs = inputs
-
     def run_impl(self,
                  use_gpu,
                  config,
@@ -208,5 +205,3 @@ class PytorchAPIBenchmarkBase(object):
         self._status = BEFORE_RUN
         self._layers_function = None
         self._ones_like_targets = []
-        self._backward_targets = None
-        self._backward_inputs = None


### PR DESCRIPTION
移除动态图op反向性能测试，组网中的fill_constant操作。

- 优化后pytorch的nvprof如下
```
run command: nvprof /work/.virtualenvs_cuda10.1/paddle_py37/bin/python /work/benchmark/api/dynamic_tests_v2/abs.py --task speed --framework pytorch --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/abs.json --config_id 0 --check_output False --profiler none --backward True --use_gpu True --repeat 10 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   82.33%  235.89ms         1  235.89ms  235.89ms  235.89ms  [CUDA memcpy HtoD]
                    7.31%  20.945ms        11  1.9041ms  1.9034ms  1.9051ms  void at::native::vectorized_elementwise_kernel<int=4, at::native::MulFunctor<float>, at::detail::Array<char*, int=3>>(int, float, at::native::MulFunctor<float>)
                    5.03%  14.418ms        11  1.3108ms  1.3102ms  1.3126ms  _ZN2at6native29vectorized_elementwise_kernelILi4EZZZNS0_16sign_kernel_cudaERNS_14TensorIteratorEENKUlvE_clEvENKUlvE2_clEvEUlfE_NS_6detail5ArrayIPcLi2EEEEEviT0_T1_
                    5.03%  14.413ms        11  1.3102ms  1.3093ms  1.3151ms  void at::native::vectorized_elementwise_kernel<int=4, at::native::AbsFunctor<float>, at::detail::Array<char*, int=2>>(int, float, at::native::AbsFunctor<float>)
                    0.30%  867.68us         1  867.68us  867.68us  867.68us  void at::native::vectorized_elementwise_kernel<int=4, at::native::FillFunctor<float>, at::detail::Array<char*, int=1>>(int, float, at::native::FillFunctor<float>)
```

- 优化后paddle的nvprof如下：
```
run command: nvprof /work/.virtualenvs_cuda10.1/paddle_py37/bin/python /work/benchmark/api/dynamic_tests_v2/abs.py --task speed --framework paddle --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/abs.json --config_id 0 --check_output False --profiler none --backward True --use_gpu True --repeat 10 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   93.80%  586.18ms         8  73.272ms  1.7280us  586.17ms  [CUDA memcpy HtoD]
                    3.64%  22.722ms        11  2.0657ms  2.0364ms  2.1030ms  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float const , float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const , Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_sign_op<float const , bool=0>, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const > const , Eigen::GpuDevice>, int>(float, int=1)
                    2.45%  15.298ms        11  1.3908ms  1.3802ms  1.3976ms  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, int>, int=16, Eigen::MakePointer>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_abs_op<float const >, Eigen::TensorMap<Eigen::Tensor<float const , int=1, int=1, int>, int=16, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, int>(float, int=1)
                    0.11%  687.35us         1  687.35us  687.35us  687.35us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                    0.00%  6.8160us         4  1.7040us  1.6000us  1.9840us  [CUDA memset]
```

TODO：

- 像split这样，目标是多个tensor的，反向计算还需要验证。