### PR TITLE
update_seg_models and dynamic scripts, test=document_fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,10 +50,6 @@
 [submodule "static_graph/Detection/pytorch/Detectron-Cascade-RCNN"]
   path = static_graph/Detection/pytorch/Detectron-Cascade-RCNN
   url = https://github.com/zhaoweicai/Detectron-Cascade-RCNN.git
-[submodule "PaddleSeg"]
-  path = PaddleSeg
-  url = https://github.com/PaddlePaddle/PaddleSeg.git
-  branch = develop
 [submodule "PaddleGAN"]
   path = PaddleGAN
   url = https://github.com/PaddlePaddle/PaddleGAN.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,7 @@
 	path = PaddleVideo
 	url = https://github.com/PaddlePaddle/PaddleVideo.git
 	branch = develop
+[submodule "PaddleSeg"]
+	path = PaddleSeg
+	url = https://github.com/PaddlePaddle/PaddleSeg.git
+	branch = benchmark

--- a/dynamic_graph/seg_models/paddle/run_benchmark.sh
+++ b/dynamic_graph/seg_models/paddle/run_benchmark.sh
@@ -20,11 +20,9 @@ function _set_params(){
     mission_name="图像分割"
     direction_id=0
     skip_steps=5
-    keyword="batch_cost="
-    separator="="
-    position=5
-    range=0:5
-    model_mode=0 # s/step -> sample/s 
+    keyword="ips:"
+    model_mode=-1
+    ips_unit="samples/s"
 
     device=${CUDA_VISIBLE_DEVICES//,/ }
     arr=($device)

--- a/dynamic_graph/seg_models/paddle/run_benchmark.sh
+++ b/dynamic_graph/seg_models/paddle/run_benchmark.sh
@@ -22,7 +22,7 @@ function _set_params(){
     skip_steps=5
     keyword="ips:"
     model_mode=-1
-    ips_unit="samples/s"
+    ips_unit="images/s"
 
     device=${CUDA_VISIBLE_DEVICES//,/ }
     arr=($device)
@@ -37,6 +37,7 @@ function _set_params(){
 
 function _train(){
     export PYTHONPATH=$(pwd):{PYTHONPATH}
+    export FLAGS_cudnn_exhaustive_search=1
     if [ ${model_name} = "HRnet" ]; then
         config="benchmark/hrnet.yml"
     elif [ ${model_name} = "deeplabv3" ]; then

--- a/scripts/dynamic_graph_models.sh
+++ b/scripts/dynamic_graph_models.sh
@@ -149,6 +149,7 @@ dy_gan(){
 dy_seg(){
     cur_model_path=${BENCHMARK_ROOT}/PaddleSeg/
     cd ${cur_model_path}
+    git checkout develop    # 静态图监控benchmark分支，已将默认分支切为benchmark。故而静态图训练完毕后，需切下分支
     
     #apt-get install lsb-core -y
     pip install  visualdl


### PR DESCRIPTION

 * update PaddleSeg from develop f400b02 to **benchmark** ae911056a115e86d1234cc095988c69d318764d0
 * 同模型RD 沟通，Seg 当前静态图需监控benchmark 分支，当框架的amp 和分布式训练稳定后 切到develop
 * 动态图当前使用develop 分支，新提的动态图修改也会到该分支，所以动态图还是develop 监控
 * 动态图数据(export FLAGS_cudnn_exhaustive_search=1)(单位 images/s)【动态图bs 为每张卡的bs，num_worker为每个卡的数值】：
    *  flag 开启时
          * deeplab 单卡 5.983 八卡 39.725
          * hrnet 单卡 7.516 八卡 42.299
    *  flag 未开启时
          * deeplab 单卡3.477 八卡 25.124
          * hrnet 单卡 7.023 八卡 41.121
 * 静态图数据见#940 

