### PR TITLE
[Fix message]: Fix the warning message of data_format in conv2d.py

### DIFF
--- a/api/dynamic_tests_v2/conv2d.py
+++ b/api/dynamic_tests_v2/conv2d.py
@@ -43,7 +43,7 @@ class Conv2dConfig(APIConfig):
         if self.data_format == 'NHWC':
             print(
                 "Warning:\n"
-                "  1. PyTorch does not have data_format param, it only support NHWC format.\n"
+                "  1. PyTorch does not have data_format param, it only support NCHW format.\n"
             )
             self.run_torch = False
 


### PR DESCRIPTION
Fix the warning message of data_format in conv2d.py while testing pytorch framework,  owing to that pytorch does not support "nhwc"  type convolution operation.