### PR TITLE
add dist op

### DIFF
--- a/api/dynamic_tests_v2/dist.py
+++ b/api/dynamic_tests_v2/dist.py
@@ -1,0 +1,44 @@
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class PDDist(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
+        result = paddle.dist(x=x, y=y, p=config.p)
+
+        self.feed_list = [x, y]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, self.feed_list)
+
+
+class TorchDist(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
+        result = torch.dist(input=x, other=y, p=config.p)
+
+        self.feed_list = [x, y]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, self.feed_list)
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDDist(), torch_obj=TorchDist(), config=APIConfig("dist"))

--- a/api/tests_v2/configs/dist.json
+++ b/api/tests_v2/configs/dist.json
@@ -1,0 +1,56 @@
+[{
+    "op": "dist",
+    "param_info": {
+        "p": {
+            "type": "float",
+            "value": "2"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1000L, 1000L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[1000L, 1000L]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.5
+}, {
+    "op": "dist",
+    "param_info": {
+        "p": {
+            "type": "float",
+            "value": "inf"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1000L, 1000L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[1000L, 1000L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "dist",
+    "param_info": {
+        "p": {
+            "type": "float",
+            "value": "0"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1000L, 1000L]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[1000L, 1000L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/dist.py
+++ b/api/tests_v2/dist.py
@@ -1,0 +1,37 @@
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class DistConfig(APIConfig):
+    def __init__(self):
+        super(DistConfig, self).__init__("dist")
+        self.run_tf = False
+
+
+class PDDist(PaddleAPIBenchmarkBase):
+    def build_program(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
+        result = paddle.dist(x=x, y=y, p=config.p)
+
+        self.feed_vars = [x, y]
+        self.fetch_vars = [result]
+        if config.backward:
+            self.append_gradients(result, [x, y])
+
+
+if __name__ == '__main__':
+    test_main(PDDist(), config=DistConfig())


### PR DESCRIPTION
x_shape=[1000, 1000], y_shape=[1000, 1000], p=2

- torch
```
             Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   41.79%  4.8713ms       303  16.076us  14.944us  17.216us  void at::native::vectorized_elementwise_kernel<int=4, at::native::AddFunctor<float>, at::detail::Array<char*, int=3>>(int, float, at::native::AddFunctor<float>)
                   17.76%  2.0702ms         2  1.0351ms  755.68us  1.3146ms  [CUDA memcpy HtoD]
                   16.93%  1.9734ms       202  9.7690us  9.3440us  14.304us  void at::native::unrolled_elementwise_kernel<at::native::MulFunctor<float>, at::detail::Array<char*, int=3>, OffsetCalculator<int=2, unsigned int>, OffsetCalculator<int=1, unsigned int>, at::native::memory::LoadWithoutCast, at::native::memory::StoreWithoutCast>(int, float, at::native::MulFunctor<float>, char*, int=3, at::detail::Array<char*, int=3>, int=2)
                    7.43%  866.43us       101  8.5780us  8.2880us  8.9600us  _ZN2at6native29vectorized_elementwise_kernelILi4EZZZNS0_15neg_kernel_cudaERNS_14TensorIteratorEENKUlvE_clEvENKUlvE6_clEvEUlfE_NS_6detail5ArrayIPcLi2EEEEEviT0_T1_
                    6.69%  779.97us       101  7.7220us  7.4880us  9.6640us  void at::native::reduce_kernel<int=512, int=1, at::native::ReduceOp<float, at::native::NormTwoOps<float, float>, unsigned int, float, int=4>>(float)
                    3.11%  362.14us       202  1.7920us  1.6960us  6.9120us  void at::native::vectorized_elementwise_kernel<int=4, at::native::DivFunctor<float>, at::detail::Array<char*, int=3>>(int, float, at::native::DivFunctor<float>)
                    2.37%  276.45us       202  1.3680us  1.1520us  10.080us  void kernelPointwiseApply2<TensorMaskedFillOp<float, bool>, float, bool, unsigned int, int=1, int=1>(OffsetInfo<bool, float, bool>, OffsetInfo<TensorMaskedFillOp<float, bool>, float, unsigned int>, float, float)
                    2.34%  272.90us       202  1.3500us  1.3120us  1.9200us  void at::native::vectorized_elementwise_kernel<int=4, at::native::BUnaryFunctor<at::native::CompareEqFunctor<float>>, at::detail::Array<char*, int=2>>(int, float, at::native::CompareEqFunctor<float>)
                    1.57%  183.46us       101  1.8160us  1.6640us  7.8400us  [CUDA memset]
                    0.01%  1.4400us         1  1.4400us  1.4400us  1.4400us  void at::native::vectorized_elementwise_kernel<int=4, at::native::FillFunctor<float>, at::detail::Array<char*, int=1>>(int, float, at::native::FillFunctor<float>)

percent: 0.42; gpu_time: 4.8713 ms; calls: 303; function: void at::native::vectorized_elementwise_kernel<int=4, at::native::AddFunctor<float>, at::detail::Array<char*, int=3>>(int, float, at::native::AddFunctor<float>)
total gpu_time: 11.6566 ms
```
  - paddle
```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   50.23%  10.275ms       101  101.73us  100.54us  103.55us  void Eigen::internal::FullReductionKernel<int=256, int=128, Eigen::TensorReductionEvaluatorBase<Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DimensionList<long, unsigned long=2> const , Eigen::TensorCwiseUnaryOp<Eigen::internal::bind2nd_op<Eigen::internal::scalar_pow_op<float, float>>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const > const , Eigen::MakePointer> const , Eigen::GpuDevice>, Eigen::internal::SumReducer<float>, long>(Eigen::internal::SumReducer<float>, float, long, Eigen::internal::SumReducer<float>::CoeffReturnType*, unsigned int*)
                   20.65%  4.2247ms       101  41.828us  40.832us  45.344us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=2, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float, float>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float, float>, Eigen::TensorCwiseUnaryOp<Eigen::internal::bind2nd_op<Eigen::internal::scalar_pow_op<float, float>>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_quotient_op<float, float>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorCwiseUnaryOp<Eigen::internal::bind2nd_op<Eigen::internal::scalar_sum_op<float const , float const >>, Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const > const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_sum_op<float, float>, Eigen::TensorCwiseUnaryOp<Eigen::internal::bind2nd_op<Eigen::internal::scalar_product_op<float, float>>, Eigen::TensorConversionOp<float, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_cmp_op<float, float, Eigen::internal::ComparisonName>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const > const > const > const , Eigen::TensorCwiseUnaryOp<Eigen::internal::bind2nd_op<Eigen::internal::scalar_product_op<float, float>>, Eigen::TensorConversionOp<float, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_cmp_op<float, float, Eigen::internal::ComparisonName>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const > const > const > const > const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const , Eigen::GpuDevice>
                    8.04%  1.6444ms       101  16.281us  15.616us  17.216us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=2, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_opposite_op<float>, Eigen::TensorReshapingOp<Eigen::DSizes<long, int=2> const , Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DSizes<int, int=2> const , Eigen::TensorReshapingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float, int=2, int=1, long>, int=0, Eigen::MakePointer>> const , Eigen::MakePointer> const > const > const > const , Eigen::GpuDevice>, long>(float, int=2)
                    7.98%  1.6321ms       101  16.158us  15.520us  17.887us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=2, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorReshapingOp<Eigen::DSizes<long, int=2> const , Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DSizes<int, int=2> const , Eigen::TensorReshapingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float, int=2, int=1, long>, int=0, Eigen::MakePointer>> const , Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=2)
                    7.21%  1.4741ms        10  147.41us  1.6960us  730.88us  [CUDA memcpy HtoD]
                    5.85%  1.1959ms       101  11.840us  11.584us  13.056us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseUnaryOp<Eigen::internal::bind2nd_op<Eigen::internal::scalar_pow_op<float, float>>, Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DimensionList<long, unsigned long=2> const , Eigen::TensorCwiseUnaryOp<Eigen::internal::bind2nd_op<Eigen::internal::scalar_pow_op<float, float>>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const > const , Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                    0.04%  8.3840us         5  1.6760us  1.5680us  1.9200us  [CUDA memset]
                    0.01%  1.4080us         1  1.4080us  1.4080us  1.4080us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)

percent: 0.50; gpu_time: 10.2750 ms; calls: 101; function: void Eigen::internal::FullReductionKernel<int=256, int=128, Eigen::TensorReductionEvaluatorBase<Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DimensionList<long, unsigned long=2> const , Eigen::TensorCwiseUnaryOp<Eigen::internal::bind2nd_op<Eigen::internal::scalar_pow_op<float, float>>, Eigen::TensorCwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const > const , Eigen::MakePointer> const , Eigen::GpuDevice>, Eigen::internal::SumReducer<float>, long>(Eigen::internal::SumReducer<float>, float, long, Eigen::internal::SumReducer<float>::CoeffReturnType*, unsigned int*)
total gpu_time: 20.4559 ms
```