### PR TITLE
fix dynamic models PPOCR_mobile_2.0, test=document_fix

### DIFF
--- a/scripts/dynamic_graph_models.sh
+++ b/scripts/dynamic_graph_models.sh
@@ -459,6 +459,14 @@ dy_lac(){
 dy_ppocr_mobile_2() {
     cur_model_path=${BENCHMARK_ROOT}/PaddleOCR
     cd ${cur_model_path}
+
+    if python -c "import pooch" >/dev/null 2>&1; then
+        echo "pooch have already installed, need uninstall"
+        pip uninstall -y pooch
+    else
+        echo "pooch not installed"
+    fi
+
     package_check_list=(shapely scikit-image imgaug pyclipper lmdb tqdm numpy visualdl python-Levenshtein)
     for package in ${package_check_list[@]}; do
         if python -c "import ${package}" >/dev/null 2>&1; then


### PR DESCRIPTION
修复PPOCR模型运行时，额外包含了pooch第三方库会导致模型运行失败的问题。