### PR TITLE
add adaptive_avg_pool2d.py in dynamice_tests_v2

### DIFF
--- a/api/dynamic_tests_v2/adaptive_avg_pool2d.py
+++ b/api/dynamic_tests_v2/adaptive_avg_pool2d.py
@@ -13,18 +13,18 @@
 # limitations under the License.
 
 from common_import import *
-import paddle
+
 
 class AdaptiveAvgPool2dConfig(APIConfig):
     def __init__(self):
         super(AdaptiveAvgPool2dConfig, self).__init__("adaptive_avg_pool2d")
 
+
 class PaddleAdaptiveAvgPool2D(PaddleDynamicAPIBenchmarkBase):
     def build_graph(self, config):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         adaptive_avg_pool2d = paddle.nn.AdaptiveAvgPool2D(
-            output_size=config.output_size,
-            data_format=config.data_format)
+            output_size=config.output_size, data_format=config.data_format)
         result = adaptive_avg_pool2d(x)
 
         self.feed_list = [x]
@@ -32,10 +32,12 @@ class PaddleAdaptiveAvgPool2D(PaddleDynamicAPIBenchmarkBase):
         if config.backward:
             self.append_gradients(result, [x])
 
+
 class TorchAdaptiveAvgPool2D(PytorchAPIBenchmarkBase):
     def build_graph(self, config):
         x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
-        adaptiveavgpool2d = torch.nn.AdaptiveAvgPool2d(output_size=config.output_size)
+        adaptiveavgpool2d = torch.nn.AdaptiveAvgPool2d(
+            output_size=config.output_size)
         result = adaptiveavgpool2d(x)
         self.feed_list = [x]
         self.fetch_list = [result]

--- a/api/dynamic_tests_v2/adaptive_avg_pool2d.py
+++ b/api/dynamic_tests_v2/adaptive_avg_pool2d.py
@@ -1,0 +1,50 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+import paddle
+
+class AdaptiveAvgPool2dConfig(APIConfig):
+    def __init__(self):
+        super(AdaptiveAvgPool2dConfig, self).__init__("adaptive_avg_pool2d")
+
+class PaddleAdaptiveAvgPool2D(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        adaptive_avg_pool2d = paddle.nn.AdaptiveAvgPool2D(
+            output_size=config.output_size,
+            data_format=config.data_format)
+        result = adaptive_avg_pool2d(x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+class TorchAdaptiveAvgPool2D(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        adaptiveavgpool2d = torch.nn.AdaptiveAvgPool2d(output_size=config.output_size)
+        result = adaptiveavgpool2d(x)
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PaddleAdaptiveAvgPool2D(),
+        torch_obj=TorchAdaptiveAvgPool2D(),
+        config=AdaptiveAvgPool2dConfig())

--- a/api/tests_v2/configs/adaptive_avg_pool2d.json
+++ b/api/tests_v2/configs/adaptive_avg_pool2d.json
@@ -3,7 +3,7 @@
     "param_info": {
         "x": {
             "dtype": "float32",
-            "shape": "[4L, 2048L, 64L, 64L]",
+            "shape": "[4L, 2048L, 64L, 128L]",
             "type": "Variable"
         },
         "data_format": {
@@ -16,12 +16,12 @@
         }
     },
     "repeat": 5000
-},{
+}, {
     "op": "adaptive_avg_pool2d",
     "param_info": {
         "x": {
             "dtype": "float16",
-            "shape": "[1L, 1L, 64L, 64L]",
+            "shape": "[4L, 2048L, 64L, 128L]",
             "type": "Variable"
         },
         "data_format": {

--- a/api/tests_v2/configs/adaptive_avg_pool2d.json
+++ b/api/tests_v2/configs/adaptive_avg_pool2d.json
@@ -1,0 +1,37 @@
+[{
+    "op": "adaptive_avg_pool2d",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[4L, 2048L, 64L, 64L]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "output_size": {
+            "type": "list",
+            "value": "[32L, 32L]"
+        }
+    },
+    "repeat": 5000
+},{
+    "op": "adaptive_avg_pool2d",
+    "param_info": {
+        "x": {
+            "dtype": "float16",
+            "shape": "[1L, 1L, 64L, 64L]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "output_size": {
+            "type": "list",
+            "value": "[32L, 32L]"
+        }
+    },
+    "repeat": 5000
+}]


### PR DESCRIPTION
add adaptive_avg_pool2d.py in dynamice_tests_v2 and add config for adaptive_avg_pool2d

test results:
```
[pytorch][adaptive_avg_pool2d] 
 adaptive_avg_pool2d { 
      run_tf: True 
      run_torch: True 
      repeat: 5000 
      data_format: NCHW 
      output_size: [32, 32] 
      x_shape: [4, 2048, 64, 64] 
      x_dtype: float32 
     atol: 1e-06 } 
[paddle][adaptive_avg_pool2d] 
adaptive_avg_pool2d { 
     run_tf: True 
     run_torch: True 
     repeat: 5000 
     data_format: NCHW 
     output_size: [32, 32] 
     x_shape: [4, 2048, 64, 64] 
     x_dtype: float32 
     atol: 1e-06 }
      {"name": "adaptive_avg_pool2d", "device": "GPU", "backward": true, "consistent": true, "num_outputs": 2, "diff": 0.0, "parameters": "x (Variable) - dtype: float32, shape: [4, 2048, 64, 64]\ndata_format (string): NCHW\noutput_size (list): [32, 32]\n"}

[pytorch][adaptive_avg_pool2d] 
 adaptive_avg_pool2d { 
     run_tf: True 
     run_torch: True 
     repeat: 5000 
     data_format: NCHW 
     output_size: [32, 32] 
     x_shape: [1, 1, 64, 64] 
     x_dtype: float16 
     atol: 0.001 } 
 [paddle][adaptive_avg_pool2d] 
 adaptive_avg_pool2d { 
     run_tf: True run_torch: True repeat: 5000 data_format: NCHW output_size: [32, 32] x_shape: [1, 1, 64, 64] x_dtype: float16 atol: 0.001 } {"name": "adaptive_avg_pool2d", "device": "GPU", "backward": true, "consistent": true, "num_outputs": 2, "diff": 0.0, "parameters": "x (Variable) - dtype: float16, shape: [1, 1, 64, 64]\ndata_format (string): NCHW\noutput_size (list): [32, 32]\n"}
```