### PR TITLE
add pytorch test case

### DIFF
--- a/api/dynamic_tests_v2/argsort.py
+++ b/api/dynamic_tests_v2/argsort.py
@@ -1,0 +1,42 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDArgsort(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        indices = paddle.argsort(
+            x=x, axis=config.axis, descending=config.descending)
+
+        self.feed_list = [x]
+        self.fetch_list = [indices]
+
+
+class TorchArgsort(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        indices = torch.argsort(
+            x=x, axis=config.axis, descending=config.descending)
+
+        self.feed_list = [x]
+        self.fetch_list = [indices]
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDArgsort(),
+        torch_obj=TorchArgsort(),
+        config=APIConfig("argsort"))

--- a/api/dynamic_tests_v2/argsort.py
+++ b/api/dynamic_tests_v2/argsort.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ class PDArgsort(PaddleDynamicAPIBenchmarkBase):
 
         self.feed_list = [x]
         self.fetch_list = [indices]
+        if config.backward:
+            self.append_gradients(indices, [x])
 
 
 class TorchArgsort(PytorchAPIBenchmarkBase):
@@ -34,6 +36,9 @@ class TorchArgsort(PytorchAPIBenchmarkBase):
         self.feed_list = [x]
         self.fetch_list = [indices]
 
+
+#        if config.backward:
+#            self.append_gradients(indices, [x])
 
 if __name__ == '__main__':
     test_main(

--- a/api/dynamic_tests_v2/argsort.py
+++ b/api/dynamic_tests_v2/argsort.py
@@ -23,8 +23,6 @@ class PDArgsort(PaddleDynamicAPIBenchmarkBase):
 
         self.feed_list = [x]
         self.fetch_list = [indices]
-        if config.backward:
-            self.append_gradients(indices, [x])
 
 
 class TorchArgsort(PytorchAPIBenchmarkBase):
@@ -36,9 +34,6 @@ class TorchArgsort(PytorchAPIBenchmarkBase):
         self.feed_list = [x]
         self.fetch_list = [indices]
 
-
-#        if config.backward:
-#            self.append_gradients(indices, [x])
 
 if __name__ == '__main__':
     test_main(

--- a/api/dynamic_tests_v2/avg_pool2d.py
+++ b/api/dynamic_tests_v2/avg_pool2d.py
@@ -1,0 +1,55 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDAvgPool2d(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.nn.functional.avg_pool2d(
+            x=x,
+            kernel_size=config.kernel_size,
+            stride=config.stride,
+            padding=config.padding,
+            ceil_mode=config.ceil_mode,
+            data_format=config.data_format)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchAvgPool2d(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.avg_pool2d(
+            input=x,
+            kernel_size=config.kernel_size,
+            stride=config.stride,
+            padding=config.padding,
+            ceil_mode=config.ceil_mode)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDAvgPool2d(),
+        torch_obj=TorchAvgPool2d(),
+        config=APIConfig('avg_pool2d'))

--- a/api/dynamic_tests_v2/conv2d_transpose.py
+++ b/api/dynamic_tests_v2/conv2d_transpose.py
@@ -1,0 +1,72 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDConv2dTranspose(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name="weight",
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+
+        result = paddle.nn.functional.conv2d_transpose(
+            x=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            output_padding=0,
+            dilation=config.dilation,
+            groups=1,
+            output_size=config.output_size,
+            data_format=config.data_format)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])
+
+
+class TorchConv2dTranspose(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name="weight",
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+
+        result = torch.nn.functional.conv_transpose2d(
+            input=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            output_padding=0,
+            dilation=config.dilation,
+            groups=1)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDConv2dTranspose(),
+        torch_obj=TorchConv2dTranspose(),
+        config=APIConfig("conv2d_transpose"))

--- a/api/dynamic_tests_v2/conv2d_transpose.py
+++ b/api/dynamic_tests_v2/conv2d_transpose.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,17 @@
 # limitations under the License.
 
 from common_import import *
+
+
+class Conv2dTransposeConfig(APIConfig):
+    def __init__(self):
+        super(Conv2dTransposeConfig, self).__init__("conv2d_transpose")
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(Conv2dTransposeConfig, self).init_from_json(filename, config_id,
+                                                          unknown_dim)
+        if self.groups == None:
+            self.groups = 1
 
 
 class PDConv2dTranspose(PaddleDynamicAPIBenchmarkBase):
@@ -31,7 +42,7 @@ class PDConv2dTranspose(PaddleDynamicAPIBenchmarkBase):
             padding=config.padding,
             output_padding=0,
             dilation=config.dilation,
-            groups=1,
+            groups=config.groups,
             output_size=config.output_size,
             data_format=config.data_format)
 
@@ -57,7 +68,7 @@ class TorchConv2dTranspose(PytorchAPIBenchmarkBase):
             padding=config.padding,
             output_padding=0,
             dilation=config.dilation,
-            groups=1)
+            groups=config.groups)
 
         self.feed_list = [x, weight]
         self.fetch_list = [result]
