### PR TITLE
add time-consuming configuration of general model

### DIFF
--- a/api/tests_v2/model_configs/bmm.json
+++ b/api/tests_v2/model_configs/bmm.json
@@ -1,0 +1,43 @@
+[{
+    "op": "bmm",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 32768, 19]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[2, 19, 256]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "bmm",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 19, 32768]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[2, 32768, 512]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "bmm",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 32768, 256]",
+            "type": "Variable"
+        },
+        "y": {
+            "dtype": "float32",
+            "shape": "[2, 256, 19]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/model_configs/conv1d.json
+++ b/api/tests_v2/model_configs/conv1d.json
@@ -1,0 +1,841 @@
+[{
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[64, 1, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 1, 25500]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[80, 80, 5]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 80, 89]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128, 64, 3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "2"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 64, 25500]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "2"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128, 64, 3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "4"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 64, 25500]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "4"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128, 64, 3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "8"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 64, 25500]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "8"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128, 64, 3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "16"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 64, 25500]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "16"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128, 64, 3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "32"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 64, 25500]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "32"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128, 64, 3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 64, 25500]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128, 64, 3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "64"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 64, 25500]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "64"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128, 64, 3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "128"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 64, 25500]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "128"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128, 64, 3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "256"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 64, 25500]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "256"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128, 64, 3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "512"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 64, 25500]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "512"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[512, 256, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 36]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[256, 256, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 46]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[512, 256, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 40]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[256, 256, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 40]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[512, 256, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 52]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[256, 256, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 36]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[256, 1, 15]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "7"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "256"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 40]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[256, 256, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 38]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[512, 256, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 53]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[512, 256, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 47]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[256, 256, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 52]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[512, 256, 1]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCL"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 43]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.01,
+    "op": "conv1d"
+}]

--- a/api/tests_v2/model_configs/depthwise_conv2d.json
+++ b/api/tests_v2/model_configs/depthwise_conv2d.json
@@ -1,0 +1,911 @@
+[{
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "128"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,128,256,256]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[640,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "640"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,640,64,64]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[256,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "256"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,256,128,128]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[1024,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "1024"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,1024,32,32]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "128"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,128,256,256]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[1024,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "1024"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,1024,32,32]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[640,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "640"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,640,64,64]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[256,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "256"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,256,128,128]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[3,1,13,13]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "3"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,3,268,268]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[3,1,5,5]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "3"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,3,260,260]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[3,1,29,29]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "0"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "3"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,3,284,284]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[576,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "576"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,576,32,32]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[384,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "384"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,384,64,64]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[384,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "groups": {
+            "type": "long",
+            "value": "384"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,384,64,64]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[768,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "768"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,768,32,32]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "128"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,128,128,128]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[32,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "groups": {
+            "type": "long",
+            "value": "32"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,32,512,512]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[32,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "groups": {
+            "type": "long",
+            "value": "32"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,32,512,512]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[128,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "128"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,128,128,128]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[384,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "384"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,384,64,64]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[48,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "groups": {
+            "type": "long",
+            "value": "48"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,48,256,256]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[384,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "groups": {
+            "type": "long",
+            "value": "384"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,384,64,64]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[768,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "768"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,768,32,32]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[384,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "groups": {
+            "type": "long",
+            "value": "384"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,384,128,128]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[576,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "1"
+        },
+        "groups": {
+            "type": "long",
+            "value": "576"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,576,32,32]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}, {
+    "param_info": {
+        "weight": {
+            "dtype": "float32",
+            "shape": "[48,1,3,3]",
+            "type": "Variable"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "padding": {
+            "type": "int",
+            "value": "1"
+        },
+        "stride": {
+            "type": "int",
+            "value": "2"
+        },
+        "groups": {
+            "type": "long",
+            "value": "48"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,48,256,256]",
+            "type": "Variable"
+        },
+        "dilation": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "atol": 0.0001,
+    "op": "depthwise_conv2d"
+}]

--- a/api/tests_v2/model_configs/dropout.json
+++ b/api/tests_v2/model_configs/dropout.json
@@ -1,0 +1,379 @@
+[{
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,36,2048]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,40,2048]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,38,2048]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,42,2048]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,36,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,36,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,6,2048]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,6,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,43,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,43,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,42,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,7,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,38,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,40,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float16",
+            "shape": "[8,12,1024,1024]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float16",
+            "shape": "[8,1024,768]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,1024,768]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,12,1024,1024]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "string",
+            "value": "None"
+        },
+        "mode": {
+            "type": "string",
+            "value": "upscale_in_train"
+        },
+        "p": {
+            "type": "float",
+            "value": "0.1"
+        }
+    },
+    "op": "dropout"
+}]

