### PR TITLE
Avoid initializing running_mean and running_var repeatly in batch_norm script.

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -313,9 +313,8 @@ class APIConfig(object):
             'api_list', 'variable_list', 'params_list', 'backward',
             'feed_spec', 'alias_name'
         ]
-        if self.framework == "tensorflow":
+        if self.framework != "paddle":
             exclude_attrs.append("run_torch")
-        elif self.framework == "pytorch":
             exclude_attrs.append("run_tf")
         prefix = ""
         debug_str = ('[%s][%s] %s {\n') % (self.framework, self.name,

--- a/api/tests_v2/configs/batch_norm.json
+++ b/api/tests_v2/configs/batch_norm.json
@@ -1,4 +1,5 @@
 [{
+    "config_id": 0,
     "op": "batch_norm",
     "param_info": {
         "data_format": {
@@ -24,6 +25,7 @@
         }
     }
 }, {
+    "config_id": 1,
     "op": "batch_norm",
     "param_info": {
         "data_format": {
@@ -49,6 +51,7 @@
         }
     }
 }, {
+    "config_id": 2,
     "op": "batch_norm",
     "param_info": {
         "data_format": {
@@ -75,6 +78,7 @@
     },
     "repeat": 5000
 }, {
+    "config_id": 3,
     "op": "batch_norm",
     "param_info": {
         "data_format": {
@@ -98,8 +102,10 @@
             "type": "float",
             "value": "0.99"
         }
-    }
+    },
+    "repeat": 5000
 }, {
+    "config_id": 4,
     "op": "batch_norm",
     "param_info": {
         "data_format": {


### PR DESCRIPTION
- 减少动态图batch_norm测试脚本中，反复定义和初始化running_mean和running_var的开销，具体原因在脚本中有解释。