### PR TITLE
Add benchmarking script for conv3d.

### DIFF
--- a/api/tests_v2/configs/conv3d.json
+++ b/api/tests_v2/configs/conv3d.json
@@ -1,0 +1,36 @@
+[{
+    "op": "conv3d",
+    "param_info": {
+        "data_format": {
+            "type": "string",
+            "value": "NCDHW"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1L, 64L, 5L, 360L, 360L]",
+            "type": "Variable"
+        },
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128L, 64L, 3L, 3L, 3L]",
+            "type": "Variable"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "list",
+            "value": "[1, 2, 2]"
+        }
+    },
+    "repeat": 100
+}]

--- a/api/tests_v2/conv3d.py
+++ b/api/tests_v2/conv3d.py
@@ -1,0 +1,57 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class Conv3dConfig(APIConfig):
+    def __init__(self, op_type="conv3d"):
+        super(Conv3dConfig, self).__init__(op_type)
+        self.feed_spec = [
+            {
+                "range": [-1, 1]
+            },  # x
+            {
+                "range": [-1, 1],
+                "permute": [2, 3, 4, 1, 0]
+            }  # weight
+        ]
+        self.run_tf = False
+
+
+class PDConv3d(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name='weight',
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+        result = paddle.nn.functional.conv3d(
+            x=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            dilation=config.dilation,
+            groups=config.groups,
+            data_format=config.data_format)
+
+        self.feed_vars = [x, weight]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])
+
+
+if __name__ == '__main__':
+    test_main(PDConv3d(), config=Conv3dConfig())


### PR DESCRIPTION
因为https://github.com/PaddlePaddle/Paddle/pull/30512 ，新增conv3d的测试脚本。这个pr暂时只添加paddle的测试，tf对齐的测试后续再依据需求添加。