### PR TITLE
Update nlp version 0723

### DIFF
--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -199,6 +199,7 @@ function run_models(){
             -e "DEVICE_TYPE=${device_type}" \
             -e "VERSION_CUDA=${cuda_version}" \
             --net=host \
+            --privileged \
             --shm-size=128G \
             ${RUN_IMAGE_NAME} \
             /bin/bash -c "${run_cmd}"
@@ -222,6 +223,7 @@ function run_models(){
             -e "DEVICE_TYPE=${device_type}" \
             -e "VERSION_CUDA=${cuda_version}" \
             --net=host \
+            --privileged \
             --shm-size=128G \
             ${RUN_IMAGE_NAME} \
             /bin/bash -c "${run_cmd}"
@@ -242,6 +244,7 @@ function run_models(){
             -e "DEVICE_TYPE=${device_type}" \
             -e "VERSION_CUDA=${cuda_version}" \
             --net=host \
+            --privileged \
             --shm-size=128G \
             ${RUN_IMAGE_NAME} \
             /bin/bash -c "${run_cmd}"

--- a/scripts/dynamic_graph_models.sh
+++ b/scripts/dynamic_graph_models.sh
@@ -125,7 +125,8 @@ dy_ptb_medium(){
 # transformer
 dy_transformer(){
     echo "###########pip install paddlenlp"
-    pip install paddlenlp attrdict
+    pip install paddlenlp==2.0.5 # 20210723：nlp API不兼容升级，导致模型报错；暂时使用paddlenlp=2.0.5版本；后续进行子库代码升级
+    pip install attrdict
     cur_model_path=${BENCHMARK_ROOT}/PaddleNLP/examples/machine_translation/transformer
     cd ${cur_model_path}
     # prepare data

--- a/scripts/static_graph_models.sh
+++ b/scripts/static_graph_models.sh
@@ -260,7 +260,8 @@ bert(){
 
 #run_transformer
 transformer(){
-    pip install paddlenlp attrdict
+    pip install paddlenlp==2.0.5 # 20210723：nlp API不兼容升级，导致模型报错；暂时使用paddlenlp=2.0.5版本；后续进行子库代码升级
+    pip install attrdict
     cur_model_path=${BENCHMARK_ROOT}/PaddleNLP/examples/machine_translation/transformer/static
     cd ${cur_model_path}
     # prepare data


### PR DESCRIPTION
20210723：nlp API不兼容升级，导致模型报错；暂时使用paddlenlp=2.0.5版本；后续进行子库代码升级