### PR TITLE
benchmark add where_index op test script

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -74,6 +74,7 @@ NO_BACKWARD_OPS = [
     "linspace",
     "remainder",
     "unique",
+    "where_index",
     "yolo_box",
 
     # Temporarily add to this list to pass CI.

--- a/api/tests_v2/configs/where_index.json
+++ b/api/tests_v2/configs/where_index.json
@@ -1,0 +1,28 @@
+[{
+    "op": "where_index",
+    "param_info": {
+        "x": {
+            "dtype": "bool",
+            "shape": "[-1L, 100L, 100L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "where_index",
+    "param_info": {
+        "x": {
+            "dtype": "int32",
+            "shape": "[-1L, 10L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "where_index",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 1000L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/where_index.py
+++ b/api/tests_v2/where_index.py
@@ -1,0 +1,42 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDWhereIndex(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        data = self.variable(
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
+        # paddle.where invoke paddle.fluid.core.ops.where_index
+        value = paddle.fluid.layers.where(data)
+
+        self.feed_vars = [data]
+        self.fetch_vars = [value]
+        print(self.fetch_vars)
+
+
+class TFWhereIndex(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        data = self.variable(
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
+        value = tf.where(data)
+
+        self.feed_list = [data]
+        self.fetch_list = [value]
+        print(self.fetch_list)
+
+
+if __name__ == '__main__':
+    test_main(PDWhereIndex(), TFWhereIndex(), config=APIConfig("where_index"))


### PR DESCRIPTION
### PR changes
Ops

### Describe
作用：
添加`paddle.fluid.core.ops.where_index`算子的test script

起因：
现benchmark缺乏`where_index` op的test script，导致CI的op benchmark一直失败

要点：
1. 由于`paddle.fluid.core.ops.where_index`的参数为tensor，不能直接调用。所以只能通过`paddle.fluid.layers.where`来间接调用该op，后者在实现中实际调用的就是`paddle.fluid.core.ops.where_index`。
2. 根据[where_index_op.cc#L56](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/operators/where_index_op.cc#L56)显示，`where_index`不用计算反向梯度，因此需要将`where_index`加入`api/common/special_op_list.py`