### PR TITLE
disable pull_box_sparse and setitem quikly

### DIFF
--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -34,4 +34,6 @@ SKIP_OP_MAP=(
   ["dgc"]="no reason"
   ["lookup_table"]="belong to 1.8"
   ["gru_unit"]="temporarily blocking"
+  ["pull_box_sparse"]="temporarily blocking"
+  ["setitem"]="temporarily blocking"
 )


### PR DESCRIPTION
`pull_box_sparse`和`setitem`没有测试脚本，暂时disable。