--- a/api/tests_v2/model_configs/elementwise_div.json
+++ b/api/tests_v2/model_configs/elementwise_div.json
@@ -1,0 +1,419 @@
+[{
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[196,8,768]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,1569,768]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,197,768]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,1024,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,4096,160]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,65536,32]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,16384,64]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,3,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,3,32,32]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,3,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,3,64,64]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,3,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,3,128,128]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,3,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,3,256,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,1,4,1,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,13475,8,4,4,2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,1,4,1,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,17821,8,4,4,2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,1,4,1,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,8223,8,4,4,2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,1,4,1,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,10647,8,4,4,2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,1,4,1,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,14740,8,4,4,2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,1,4,1,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,300,8,4,4,2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,1,4,1,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,14145,8,4,4,2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,1,4,1,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,16742,8,4,4,2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,1,4,1,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,16320,8,4,4,2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,1,4,1,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,14105,8,4,4,2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}]

--- a/api/tests_v2/model_configs/elementwise_mul.json
+++ b/api/tests_v2/model_configs/elementwise_mul.json
@@ -1,0 +1,856 @@
+[{
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[196,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[196,8,768]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,1569,768]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[8,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,197,768]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[2,256,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,256,256,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[2,1024,1024]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,1024,1024]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[2,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,4096,160]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[2,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,1024,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[2,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,65536,32]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[2,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,16384,64]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,58,58,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,10,58,58,1]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[8,1,25]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,10,25]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[8,11,1,64,64]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,11,2,64,64]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[8,1,64,64]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,256,64,64]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[8,10,4,58,58]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,10,4,58,58]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[8,10,25]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8,10,25]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,512,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,512,512,3,3]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[3,1,512,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,512,512,3,3]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,512,512,3,3]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,512,512,3,3]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[3,1,16,16]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,1,512,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,256,512,3,3]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[3,1,512,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,3,512,1,1]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1,256,512,3,3]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,256,512,3,3]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[3,1,128,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,128,128,3,3]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[3,1,256,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,128,256,3,3]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[3,1,512,1,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,256,512,3,3]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,1,1,7]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "0"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[80]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[80,80,5]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "0"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,1,1,9]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "0"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[512]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6,511,512]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[6,64,25500]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6,64,25500]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1,64,1]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "0"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[128]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[128,80,1]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "0"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[2048]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[6,107,2048]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[128]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[128,64,3]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "0"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[64]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[64,64,1]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "0"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[16,1,13475,16]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,32,13475,16]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[16,1,20069,16]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,32,20069,16]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[16,1,19947,16]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,32,19947,16]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[16,1,18360,16]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,32,18360,16]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[16,1,15637,16]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,32,15637,16]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[2,1,4,2]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,300,1,2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[16,1,17546,16]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,32,17546,16]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[16,1,17821,16]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,32,17821,16]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[2,13475,1]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2,13475,256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}, {
+    "param_info": {
+        "y": {
+            "dtype": "float32",
+            "shape": "[16,1,300,16]",
+            "type": "Variable"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16,32,300,16]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        }
+    },
+    "atol": 0.00001,
+    "op": "elementwise"
+}]

