### PR TITLE
fix tensorflow maximum, minimun accuracy

### DIFF
--- a/api/common/main.py
+++ b/api/common/main.py
@@ -309,11 +309,15 @@ def test_main_without_json(pd_obj=None,
             if args.log_level == 2:
                 print("Output of Paddle: ", base_outputs)
                 print("Output of TensorFlow: ", compare_outputs)
-            utils.check_outputs(
-                base_outputs,
-                compare_outputs,
-                name=config.api_name,
-                atol=config.atol,
-                use_gpu=args.use_gpu,
-                backward=backward,
-                config_params=config.to_string())
+            if is_run_tf and config.api_name in special_op_list.NO_ALIGN_TF_OPS:
+                print("The api (%s) is not aligned with tensorflow." %
+                      (config.api_name))
+            else:
+                utils.check_outputs(
+                    base_outputs,
+                    compare_outputs,
+                    name=config.api_name,
+                    atol=config.atol,
+                    use_gpu=args.use_gpu,
+                    backward=backward,
+                    config_params=config.to_string())

--- a/api/common/main.py
+++ b/api/common/main.py
@@ -309,15 +309,12 @@ def test_main_without_json(pd_obj=None,
             if args.log_level == 2:
                 print("Output of Paddle: ", base_outputs)
                 print("Output of TensorFlow: ", compare_outputs)
-            if is_run_tf and config.api_name in special_op_list.NO_ALIGN_TF_OPS:
-                print("The api (%s) is not aligned with tensorflow." %
-                      (config.api_name))
-            else:
-                utils.check_outputs(
-                    base_outputs,
-                    compare_outputs,
-                    name=config.api_name,
-                    atol=config.atol,
-                    use_gpu=args.use_gpu,
-                    backward=backward,
-                    config_params=config.to_string())
+            utils.check_outputs(
+                base_outputs,
+                compare_outputs,
+                args.testing_mode,
+                name=config.api_name,
+                atol=config.atol,
+                use_gpu=args.use_gpu,
+                backward=backward,
+                config_params=config.to_string())

--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -117,4 +117,6 @@ ALIAS_OP_MAP = {
     "sample_logits": "sampled_softmax_with_cross_entropy"
 }
 
-NO_ALIGN_TF_OPS = ["maximum", "minimum", "argsort"]
+# For example, maximum op need to pick maximum value from two inputs. When the value of inputs are same, 
+# Paddle choose the second value as output and TF choose the first value as output.
+DIFF_IMPLEMENTATION_TF_OPS = ["maximum", "minimum", "argsort"]

--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -116,3 +116,5 @@ ALIAS_OP_MAP = {
     "hierarchical_sigmoid": "hsigmoid",
     "sample_logits": "sampled_softmax_with_cross_entropy"
 }
+
+NO_ALIGN_TF_OPS = ["maximum", "minimum", "argsort"]

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -23,6 +23,8 @@ import collections
 import subprocess
 import itertools
 
+from common import special_op_list
+
 if six.PY3:
     from . import special_op_list
 else:
@@ -179,6 +181,7 @@ def _permute_order(name, output1, output2):
 
 def check_outputs(list1,
                   list2,
+                  testing_mode,
                   name,
                   atol=1E-6,
                   use_gpu=True,
@@ -264,7 +267,13 @@ def check_outputs(list1,
 
             max_diff = max_diff_i if max_diff_i > max_diff else max_diff
             if max_diff > atol:
-                consistent = False
+                is_special_op = name in special_op_list.DIFF_IMPLEMENTATION_TF_OPS or name in special_op_list.RANDOM_OP_LIST
+                if testing_mode == "static" and is_special_op:
+                    print(
+                        "----Warning: The api (%s) is not aligned with tensorflow."
+                        % (name))
+                else:
+                    consistent = False
 
     status = collections.OrderedDict()
     status["name"] = name

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -267,10 +267,15 @@ def check_outputs(list1,
 
             max_diff = max_diff_i if max_diff_i > max_diff else max_diff
             if max_diff > atol:
-                is_special_op = name in special_op_list.DIFF_IMPLEMENTATION_TF_OPS or name in special_op_list.RANDOM_OP_LIST
-                if testing_mode == "static" and is_special_op:
+                if testing_mode == "static" and name in special_op_list.DIFF_IMPLEMENTATION_TF_OPS:
                     print(
-                        "----Warning: The api (%s) is not aligned with tensorflow."
+                        "---- Warning: This situation is not a error. The implementation of api (%s) is different with tensorflow. "
+                        "When the value of inputs are same, Paddle choose the second value as the output and"
+                        "TF choose the first value as the output." % (name))
+
+                elif testing_mode == "static" and name in special_op_list.RANDOM_OP_LIST:
+                    print(
+                        "---- Warning: This situation is not a error. The api (%s) is random op and the value of outputs is random."
                         % (name))
                 else:
                     consistent = False


### PR DESCRIPTION
-  maximum, minimun, argsort 3个与pytorch对齐，跟tf不能对齐 (相同数值的输入，返回的不一样)。
![image](https://user-images.githubusercontent.com/53294385/102970709-f968ac00-4532-11eb-9afd-888558cb6d9a.png)

- 去除掉随机op。bernoulli, dropout
![image](https://user-images.githubusercontent.com/53294385/102970526-9d9e2300-4532-11eb-99b7-fc241237e8f0.png)
