### PR TITLE
fix_seq2seq_and_gan model benchmark failed

### DIFF
--- a/dynamic_graph/gan_models/paddle/run_benchmark.sh
+++ b/dynamic_graph/gan_models/paddle/run_benchmark.sh
@@ -13,6 +13,7 @@ function _set_params(){
     base_batch_size=1
     run_mode=${2:-"sp"} # Use sp for single GPU and mp for multiple GPU.
     model_name=${3}_bs${base_batch_size}
+    model=${3}
     max_epoch=${4:-"1"}
     if [ ${3} != "CycleGAN" ] && [ ${3} != "Pix2pix" ]; then
         echo "Please check the model name! it should be CycleGAN|Pix2pix"
@@ -41,8 +42,11 @@ function _set_params(){
 
 function _train(){
     export PYTHONPATH=$PWD:$PYTHONPATH
-   
-    train_cmd=" --config-file configs/$(echo ${model_name%_bs*} | tr '[A-Z]' '[a-z]')_cityscapes.yaml -o log_config.interval=100 epochs=1 validate.interval=-1"
+    if [ ${model} = "CycleGAN" ]; then
+        train_cmd=" --config-file configs/$(echo ${model_name%_bs*} | tr '[A-Z]' '[a-z]')_cityscapes.yaml -o log_config.interval=100 epochs=1"
+    else
+        train_cmd=" --config-file configs/$(echo ${model_name%_bs*} | tr '[A-Z]' '[a-z]')_cityscapes.yaml -o log_config.interval=100 epochs=1 validate.interval=-1"
+    fi
     if [ ${run_mode} = "sp" ]; then
         train_cmd="python -u tools/main.py "${train_cmd}
     else

--- a/scripts/dynamic_graph_models.sh
+++ b/scripts/dynamic_graph_models.sh
@@ -101,7 +101,7 @@ dy_seq2seq(){
     cp ${BENCHMARK_ROOT}/dynamic_graph/seq2seq/paddle/run_benchmark.sh ./
     sed -i '/set\ -xe/d' run_benchmark.sh
     echo "index is speed, 1gpu begin"
-    CUDA_VISIBLE_DEVICES=5 bash run_benchmark.sh 1 2 | tee ${log_path}/dynamic_seq2seq_bs128_speed_1gpus 2>&1
+    CUDA_VISIBLE_DEVICES=5 bash run_benchmark.sh 1 1 | tee ${log_path}/dynamic_seq2seq_bs128_speed_1gpus 2>&1
 }
 
 # ptb


### PR DESCRIPTION
修复benchmark动态图失败任务：
1. seq2seq模型失败是运行时间过程，导致被kill，修改方式，运行的epoch次数从2修改到1。
2. gan模型是针对CycleGAN模型时，配置文件中没有validate字段，主动传入后会导致运行异常。