--- a/api/tests_v2/model_configs/gelu.json
+++ b/api/tests_v2/model_configs/gelu.json
@@ -1,0 +1,170 @@
+[{
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[64L,784L,768L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[14L,1569L,3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[64L,196L,1536L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[64L,3136L,384L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2L,1024L,1024L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "True"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[8L,1024L,3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "True"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8L,1024L,3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2L,65536L,128L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2L,16384L,256L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2L,4096L,640L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[128L,32L,3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[64L,49L,3072L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "gelu",
+    "param_info": {
+        "approximate": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1L,1569L,3072L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/model_configs/group_norm.json
+++ b/api/tests_v2/model_configs/group_norm.json
@@ -1,0 +1,441 @@
+[{
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 38, 26]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 152, 104]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 76, 52]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 25, 33]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 100, 132]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 50, 66]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 10, 11]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 13, 13]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 144, 128]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 74, 68]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 128, 25, 42]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 128, 70, 76]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 280, 304]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 304, 232]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 128, 35, 38]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 272, 312]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 320, 312]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 256, 280, 200]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 128, 140, 152]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}, {
+    "param_info": {
+        "num_groups": {
+            "type": "int",
+            "value": "32"
+        },
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "data_format": {
+            "type": "string",
+            "value": "NCHW"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 128, 136, 156]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "group_norm"
+}]

--- a/api/tests_v2/model_configs/index_select.json
+++ b/api/tests_v2/model_configs/index_select.json
@@ -1,0 +1,19 @@
+[{
+    "op": "index_select",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": 3
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[32, 12, 128, 255]",
+            "type": "Variable"
+        },
+        "index": {
+            "dtype": "int64",
+            "shape": "[128]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/model_configs/layer_norm.json
+++ b/api/tests_v2/model_configs/layer_norm.json
@@ -1,0 +1,197 @@
+[{
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 1024, 768]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 65536, 32]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-06"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 65536, 32]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 1024, 32]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 16384, 64]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-06"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 16384, 64]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 4096, 160]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-06"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 4096, 160]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 1024, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1, 65536, 32]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-06"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 1024, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 1024, 160]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 1024, 64]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-05"
+        },
+        "x": {
+            "dtype": "float16",
+            "shape": "[8, 1024, 768]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}]

--- a/api/tests_v2/model_configs/layer_norm.json
+++ b/api/tests_v2/model_configs/layer_norm.json
@@ -16,6 +16,216 @@
     "param_info": {
         "epsilon": {
             "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 43, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 40, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 36, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 57, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 52, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 81, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 74, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 55, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 45, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 83, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 48, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 47, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 9, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 56, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
+            "value": "1e-12"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 8, 256]",
+            "type": "Variable"
+        }
+    },
+    "atol": 0.00001,
+    "op": "layer_norm"
+}, {
+    "param_info": {
+        "epsilon": {
+            "type": "float",
             "value": "1e-05"
         },
         "x": {

--- a/api/tests_v2/model_configs/slice.json
+++ b/api/tests_v2/model_configs/slice.json
@@ -1,0 +1,421 @@
+[{
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[4, 5, 64, 16, 16]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[0]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[4, 5, 64, 64, 64]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[3]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[2]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[4, 5, 64, 32, 32]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[5]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[4]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[4, 216, 16, 16]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[72]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[0]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[4, 216, 32, 32]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[216]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[144]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[4, 5, 64, 64, 64]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[0]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[4, 216, 16, 16]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[216]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[144]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[4, 5, 64, 32, 32]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[3]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[2]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[4, 5, 64, 64, 64]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[2]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[1]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[4, 5, 64, 32, 32]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[0]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[3, 112, 12, 197, 64]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[3]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[0]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[2]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[14, 1569, 768]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[1569]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[1]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[112, 197, 768]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[197]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[1]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[3, 112, 12, 197, 64]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[0]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[0]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[3, 2744, 12, 8, 64]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[3]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[0]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[2]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[3, 2744, 12, 8, 64]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[0]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[0]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[3, 112, 12, 197, 64]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[2]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[0]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[1]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[14, 1569, 768]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[0]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[3, 2744, 12, 8, 64]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[2]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[0]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[1]"
+        }
+    },
+    "op": "slice"
+}, {
+    "param_info": {
+        "input": {
+            "dtype": "float32",
+            "shape": "[112, 197, 768]",
+            "type": "Variable"
+        },
+        "ends": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "axes": {
+            "type": "list",
+            "value": "[1]"
+        },
+        "starts": {
+            "type": "list",
+            "value": "[0]"
+        }
+    },
+    "op": "slice"
+}]

--- a/api/tests_v2/model_configs/softmax.json
+++ b/api/tests_v2/model_configs/softmax.json
@@ -1,0 +1,79 @@
+[{
+    "op": "softmax",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[112, 4233]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "softmax",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[96, 4233]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "softmax",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[128, 4233]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "softmax",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[144, 4233]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "softmax",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[176, 4233]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "softmax",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "1"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[160, 4233]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/model_configs/transpose.json
+++ b/api/tests_v2/model_configs/transpose.json
@@ -1,0 +1,677 @@
+[{
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 46, 4233]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[1,0,2]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 40, 4233]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[1,0,2]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 48, 4233]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[1,0,2]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 40, 256]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 40]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 40, 19]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 45, 4233]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[1,0,2]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 4, 40, 64]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 47, 19]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[16, 256, 48, 19]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 2, 64, 64]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,3,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 11, 64, 64, 2]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,1,4,2,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 8, 1024, 32]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 65536, 256]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 19, 1024, 1024]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,3,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 1, 65536, 32]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 2, 16384, 32]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 5, 4096, 32]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 64, 64, 160]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,3,1,2]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 65536, 32]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 16384, 64]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 4096, 160]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[512, 65, 65, 1, 1, 1]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,3,1,4,2,5]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[1536, 33, 33, 1, 1, 1]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,3,1,4,2,5]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[1536, 1, 16, 16]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,3,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[3, 8, 1, 8, 1, 1]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,1,3,5,2,4]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[512, 33, 33, 1, 1, 1]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,3,1,4,2,5]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[3, 4, 4, 1, 2, 2]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,3,1,4,2,5]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[1536, 1, 15, 15]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,3,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[3, 512, 512, 3, 3]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3,4]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[768, 128, 128, 1, 1, 1]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,3,1,4,2,5]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[1536, 32, 32, 1, 1, 1]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,3,1,4,2,5]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32, 128, 128, 1, 12]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,4,1,2,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[128, 32, 768]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[1,0,2]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32, 12, 128, 1, 2]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,4,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[128, 32, 1, 768]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,1,3,2]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[128, 32, 12, 2]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[1,2,0,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2, 12, 64]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[1,0,2]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32, 12, 128, 1, 128]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,1,2,4,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[768, 768]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32, 12, 128, 128]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[2,0,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[32, 12, 128, 1, 256]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,1,2,4,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[14, 8, 196, 768]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[112, 12, 197, 64]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[112, 768, 196]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2744, 12, 8, 64]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,1,3]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[112, 197, 3, 12, 64]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[2,0,3,1,4]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[112, 12, 197, 64]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,1,3,2]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2744, 8, 3, 12, 64]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[2,0,3,1,4]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[14, 14, 14, 8, 768]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,3,1,2,4]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[14, 8, 14, 14, 768]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,2,3,1,4]"
+        }
+    },
+    "op": "transpose"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[2744, 12, 8, 64]",
+            "type": "Variable"
+        },
+        "perm": {
+            "type": "list",
+            "value": "[0,1,3,2]"
+        }
+    },
+    "op": "transpose"
+}]

