### PR TITLE
Update transformer base dy

### DIFF
--- a/dynamic_graph/lac/paddle/run_benchmark.sh
+++ b/dynamic_graph/lac/paddle/run_benchmark.sh
@@ -44,10 +44,13 @@ function _set_params(){
 function _train(){
     # 去掉test，当前实现里没有开关可以关闭或者修改
     grep -q "#             eval_data=test_loader" ./train.py
-    if [ $? -eq 1 ]; then
+    if [ $? -eq 0 ]; then
         echo "----------already addressed disable test after train"
     else    
         sed -i "s/             eval_data=test_loader,/#             eval_data=test_loader,/g" train.py
+        # 打开benchmark 输出，目前不支持参数配置，只可sed 修改
+        sed -i "103 a \    callback = paddle.callbacks.ProgBarLogger(log_freq=10, verbose=3)" train.py
+        sed -i "112 a \              callbacks=callback," train.py
     fi
 
     train_cmd="--data_dir ./data

--- a/dynamic_graph/transformer/paddle/run_benchmark.sh
+++ b/dynamic_graph/transformer/paddle/run_benchmark.sh
@@ -41,19 +41,15 @@ function _set_params(){
 
 function _train(){
     if [ ${model_name} == "transformer_base" ]; then 
-        train_cmd="--max_iter ${max_iter} \
-                   --src_vocab_fpath gen_data/iwslt14.tokenized.de-en/vocab.de \
-                   --trg_vocab_fpath gen_data/iwslt14.tokenized.de-en/vocab.en \
-                   --special_token  <s> <e> <unk> \
-                   --training_file gen_data/iwslt14.tokenized.de-en/para_small.de-en \
-                   --validation_file gen_data/wmt16_ende_data_bpe/newstest2014.tok.bpe.32000.en-de \
-                   --predict_file gen_data/wmt16_ende_data_bpe/newstest2016.tok.bpe.32000.en-de \
-                   --weight_sharing False \
-                   --batch_size ${base_batch_size}"
+        config_file="transformer.base.yaml"
+    elif [ ${model_name} == "transformer_big" ]; then
+        config_file="transformer.big.yaml"
     else
-        sed -i "s/^max_iter.*/max_iter: ${max_iter}/g" ../configs/transformer.big.yaml #不支持传参修改
-        train_cmd="--config ../configs/transformer.big.yaml"
+        echo " The model should be transformer_big or transformer_base!"
+        exit 1
     fi
+    sed -i "s/^max_iter.*/max_iter: ${max_iter}/g" ../configs/${config_file} #不支持传参修改
+    train_cmd="--config ../configs/${config_file}"
 
     if [ ${run_mode} = "sp" ]; then
         train_cmd="python -u train.py "${train_cmd}

--- a/scripts/dynamic_graph_models.sh
+++ b/scripts/dynamic_graph_models.sh
@@ -77,42 +77,26 @@ dy_ptb_lm(){
 
 # transformer
 dy_transformer(){
-    model_name="transformer_base"
-    cur_model_path=${BENCHMARK_ROOT}/models/dygraph/transformer
-    cd ${cur_model_path}
-
-    # Prepare data
-    mkdir -p data
-    ln -s ${data_path}/dygraph_data/transformer/gen_data/ ${cur_model_path}/
-
-    # Running ...
-    rm -f ./run_benchmark.sh
-    cp ${BENCHMARK_ROOT}/dynamic_graph/transformer/paddle/run_benchmark.sh ./
-    sed -i '/set\ -xe/d' run_benchmark.sh
-    echo "index is speed, 1gpu begin"
-    CUDA_VISIBLE_DEVICES=5 bash run_benchmark.sh 1 sp 3000 base | tee ${log_path}/dynamic_${model_name}_speed_1gpus 2>&1
-    sleep 60
-    echo "index is speed, 8gpus begin, mp"
-    CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 1 mp 3000 base | tee ${log_path}/dynamic_${model_name}_speed_8gpus 2>&1
-    sleep 60
-
-    model_name="transformer_big"
     echo "###########pip install paddlenlp"
     pip install paddlenlp attrdict
     cur_model_path=${BENCHMARK_ROOT}/models/PaddleNLP/benchmark/transformer/dygraph
     cd ${cur_model_path}
     # prepare data
-    mkdir -p /root/.paddlenlp/datasets/
-    ln -s ${data_path}/dygraph_data/transformer/big_mode/* /root/.paddlenlp/datasets/   # 注意big 和base 数据有diff. 目前复用 paddlenlp 的数据准备逻辑，所以数据位置需要改变
+    mkdir -p ~/.paddlenlp/datasets/machine_translation
+    ln -s ${data_path}/dygraph_data/transformer/WMT14ende ~/.paddlenlp/datasets/machine_translation/ 
     rm -f ./run_benchmark.sh
     cp ${BENCHMARK_ROOT}/dynamic_graph/transformer/paddle/run_benchmark.sh ./
     sed -i '/set\ -xe/d' run_benchmark.sh
-    echo "index is speed, 1gpu begin"
-    CUDA_VISIBLE_DEVICES=5 bash run_benchmark.sh 1 sp 400 big  | tee ${log_path}/dynamic_${model_name}_speed_1gpus 2>&1
-    sleep 60
-    echo "index is speed, 8gpus begin, mp"
-    CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 1 mp 500 big | tee ${log_path}/dynamic_${model_name}_speed_8gpus 2>&1
-   
+    mode_list=(big base)
+    for mode_item=${mode_list[@]}
+    do
+        model_name="transformer_${mode_item}"
+        echo "index is speed, ${model_name} 1gpu begin"
+        CUDA_VISIBLE_DEVICES=5 bash run_benchmark.sh 1 sp 400 ${mode_item}  | tee ${log_path}/dynamic_${model_name}_speed_1gpus 2>&1
+        sleep 60
+        echo "index is speed, ${model_name} 8gpus begin, mp"
+        CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 1 mp 500 ${mode_item} | tee ${log_path}/dynamic_${model_name}_speed_8gpus 2>&1
+    done 
 }
 
 # tsn 

--- a/scripts/dynamic_graph_models.sh
+++ b/scripts/dynamic_graph_models.sh
@@ -88,7 +88,7 @@ dy_transformer(){
     cp ${BENCHMARK_ROOT}/dynamic_graph/transformer/paddle/run_benchmark.sh ./
     sed -i '/set\ -xe/d' run_benchmark.sh
     mode_list=(big base)
-    for mode_item=${mode_list[@]}
+    for mode_item in ${mode_list[@]}
     do
         model_name="transformer_${mode_item}"
         echo "index is speed, ${model_name} 1gpu begin"

--- a/scripts/dynamic_graph_models.sh
+++ b/scripts/dynamic_graph_models.sh
@@ -92,7 +92,7 @@ dy_transformer(){
     do
         model_name="transformer_${mode_item}"
         echo "index is speed, ${model_name} 1gpu begin"
-        CUDA_VISIBLE_DEVICES=5 bash run_benchmark.sh 1 sp 400 ${mode_item}  | tee ${log_path}/dynamic_${model_name}_speed_1gpus 2>&1
+        CUDA_VISIBLE_DEVICES=5 bash run_benchmark.sh 1 sp 600 ${mode_item}  | tee ${log_path}/dynamic_${model_name}_speed_1gpus 2>&1
         sleep 60
         echo "index is speed, ${model_name} 8gpus begin, mp"
         CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 bash run_benchmark.sh 1 mp 500 ${mode_item} | tee ${log_path}/dynamic_${model_name}_speed_8gpus 2>&1


### PR DESCRIPTION
 **可暂缓合入**
* 动态图transformer_base 模型切换到2.0 API
* 1.8 分支基于测试得一下结果：
* 
<img width="496" alt="图片" src="https://user-images.githubusercontent.com/52739577/106100399-40bc0b00-6177-11eb-88a9-1b5d2cdc746f.png">

1.8 在 iwslt14 上数据偏大主要是句子的长度的影响，batch size 4096 是一个最大的限制值，限制一个 batch 内的 token 的数目，token 这里可以理解是词的数目。也可以看到使用 iwslt14 的时候，有的 batch 会很快，有的 batch 很慢，也是因为这个限制，有的 batch 计算量实际较大，有的较小，导致不同的 batch 之间时间上差异大。较快的 batch 也就拉高了 step/s 计算的平均值。
* 更新lac 脚本