### PR TITLE
add Paddle repo op benchmark ci config mapping

### DIFF
--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -1,6 +1,7 @@
 # Paddle repo file name -> op name
 declare -A PADDLE_FILENAME_OP_MAP
 PADDLE_FILENAME_OP_MAP=(
+  ["pool_op.cu"]="max_pool2d avg_pool2d"
   ["tril_triu_op.cu"]="tril triu"
   ["conv_op.cu.cc"]="depthwise_conv2d conv2d conv3d"
   ["conv_cudnn_op.cu"]="conv2d conv3d"


### PR DESCRIPTION
添加`pool` OP对应测试API脚本映射关系。

失败CI日志：https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/2444063/job/3431236