### PR TITLE
【dont merge】update_seq2seq_models,  test=document_fix

### DIFF
--- a/dynamic_graph/seq2seq/paddle/run_benchmark.sh
+++ b/dynamic_graph/seq2seq/paddle/run_benchmark.sh
@@ -39,39 +39,16 @@ function _set_params(){
 }
 
 function _train(){
-    train_cmd_en_vi="--src_lang en --tar_lang vi \
-                     --attention True \
-                     --num_layers 2 \
-                     --hidden_size 512 \
-                     --src_vocab_size 17191 \
-                     --tar_vocab_size 7709 \
-                     --batch_size ${base_batch_size} \
-                     --dropout 0.2 \
-                     --init_scale  0.1 \
-                     --max_grad_norm 5.0 \
-                     --train_data_prefix data/en-vi/train \
-                     --eval_data_prefix data/en-vi/tst2012 \
-                     --test_data_prefix data/en-vi/tst2013 \
-                     --vocab_prefix data/en-vi/vocab \
-                     --use_gpu True \
-                     --max_epoch ${max_epoch} \
-                     --model_path attention_models"
-    train_cmd_de_en="--src_lang de --tar_lang en \
-                     --attention True \
+    train_cmd_de_en="
                      --num_layers 4 \
                      --hidden_size 1000 \
-                     --src_vocab_size 8847 \
-                     --tar_vocab_size 6631 \
                      --batch_size ${base_batch_size} \
                      --dropout 0.2 \
                      --init_scale  0.1 \
                      --max_grad_norm 5.0 \
-                     --train_data_prefix data/iwslt14.tokenized.de-en/train \
-                     --eval_data_prefix data/iwslt14.tokenized.de-en/valid \
-                     --test_data_prefix data/iwslt14.tokenized.de-en/test \
-                     --vocab_prefix data/iwslt14.tokenized.de-en/vocab \
-                     --use_gpu True \
+                     --device gpu \
                      --max_epoch ${max_epoch} \
+                     --log_freq 50
                      --model_path attention_models"
 
     timeout 15m python -u train.py ${train_cmd_de_en} > ${log_file} 2>&1

--- a/scripts/dynamic_graph_models.sh
+++ b/scripts/dynamic_graph_models.sh
@@ -71,7 +71,7 @@ dy_mobilenet(){
 
 # seq2seq
 dy_seq2seq(){
-    cur_model_path=${BENCHMARK_ROOT}/models/dygraph/seq2seq
+    cur_model_path=${BENCHMARK_ROOT}/PaddleNLP/examples/machine_translation/seq2seq
     cd ${cur_model_path}
 
     # Prepare data


### PR DESCRIPTION
 * seq2seq 模型迁移到套件
 * 存在问题
   *  模型调用hapi 后，log单位是samples/s，不符合性能统计规范。需模型方和hapi 给出具体方案
   *  套件下模型参数和models 下参数相比有较大的diff,
        models 如
<img width="789" alt="图片" src="https://user-images.githubusercontent.com/52739577/120316003-877d6580-c30f-11eb-95a0-7ce07c5a006c.png">

<img width="940" alt="图片" src="https://user-images.githubusercontent.com/52739577/120316122-aa0f7e80-c30f-11eb-89fe-1a31a2d269a1.png">
        这样一来，需模型重新提供一个可与套件内模型对比的竞品版本
