### PR TITLE
Add mapping config for Paddle repo PR-CI-OP-benchmark

### DIFF
--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -2,6 +2,7 @@
 declare -A PADDLE_FILENAME_OP_MAP
 PADDLE_FILENAME_OP_MAP=(
   ["activation_op.cu"]="leaky_relu elu sqrt square pow exp abs log"
+  ["activation_cudnn_op.cu.cc"]="relu relu6 sigmoid tanh"
   ["interpolate_op.cu"]="bilinear_interp nearest_interp trilinear_interp bicubic_interp linear_interp"
 )
 
@@ -19,4 +20,18 @@ BENCHMARK_APINAME_OP_MAP=(
   ["interp_trilinear"]="trilinear_interp"
   ["interp_bicubic"]="bicubic_interp"
   ["interp_linear"]="linear_interp"
+  ["mean"]="reduce_mean"
+  ["sum"]="reduce_sum"
+  ["prod"]="reduce_prod"
+  ["matmul"]="matmul_v2"
+  ["full"]="fill_constant"
+  ["embedding"]="lookup_table_v2"
+)
+
+# Paddle repo skip op
+declare -A SKIP_OP_MAP
+SKIP_OP_MAP=(
+  ["dgc"]="no reason"
+  ["lookup_table"]="belong to 1.8"
+  ["gru_unit"]="temporarily blocking"
 )


### PR DESCRIPTION
1. 添加Paddle repo源文件OP->benchmark repo测试脚本映射；
2. 添加白名单`SKIP_OP_MAP`用于忽略一部分OP测试；