### PR TITLE
update_fp16_flag, test=document_fix

### DIFF
--- a/static_graph/image_classification/resnet50_fp/paddle/run_benchmark_fp16.sh
+++ b/static_graph/image_classification/resnet50_fp/paddle/run_benchmark_fp16.sh
@@ -40,7 +40,7 @@ function _set_params(){
 }
 
 function _set_env(){
-    export FLAGS_conv_workspace_size_limit=4000 #MB
+    export FLAGS_conv_workspace_size_limit=1500 #MB
     export FLAGS_cudnn_exhaustive_search=1
     export FLAGS_cudnn_batchnorm_spatial_persistent=1
     export FLAGS_fraction_of_gpu_memory_to_use=0.8


### PR DESCRIPTION
 * 更新fp16 下的FLAGS_conv_workspace_size_limit 值
 * 由于 [PR-30959](https://github.com/PaddlePaddle/Paddle/pull/30959 )   导致静态图resent50 bs208 fp16 pure& amp 单卡任务OOM  ，经 @zhangting2020 排查，根因在于该 PR对fp16类型的卷积算法开启了search功能，search的这个接口因为是根据环境变量FLAGS_conv_workspace_size_limit预先分配内存，所以这个环境变量值较大，就会引起OOM。测试调小该flag到1500，模型能正常运行，速度上和PR前设置4000持平