### PR TITLE
add pytorch test case

### DIFF
--- a/api/dynamic_tests_v2/affine_grid.py
+++ b/api/dynamic_tests_v2/affine_grid.py
@@ -1,0 +1,50 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file ethetacept in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either ethetapress or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDAffineGrid(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        theta = self.variable(
+            name='theta', shape=config.theta_shape, dtype=config.theta_dtype)
+        result = paddle.nn.functional.affine_grid(
+            theta,
+            out_shape=config.out_shape,
+            align_corners=config.align_corners)
+
+        self.feed_list = [theta]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [theta])
+
+
+class TorchAffineGrid(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        theta = self.variable(
+            name='theta', shape=config.theta_shape, dtype=config.theta_dtype)
+        result = torch.nn.functional.affine_grid(
+            theta, size=config.out_shape, align_corners=config.align_corners)
+
+        self.feed_list = [theta]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [theta])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDAffineGrid(),
+        torch_obj=TorchAffineGrid(),
+        config=APIConfig("affine_grid"))

--- a/api/dynamic_tests_v2/bernoulli.py
+++ b/api/dynamic_tests_v2/bernoulli.py
@@ -1,0 +1,46 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class BernoulliConfig(APIConfig):
+    def __init__(self):
+        super(BernoulliConfig, self).__init__('bernoulli')
+        self.feed_spec = {"range": [0, 1]}
+
+
+class PDBernoulli(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.bernoulli(x=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+class TorchBernoulli(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.bernoulli(input=x)
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDBernoulli(),
+        torch_obj=TorchBernoulli(),
+        config=BernoulliConfig())

--- a/api/dynamic_tests_v2/interp_area.py
+++ b/api/dynamic_tests_v2/interp_area.py
@@ -1,0 +1,60 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class InterpAreaConfig(APIConfig):
+    def __init__(self):
+        super(InterpAreaConfig, self).__init__('interp_area')
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(InterpAreaConfig, self).init_from_json(filename, config_id,
+                                                     unknown_dim)
+        if self.data_format == 'NHWC' or self.data_format == 'NDHWC':
+            self.run_torch = False
+
+
+class PDInterpArea(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        # align_corners option can only be set with the interpolating modes: linear, area, bicubic, trilinear
+        result = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="area",
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchnterpArea(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x, size=config.size, mode="area", scale_factor=config.scale_factor)
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDInterpArea(),
+        torch_obj=TorchnterpArea(),
+        config=InterpAreaConfig())

--- a/api/dynamic_tests_v2/interp_bicubic.py
+++ b/api/dynamic_tests_v2/interp_bicubic.py
@@ -1,0 +1,64 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class InterpBicubicConfig(APIConfig):
+    def __init__(self):
+        super(InterpBicubicConfig, self).__init__('interp_bicubic')
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(InterpBicubicConfig, self).init_from_json(filename, config_id,
+                                                        unknown_dim)
+        if self.data_format == 'NHWC':
+            self.run_torch = False
+
+
+class PDInterpBicubic(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="bilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+class TorchInterpBicubic(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="bilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor)
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDInterpBicubic(),
+        torch_obj=TorchInterpBicubic(),
+        config=InterpBicubicConfig())

--- a/api/dynamic_tests_v2/interp_bilinear.py
+++ b/api/dynamic_tests_v2/interp_bilinear.py
@@ -1,0 +1,64 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class InterpBilinearConfig(APIConfig):
+    def __init__(self):
+        super(InterpBilinearConfig, self).__init__('interp_bilinear')
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(InterpBilinearConfig, self).init_from_json(filename, config_id,
+                                                         unknown_dim)
+        if self.data_format == 'NHWC':
+            self.run_torch = False
+
+
+class PDInterpBilinear(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="bilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+class TorchInterpBilinear(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="bilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor)
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDInterpBilinear(),
+        torch_obj=TorchInterpBilinear(),
+        config=InterpBilinearConfig())

--- a/api/dynamic_tests_v2/interp_linear.py
+++ b/api/dynamic_tests_v2/interp_linear.py
@@ -1,0 +1,53 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDInterpLinear(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="linear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+class TorchInterpLinear(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="linear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor)
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDInterpLinear(),
+        torch_obj=TorchInterpLinear(),
+        config=APIConfig("interp_linear"))

--- a/api/dynamic_tests_v2/interp_nearest.py
+++ b/api/dynamic_tests_v2/interp_nearest.py
@@ -1,0 +1,62 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class InterpNearestConfig(APIConfig):
+    def __init__(self):
+        super(InterpNearestConfig, self).__init__('interp_nearest')
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(InterpNearestConfig, self).init_from_json(filename, config_id,
+                                                        unknown_dim)
+        if self.data_format == 'NHWC':
+            self.run_torch = False
+
+
+class PDInterpNearest(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="nearest",
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+class TorchInterpNearest(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="nearest",
+            scale_factor=config.scale_factor)
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDInterpNearest(),
+        torch_obj=TorchInterpNearest(),
+        config=InterpNearestConfig())

--- a/api/dynamic_tests_v2/interp_trilinear.py
+++ b/api/dynamic_tests_v2/interp_trilinear.py
@@ -1,0 +1,53 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDInterpTrilinear(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="trilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+class TorchInterpTrilinear(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="trilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor)
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDInterpTrilinear(),
+        torch_obj=TorchInterpTrilinear(),
+        config=APIConfig("interp_trilinear"))

--- a/api/dynamic_tests_v2/inverse.py
+++ b/api/dynamic_tests_v2/inverse.py
@@ -1,0 +1,44 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDInverse(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.inverse(x=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchInverse(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.inverse(input=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDInverse(),
+        torch_obj=TorchInverse(),
+        config=APIConfig('inverse'))

--- a/api/dynamic_tests_v2/normalize.py
+++ b/api/dynamic_tests_v2/normalize.py
@@ -1,0 +1,46 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDL2Normalize(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.nn.functional.normalize(
+            x=x, p=2, axis=config.axis, epsilon=config.epsilon)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchL2Normalize(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.normalize(
+            input=x, p=2, dim=config.axis, eps=config.epsilon)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDL2Normalize(),
+        torch_obj=TorchL2Normalize(),
+        config=APIConfig("normalize"))


### PR DESCRIPTION
add interp_area、interp_nearest、interp_linear、interp_bilinear、interp_bicubic、interp_trilinear、inverse、normalize、affine_grid、bernoulli
说明：paddle.inverse前向与torch精度未对齐，[DLTP-21639](https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-21639/show?cid=5&spaceId=23205&from=email&noticeStatistics=53380086)
            paddle.nn.functional.affine_grid在config=0下，backward与pytorch精度未对齐，[[DLTP-21638]](https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-21638/show?cid=5&spaceId=23205&from=email&noticeStatistics=53379174)
           