@@ -69,4 +80,4 @@ if __name__ == '__main__':
     test_main(
         pd_dy_obj=PDConv2dTranspose(),
         torch_obj=TorchConv2dTranspose(),
-        config=APIConfig("conv2d_transpose"))
+        config=Conv2dTransposeConfig())

--- a/api/dynamic_tests_v2/diag.py
+++ b/api/dynamic_tests_v2/diag.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/diag.py
+++ b/api/dynamic_tests_v2/diag.py
@@ -1,0 +1,50 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class DiagConfig(APIConfig):
+    def __init__(self):
+        super(DiagConfig, self).__init__("diag")
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(DiagConfig, self).init_from_json(filename, config_id,
+                                               unknown_dim)
+
+        if self.padding_value != 0:
+            self.run_torch = False
+
+
+class PDDiag(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.diag(
+            x=x, offset=config.offset, padding_value=config.padding_value)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+class TorchDiag(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.diag(input=x, diagonal=config.offset)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(pd_dy_obj=PDDiag(), torch_obj=TorchDiag(), config=DiagConfig())

--- a/api/dynamic_tests_v2/flip.py
+++ b/api/dynamic_tests_v2/flip.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/flip.py
+++ b/api/dynamic_tests_v2/flip.py
@@ -1,0 +1,46 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDFlip(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        dims = []
+        dims.append(config.axis)
+        result = paddle.flip(x=x, axis=dims)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchFlip(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        dims = []
+        dims.append(config.axis)
+        result = torch.flip(input=x, dims=dims)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDFlip(), torch_obj=TorchFlip(), config=APIConfig("flip"))

--- a/api/dynamic_tests_v2/floor.py
+++ b/api/dynamic_tests_v2/floor.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/floor.py
+++ b/api/dynamic_tests_v2/floor.py
@@ -1,0 +1,51 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class FloorConfig(APIConfig):
+    def __init__(self):
+        super(FloorConfig, self).__init__("floor")
+        self.feed_spec = {"range": [-1, 1]}
+        # Floor belongs to activation op series which only has one variable
+        # thus Floor can reuse activation parameters 
+        self.alias_name = "activation"
+
+
+class PDFloor(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.floor(x=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchFloor(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.floor(input=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDFloor(), torch_obj=TorchFloor(), config=FloorConfig())

--- a/api/dynamic_tests_v2/floor_divide.py
+++ b/api/dynamic_tests_v2/floor_divide.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/floor_divide.py
+++ b/api/dynamic_tests_v2/floor_divide.py
@@ -1,0 +1,47 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class FloorDivideConfig(APIConfig):
+    def __init__(self):
+        super(FloorDivideConfig, self).__init__("floor_divide")
+        self.feed_spec = [{"range": [1, 1000]}, {"range": [1, 1000]}]
+
+
+class PDFloorDivide(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
+        result = paddle.floor_divide(x=x, y=y)
+        self.feed_list = [x, y]
+        self.fetch_list = [result]
+
+
+class TorchFloorDivide(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
+        result = torch.floor_divide(input=x, other=y)
+
+        self.feed_list = [x, y]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDFloorDivide(),
+        torch_obj=TorchFloorDivide(),
+        config=FloorDivideConfig())

--- a/api/dynamic_tests_v2/isfinite_nan_inf.py
+++ b/api/dynamic_tests_v2/isfinite_nan_inf.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/isfinite_nan_inf.py
+++ b/api/dynamic_tests_v2/isfinite_nan_inf.py
@@ -1,0 +1,51 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class IsfiniteNanInfConfig(APIConfig):
+    def __init__(self):
+        super(IsfiniteNanInfConfig, self).__init__("isfinite_nan_inf")
+        self.api_name = 'isfinite'
+        self.api_list = {
+            'isfinite': 'isfinite',
+            'isnan': 'isnan',
+            'isinf': 'isinf'
+        }
+
+
+class PDIsfiniteNanInf(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = self.layers(config.api_name, x=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+class TorchIsfiniteNanInf(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = self.layers(config.api_name, x=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDIsfiniteNanInf(),
+        torch_obj=TorchIsfiniteNanInf(),
+        config=IsfiniteNanInfConfig())

--- a/api/dynamic_tests_v2/linspace.py
+++ b/api/dynamic_tests_v2/linspace.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/linspace.py
+++ b/api/dynamic_tests_v2/linspace.py
@@ -1,0 +1,43 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDLinspace(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        result = paddle.linspace(
+            start=config.start,
+            stop=config.stop,
+            num=config.num,
+            dtype=config.dtype)
+
+        self.feed_list = []
+        self.fetch_list = [result]
+
+
+class TorchgLinspace(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        result = torch.linspace(
+            start=config.start, end=config.stop, steps=config.num)
+
+        self.feed_list = []
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDLinspace(),
+        torch_obj=TorchgLinspace(),
+        config=APIConfig('linspace'))

--- a/api/dynamic_tests_v2/logsumexp.py
+++ b/api/dynamic_tests_v2/logsumexp.py
@@ -15,41 +15,36 @@
 from common_import import *
 
 
-class PDAvgPool2d(PaddleDynamicAPIBenchmarkBase):
+class LogsumexpConfig(APIConfig):
+    def __init__(self):
+        super(LogsumexpConfig, self).__init__('logsumexp')
+
+
+class PDLogsumexp(PaddleDynamicAPIBenchmarkBase):
     def build_graph(self, config):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
-        result = paddle.nn.functional.avg_pool2d(
-            x=x,
-            kernel_size=config.kernel_size,
-            stride=config.stride,
-            padding=config.padding,
-            ceil_mode=config.ceil_mode,
-            data_format=config.data_format)
+        result = paddle.logsumexp(x=x, axis=1)
 
         self.feed_list = [x]
         self.fetch_list = [result]
+
         if config.backward:
             self.append_gradients(result, [x])
 
 
-class TorchAvgPool2d(PytorchAPIBenchmarkBase):
+class TorchLogsumexp(PytorchAPIBenchmarkBase):
     def build_graph(self, config):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
-        result = torch.nn.functional.avg_pool2d(
-            input=x,
-            kernel_size=config.kernel_size,
-            stride=config.stride,
-            padding=config.padding,
-            ceil_mode=config.ceil_mode)
-
+        result = torch.logsumexp(input=x, dim=1)
         self.feed_list = [x]
         self.fetch_list = [result]
+
         if config.backward:
             self.append_gradients(result, [x])
 
 
 if __name__ == '__main__':
     test_main(
-        pd_dy_obj=PDAvgPool2d(),
-        torch_obj=TorchAvgPool2d(),
-        config=APIConfig('avg_pool2d'))
+        pd_dy_obj=PDLogsumexp(),
+        torch_obj=TorchLogsumexp(),
+        config=LogsumexpConfig())

--- a/api/dynamic_tests_v2/max_pool2d.py
+++ b/api/dynamic_tests_v2/max_pool2d.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/max_pool2d.py
+++ b/api/dynamic_tests_v2/max_pool2d.py
@@ -1,0 +1,55 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDMaxPool2d(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.nn.functional.max_pool2d(
+            x=x,
+            kernel_size=config.kernel_size,
+            stride=config.stride,
+            padding=config.padding,
+            ceil_mode=config.ceil_mode,
+            data_format=config.data_format)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchMaxPool2d(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.max_pool2d(
+            x,
+            kernel_size=config.kernel_size,
+            stride=config.stride,
+            padding=config.padding,
+            ceil_mode=config.ceil_mode)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDMaxPool2d(),
+        torch_obj=TorchMaxPool2d(),
+        config=APIConfig("max_pool2d"))

--- a/api/dynamic_tests_v2/remainder.py
+++ b/api/dynamic_tests_v2/remainder.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/remainder.py
+++ b/api/dynamic_tests_v2/remainder.py
@@ -32,6 +32,16 @@ class RemainderConfig(APIConfig):
             return True
         return super(RemainderConfig, self).disabled()
 
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(RemainderConfig, self).init_from_json(filename, config_id,
+                                                    unknown_dim)
+        if len(self.x_shape) > len(self.y_shape) and self.y_shape != [1]:
+            self.y_shape = unsqueeze_short(
+                short=self.y_shape, long=self.x_shape)
+        elif len(self.x_shape) < len(self.y_shape) and self.x_shape != [1]:
+            self.x_shape = unsqueeze_short(
+                short=self.x_shape, long=self.y_shape)
+
 
 class PDRemainder(PaddleDynamicAPIBenchmarkBase):
     def build_graph(self, config):

--- a/api/dynamic_tests_v2/remainder.py
+++ b/api/dynamic_tests_v2/remainder.py
@@ -1,0 +1,61 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class RemainderConfig(APIConfig):
+    def __init__(self):
+        super(RemainderConfig, self).__init__("remainder")
+        self.feed_spec = [{"range": [-1000, 1000]}, {"range": [1, 1000]}]
+        # abs belongs to activation op series which only has one parameter
+        # thus abs can reuse activation.json. 
+        self.alias_name = "elementwise"
+
+    def disabled(self):
+        if self.x_dtype == "float16":
+            print(
+                "Warning:\n"
+                "  1. This config is disabled because float16 is not supported for %s.\n"
+                % (self.api_name))
+            return True
+        return super(RemainderConfig, self).disabled()
+
+
+class PDRemainder(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
+        result = paddle.remainder(x=x, y=y)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+class TorchRemainder(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
+        y = y.detach()
+        result = torch.remainder(input=x, other=y)
+
+        self.feed_list = [x, y]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDRemainder(),
+        torch_obj=TorchRemainder(),
+        config=RemainderConfig())

--- a/api/dynamic_tests_v2/tile.py
+++ b/api/dynamic_tests_v2/tile.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/tile.py
+++ b/api/dynamic_tests_v2/tile.py
@@ -1,0 +1,42 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDTile(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.tile(x=x, repeat_times=config.repeat_times)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchTile(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.tile(x, config.repeat_times)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDTile(), torch_obj=TorchTile(), config=APIConfig("tile"))

--- a/api/tests_v2/configs/conv2d_transpose.json
+++ b/api/tests_v2/configs/conv2d_transpose.json
@@ -75,7 +75,7 @@
             "value": "2"
         }
     },
-    "atol": 1E-3
+    "atol": 1E-2
 }, {
     "op": "conv2d_transpose",
     "param_info": {

--- a/api/tests_v2/configs/conv2d_transpose.json
+++ b/api/tests_v2/configs/conv2d_transpose.json
@@ -36,7 +36,7 @@
             "value": "2"
         }
     },
-    "atol": 1E-4
+    "atol": 1E-2
 }, {
     "op": "conv2d_transpose",
     "param_info": {

--- a/api/tests_v2/configs/conv2d_transpose.json
+++ b/api/tests_v2/configs/conv2d_transpose.json
@@ -152,7 +152,7 @@
             "value": "2"
         }
     },
-    "atol": 1E-4
+    "atol": 1E-3
 }, {
     "op": "conv2d_transpose",
     "param_info": {

--- a/api/tests_v2/configs/conv2d_transpose.json
+++ b/api/tests_v2/configs/conv2d_transpose.json
@@ -75,7 +75,7 @@
             "value": "2"
         }
     },
-    "atol": 1E-2
+    "atol": 1E-1
 }, {
     "op": "conv2d_transpose",
     "param_info": {

--- a/api/tests_v2/configs/logsumexp.json
+++ b/api/tests_v2/configs/logsumexp.json
@@ -15,5 +15,6 @@
             "shape": "[1024L, 512L]",
             "type": "Variable"
         }
-    }
+    },
+    "atol": 1E-5
 }]


### PR DESCRIPTION
add argsort、avg_pool2d、conv2d_transpose、diag、flip、floor、 floor_divide、 isfinite、isnan、isinf、linspace、 max_pool2d、 remainder、 tile dynamic test case

说明：
1. conv2d_transpose的config_id=0, 在GPU下，与pytorch的diff较大，详见 [【DLTP-23783】](https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-23783/show?source=planTrack-drawer-menu)
结论：conv2d_tranpose的diff 3.296e-3，在正常的范围之内(跟性能同学确认)，将config_id=0的atol=1e-4修改为1e-2
2. argsort的config_id=1, 在GPU下，与pytorch的diff非常大 ，详见 [【DLTP23784】](https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-23784/show?source=planTrack-drawer-menu)
原因：输入里面存在相同的元素值的时候，paddle和tf、pytorch选取的元素位置不一样
3. torch.tile 仅在torch=1.8.0下存在，在torch=1.7.0不存在，https://pytorch.org/docs/stable/generated/torch.tile.html?highlight=tile#torch.tile ， 目前的CI环境是1.7.0，故会报错；
结论：CI已修改torch=1.7.0为torch=1.8.0；
4. 在过benchmark_CI的过程中， conv2d_transpose在config_id=1、3和logsumexp在config_id=1下的diff是有波动的。
   (1) conv2d_transpose的config_id=1下的diff达到1.172e-02，故将该配置的atol从1e-3调整到1e-1
   (2) conv2d_transpose的config_id=3下的diff达到7.324e-04, 故将该配置的atol从1e-4调整到1e-3
   (3) logsumexp在在config_id=1下的diff达到1.431e-06，故将该配置的atol从1e-6调整到1e-5