### PR TITLE
add tril and triu tests

### DIFF
--- a/api/tests_v2/configs/tril.json
+++ b/api/tests_v2/configs/tril.json
@@ -1,0 +1,11 @@
+[{
+    "op": "tril",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[1024L, 2048L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 2000
+}]

--- a/api/tests_v2/configs/triu.json
+++ b/api/tests_v2/configs/triu.json
@@ -1,0 +1,11 @@
+[{
+    "op": "triu",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[1024L, 2048L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 2000
+}]

--- a/api/tests_v2/tril.py
+++ b/api/tests_v2/tril.py
@@ -32,5 +32,16 @@ class PDTril(PaddleAPIBenchmarkBase):
             self.append_gradients(result, [x])
 
 
+class TFTril(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = tf.experimental.numpy.tril(x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
 if __name__ == '__main__':
-    test_main(PDTril(), config=TrilConfig())
+    test_main(PDTril(), TFTril(), config=TrilConfig())

--- a/api/tests_v2/tril.py
+++ b/api/tests_v2/tril.py
@@ -1,0 +1,36 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class TrilConfig(APIConfig):
+    def __init__(self):
+        super(TrilConfig, self).__init__("tril")
+        self.run_tf = False
+
+
+class PDTril(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.tensor.tril(x)
+
+        self.feed_vars = [x]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(PDTril(), config=TrilConfig())

--- a/api/tests_v2/tril.py
+++ b/api/tests_v2/tril.py
@@ -18,7 +18,6 @@ from common_import import *
 class TrilConfig(APIConfig):
     def __init__(self):
         super(TrilConfig, self).__init__("tril")
-        self.run_tf = False
 
 
 class PDTril(PaddleAPIBenchmarkBase):

--- a/api/tests_v2/tril.py
+++ b/api/tests_v2/tril.py
@@ -18,6 +18,7 @@ from common_import import *
 class TrilConfig(APIConfig):
     def __init__(self):
         super(TrilConfig, self).__init__("tril")
+        self.run_tf = False
 
 
 class PDTril(PaddleAPIBenchmarkBase):

--- a/api/tests_v2/triu.py
+++ b/api/tests_v2/triu.py
@@ -18,6 +18,7 @@ from common_import import *
 class TriuConfig(APIConfig):
     def __init__(self):
         super(TriuConfig, self).__init__("triu")
+        self.run_tf = False
 
 
 class PDTriu(PaddleAPIBenchmarkBase):

--- a/api/tests_v2/triu.py
+++ b/api/tests_v2/triu.py
@@ -18,7 +18,6 @@ from common_import import *
 class TriuConfig(APIConfig):
     def __init__(self):
         super(TriuConfig, self).__init__("triu")
-        self.run_tf = False
 
 
 class PDTriu(PaddleAPIBenchmarkBase):

--- a/api/tests_v2/triu.py
+++ b/api/tests_v2/triu.py
@@ -1,0 +1,36 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class TriuConfig(APIConfig):
+    def __init__(self):
+        super(TriuConfig, self).__init__("triu")
+        self.run_tf = False
+
+
+class PDTriu(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.tensor.triu(x)
+
+        self.feed_vars = [x]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(PDTriu(), config=TriuConfig())

--- a/api/tests_v2/triu.py
+++ b/api/tests_v2/triu.py
@@ -32,5 +32,16 @@ class PDTriu(PaddleAPIBenchmarkBase):
             self.append_gradients(result, [x])
 
 
+class TFTriu(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = tf.experimental.numpy.triu(x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
 if __name__ == '__main__':
-    test_main(PDTriu(), config=TriuConfig())
+    test_main(PDTriu(), TFTriu(), config=TriuConfig())


### PR DESCRIPTION
add tril and triu tests

由于竞品 Tensorflow 只在 2.4.0 中才有类似接口，tf.experimental.numpy.tril (https://www.tensorflow.org/api_docs/python/tf/experimental/numpy/tril?hl=pt-br%2Fjetpack)，而 benchmark 中使用的是 2.3.0 版本，这里需要关闭相关的测试，但是保留相关代码，以备 tf 升级后使用。