### PR TITLE
add interp_bilinear config

### DIFF
--- a/api/tests_v2/configs/interp_bilinear.json
+++ b/api/tests_v2/configs/interp_bilinear.json
@@ -148,4 +148,29 @@
             "value": "None"
         }
     }
+}, {
+    "op": "interp_bilinear",
+    "param_info": {
+        "align_corners": {
+            "type": "bool",
+            "value": "False"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[4L, 256L, 1L, 1L]",
+            "type": "Variable"
+        },
+        "size": {
+            "type": "tuple",
+            "value": "(64L, 128L)"
+        },
+        "scale_factor": {
+            "type": "string",
+            "value": "None"
+        }
+    }
 }]


### PR DESCRIPTION
增加deeplabv3+中的一个耗时的配置，主要是反向的KeBilinearInterpBw耗时较多

```
run command: nvprof /root/anaconda3/envs/py36/bin/python /workspace/benchmark/api/tests_v2/interp_bilinear.py --task speed --framework paddle --json_file /workspace/benchmark/api/tests_v2/configs/interp_bilinear.json --config_id 6 --check_output False --profiler none --backward True --use_gpu True --repeat 1 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   98.71%  32.686ms         2  16.343ms  16.270ms  16.416ms  void paddle::operators::KeBilinearInterpBw<float>(float*, unsigned long, unsigned long, unsigned long, unsigned long, paddle::operators::KeBilinearInterpBw<float> const *, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, paddle::operators::KeBilinearInterpBw<float>, paddle::operators::KeBilinearInterpBw<float>, bool, int, paddle::framework::DataLayout)
                    1.09%  359.77us         2  179.89us  179.10us  180.67us  void paddle::operators::KeBilinearInterpFw<float>(float const *, unsigned long, unsigned long, unsigned long, unsigned long, paddle::operators::KeBilinearInterpFw<float>*, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, float, float, bool, int, paddle::framework::DataLayout)
                    0.13%  43.488us         3  14.496us  1.4080us  40.544us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                    0.05%  15.520us         8  1.9400us  1.7600us  2.2080us  [CUDA memcpy HtoD]
                    0.02%  7.2000us         4  1.8000us  1.6640us  1.9840us  [CUDA memset]
```