### PR TITLE
benchmark add range op test script for CI

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -72,6 +72,7 @@ NO_BACKWARD_OPS = [
     "greater",
     "less",
     "linspace",
+    "range",
     "remainder",
     "unique",
     "yolo_box",

--- a/api/tests_v2/configs/range.json
+++ b/api/tests_v2/configs/range.json
@@ -1,0 +1,61 @@
+[{
+    "op": "range",
+    "param_info": {
+        "dtype": {
+            "type": "string",
+            "value": "int32"
+        },
+        "start": {
+            "type": "int32",
+            "value": "0"
+        },
+        "end": {
+            "type": "int32",
+            "value": "100000"
+        },
+        "step": {
+            "type": "int32",
+            "value": "1"
+        }
+    }
+}, {
+    "op": "range",
+    "param_info": {
+        "dtype": {
+            "type": "string",
+            "value": "int64"
+        },
+        "start": {
+            "type": "int64",
+            "value": "100000"
+        },
+        "end": {
+            "type": "int64",
+            "value": "-100000"
+        },
+        "step": {
+            "type": "int64",
+            "value": "-3"
+        }
+    }
+}, {
+    "op": "range",
+    "param_info": {
+        "dtype": {
+            "type": "string",
+            "value": "float"
+        },
+        "start": {
+            "type": "float",
+            "value": "-2"
+        },
+        "end": {
+            "type": "float",
+            "value": "2"
+        },
+        "step": {
+            "type": "float",
+            "value": "0.001"
+        }
+    }
+}]

--- a/api/tests_v2/range.py
+++ b/api/tests_v2/range.py
@@ -1,0 +1,46 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDRange(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        # TODO(jiangcheng): need verify dtype
+        value = paddle.fluid.layers.range(
+            start=config.start,
+            end=config.end,
+            step=config.step,
+            dtype=config.dtype)
+
+        self.feed_vars = []
+        self.fetch_vars = [value]
+        print(self.fetch_vars)
+
+
+class TFRange(TensorflowAPIBenchmarkBase):
+    def build_graph(self, config):
+        value = tf.range(
+            start=config.start,
+            limit=config.end,
+            delta=config.step,
+            dtype=config.dtype)
+
+        self.feed_list = []
+        self.fetch_list = [value]
+        print(self.fetch_list)
+
+
+if __name__ == '__main__':
+    test_main(PDRange(), TFRange(), config=APIConfig("range"))


### PR DESCRIPTION
### PR changes
Ops

### Describe
作用：
添加`paddle.fluid.layers.range`算子的test script

起因：
现benchmark缺乏`range` op的test script，导致CI的op benchmark一直失败

要点：
1. 无论是paddle还是tensorflow，`range`算子参数主要是有4个变量组成：`start`、`end`、`step`和标识输入输出类型的`dtype`，因此`feed_vars`为空，详情见[tensor.py#L1323](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/tensor.py#L1323)
2. 根据[range_op.cc#L100](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/operators/range_op.cc#L100)显示，`range`算子是没有反向梯度的，因此需要将`range`加入`api/common/special_op_list.py`