### PR TITLE
fix op benchmark config error

### DIFF
--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -39,7 +39,7 @@ BENCHMARK_APINAME_OP_MAP=(
   ["matmul"]="matmul_v2"
   ["full"]="fill_constant"
   ["embedding"]="lookup_table_v2"
-  ["topk"]=["top_k_v2"]
+  ["topk"]="top_k_v2"
   ["expand_as"]="expand_as_v2"
   ["grid_sample"]="grid_sampler"
 )


### PR DESCRIPTION
修复OP `top_k_v2`到API `topk`映射关系配置错误。