### PR TITLE
add mapping config of PR-CI-OP-benchmark

### DIFF
--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -1,7 +1,8 @@
 # Paddle repo file name -> op name
 declare -A PADDLE_FILENAME_OP_MAP
 PADDLE_FILENAME_OP_MAP=(
-  ["activation_op.cu"]="leaky_relu elu sqrt square pow exp abs log"
+  ["conv_op.cu.cc"]="depthwise_conv2d conv2d conv3d"
+  ["activation_op.cu"]="leaky_relu elu sqrt square exp abs log"
   ["activation_cudnn_op.cu.cc"]="relu relu6 sigmoid tanh"
   ["interpolate_op.cu"]="bilinear_interp nearest_interp trilinear_interp bicubic_interp linear_interp"
 )
@@ -44,4 +45,6 @@ SKIP_OP_MAP=(
   ["setitem"]="temporarily blocking"
   ["conv_transpose"]="temporarily blocking"
   ["set_value"]="temporarily blocking"
+  ["inplace_abn"]="no 2.0 API"
+  ["lstmp"]="no reason"
 )


### PR DESCRIPTION
1. 移除`activation_op.cu`中`pow`的op映射；
2. 新增`conv_op.cu.cc`对应`depthwise_conv2d`，`conv2d`，`conv3d`的op映射；
3. 跳过`inplace_abn`、`lstmp`对应op测试；