### PR TITLE
add dropout config

### DIFF
--- a/api/tests_v2/configs/dropout.json
+++ b/api/tests_v2/configs/dropout.json
@@ -77,7 +77,28 @@
         },
         "x": {
             "dtype": "float32",
-            "shape": "[-1L, 16L, -1L, -1L]",
+            "shape": "[32L, 128L, 768L]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        }
+    }
+}, {
+    "op": "dropout",
+    "param_info": {
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[32L, 128L, 768L]",
             "type": "Variable"
         },
         "axis": {


### PR DESCRIPTION
添加一组bert中的dropout配置[32, 128, 768]
- FP32
```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   51.97%  38.688ms      1001  38.649us  37.664us  44.191us  void paddle::operators::VectorizedRandomGenerator<float, unsigned char, int=4>(unsigned long, unsigned long, float, float const *, unsigned char*, paddle::operators::VectorizedRandomGenerator<float, unsigned char, int=4>*, bool, unsigned long)
                   44.69%  33.266ms      1001  33.233us  32.448us  34.304us  void paddle::operators::DropoutGradCUDAKernel<float, unsigned char, int=4>(float const *, unsigned char const *, paddle::operators::DropoutGradCUDAKernel<float, unsigned char, int=4>, long, paddle::operators::DropoutGradCUDAKernel<float, unsigned char, int=4>*)
                    3.31%  2.4602ms         8  307.52us  1.6960us  2.4469ms  [CUDA memcpy HtoD]
                    0.02%  16.928us         1  16.928us  16.928us  16.928us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
```

- FP16

```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   57.09%  26.230ms      1001  26.203us  25.152us  30.912us  void paddle::operators::VectorizedRandomGenerator<paddle::platform::float16, unsigned char, int=4>(unsigned long, unsigned long, float, paddle::platform::float16 const *, unsigned char*, paddle::operators::VectorizedRandomGenerator<paddle::platform::float16, unsigned char, int=4>*, bool, unsigned long)
                   40.31%  18.518ms      1001  18.499us  17.760us  20.128us  void paddle::operators::DropoutGradCUDAKernel<paddle::platform::float16, unsigned char, int=4>(paddle::platform::float16 const *, unsigned char const *, paddle::operators::DropoutGradCUDAKernel<paddle::platform::float16, unsigned char, int=4>, long, paddle::operators::DropoutGradCUDAKernel<paddle::platform::float16, unsigned char, int=4>*)
                    2.56%  1.1774ms         8  147.18us  1.7280us  1.1637ms  [CUDA memcpy HtoD]
                    0.02%  10.304us         1  10.304us  10.304us  10.304us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<paddle::platform::float16, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<paddle::platform::float16>, Eigen::TensorMap<Eigen::Tensor<paddle::platform::float16, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(paddle::platform::float16, int=1)
```