### PR TITLE
Add mapping config and skip ops belong to 1.8

### DIFF
--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -2,6 +2,7 @@
 declare -A PADDLE_FILENAME_OP_MAP
 PADDLE_FILENAME_OP_MAP=(
   ["conv_op.cu.cc"]="depthwise_conv2d conv2d conv3d"
+  ["conv_cudnn_op.cu"]="conv2d conv3d"
   ["activation_op.cu"]="leaky_relu elu sqrt square exp abs log"
   ["activation_cudnn_op.cu.cc"]="relu relu6 sigmoid tanh"
   ["interpolate_op.cu"]="bilinear_interp nearest_interp trilinear_interp bicubic_interp linear_interp"
@@ -33,6 +34,8 @@ BENCHMARK_APINAME_OP_MAP=(
   ["matmul"]="matmul_v2"
   ["full"]="fill_constant"
   ["embedding"]="lookup_table_v2"
+  ["top_k"]=["top_k_v2"]
+  ["expand_as"]="expand_as_v2"
 )
 
 # Paddle repo skip op
@@ -47,4 +50,6 @@ SKIP_OP_MAP=(
   ["set_value"]="temporarily blocking"
   ["inplace_abn"]="no 2.0 API"
   ["lstmp"]="no reason"
+  ["top_k"]="belong to 1.8"
+  ["expand_as"]="belong to 1.8"
 )


### PR DESCRIPTION
1. `top_k`，`expand_as`属于1.8对应op，跳过这两个op测试；
2. 添加`conv_cudnn_op.cu.cc`对应op映射关系；