### PR TITLE
fix interpolate_op.cu file config error

### DIFF
--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -9,7 +9,7 @@ PADDLE_FILENAME_OP_MAP=(
   ["pool_cudnn_op.cu.cc"]="avg_pool2d max_pool2d"
   ["activation_op.cu"]="leaky_relu elu sqrt square exp abs log"
   ["activation_cudnn_op.cu.cc"]="relu relu6 sigmoid tanh"
-  ["interpolate_op.cu"]="bilinear_interp nearest_interp trilinear_interp bicubic_interp linear_interp"
+  ["interpolate_op.cu"]="interp_bilinear interp_nearest interp_trilinear interp_bicubic interp_linear"
   ["interpolate_v2_op.cu"]="interp_bilinear interp_nearest interp_trilinear interp_bicubic interp_linear"
 )
 
@@ -29,11 +29,6 @@ BENCHMARK_APINAME_OP_MAP=(
   ["subtract"]="elementwise_sub"
   ["remainder"]="elementwise_mod"
   ["floor_divide"]="elementwise_floordiv"
-  ["interp_bilinear"]="bilinear_interp"
-  ["interp_nearest"]="nearest_interp"
-  ["interp_trilinear"]="trilinear_interp"
-  ["interp_bicubic"]="bicubic_interp"
-  ["interp_linear"]="linear_interp"
   ["mean"]="reduce_mean"
   ["sum"]="reduce_sum"
   ["prod"]="reduce_prod"


### PR DESCRIPTION
修复OP性能测试CI使用的配置文件中`interpolate_op.cu`映射错误问题。

对于单文件对应多个测试API时，应仅添加在`PADDLE_FILENAME_OP_MAP`中。