--- a/api/tests_v2/model_configs/unsqueeze.json
+++ b/api/tests_v2/model_configs/unsqueeze.json
@@ -1,0 +1,248 @@
+[{
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 10, 2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "3"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 11, 64, 64]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "2"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 3, 256, 256]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "2"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 10, 58, 58]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "2"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 1, 3, 64, 64]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 10, 2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "2"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 10, 2, 2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "2"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 10, 58, 58]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "4"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 10, 64, 64, 2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "5"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[8, 10, 1, 2, 2]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "3"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 80, 25500]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "3"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 80, 85]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "1"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[64, 1, 1]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "3"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 64, 25500]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "3"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[80, 80, 5]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "3"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[128, 80, 1]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "3"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[6, 25500]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "2"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[128, 64, 3]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "3"
+        }
+    },
+    "op": "unsqueeze"
+}, {
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[64, 64, 1]",
+            "type": "Variable"
+        },
+        "axis": {
+            "type": "int",
+            "value": "3"
+        }
+    },
+    "op": "unsqueeze"
+}]


### PR DESCRIPTION
添加dropout、dropout_grad 、depthwise_conv2d、depthwise_conv2d_grad 、elementwise_mul_grad、elementwise_div_grad、gelu_grad、unsqueeze2_grad、slice_grad、layer_norm、layer_norm_grad、bmm、transpose、log_softmax、group_norm、conv1d 算子耗时配置