### PR TITLE
modify atol for elementwise ops

### DIFF
--- a/api/tests_v2/configs/elementwise.json
+++ b/api/tests_v2/configs/elementwise.json
@@ -59,6 +59,7 @@
             "type": "Variable"
         }
     },
+    "atol": 1e-5,
     "repeat": 5000
 }, {
     "config_id": 3,
@@ -100,7 +101,7 @@
             "type": "Variable"
         }
     },
-    "atol": 1E-3,
+    "atol": 0.2,
     "repeat": 5000
 }, {
     "config_id": 5,
@@ -161,5 +162,6 @@
             "shape": "[32L, 1L, 1L, 128L]",
             "type": "Variable"
         }
-    }
+    },
+    "atol": 1
 }]


### PR DESCRIPTION
修复因为atol的设置，导致CI出现的报错。
具体报错：
<img width="477" alt="983176a3013fdf4fdefcc7cc9c5f25ba" src="https://user-images.githubusercontent.com/53294385/104868138-8c9fd080-597d-11eb-817e-7e5d247bf399.png">
<img width="454" alt="0027cdf01638e34cbd7c2ae724ab0e8c" src="https://user-images.githubusercontent.com/53294385/104868144-93c6de80-597d-11eb-99bb-414b21c00a12.png">
<img width="457" alt="9b1cfcef898bb703e5dfd8bc70b752d5" src="https://user-images.githubusercontent.com/53294385/104868149-96c1cf00-597d-11eb-9847-982e659c993e.png">
