### PR TITLE
Enable the use of multi-processes for data loading.

### DIFF
--- a/static_graph/seg_models/paddle/run_benchmark.sh
+++ b/static_graph/seg_models/paddle/run_benchmark.sh
@@ -57,6 +57,7 @@ function _train(){
 
     train_cmd="--cfg=${config}
                --use_gpu
+               --use_mpio
                BATCH_SIZE ${batch_size}
                DATALOADER.NUM_WORKERS 2
                SOLVER.NUM_EPOCHS 1"


### PR DESCRIPTION
平台上hrnet静态图单卡的性能是7.388 images/s。
PaddleSeg中静态图使用老版本的DataLoader，底层基于py_reader op，训练是需要设置`--use_mpio`参数，才会使用multiprocess_reader并使用NUM_WORKER个进程来读取数据。设置了`--use_mpio`参数后，hrnet单卡训练性能可达到11.773 images/s。
