### PR TITLE
Allow to enable exhaustive search for paddle and pytorch with environ flags and adjust repeat for several configs.

### DIFF
--- a/api/common/main.py
+++ b/api/common/main.py
@@ -269,7 +269,17 @@ def test_main_without_json(pd_obj=None,
             sys.exit(1)
 
     if _is_torch_enabled(args, config):
-        assert torch_obj is not None, "Pytorch object is None."
+        assert torch_obj is not None, "PyTorch object is None."
+        import torch
+        try:
+            import paddle
+            flags = paddle.get_flags(["FLAGS_cudnn_exhaustive_search"])
+            torch.backends.cudnn.benchmark = flags[
+                "FLAGS_cudnn_exhaustive_search"]
+        except Exception:
+            torch.backends.cudnn.benchmark = os.environ.get(
+                "FLAGS_cudnn_exhaustive_search", False)
+
         torch_config = config.to_pytorch()
         print(torch_config)
         torch_outputs, torch_stats = torch_obj.run(torch_config, args)

--- a/api/dynamic_tests_v2/run.sh
+++ b/api/dynamic_tests_v2/run.sh
@@ -19,9 +19,10 @@ testing_mode="dynamic" # "static" or "dynamic"
 framework="pytorch"  # "paddle" or "tensorflow" or "pytorch"
 filename="${OP_BENCHMARK_ROOT}/tests_v2/configs/${name}.json"
 if [ -z "$CUDA_VISIBLE_DEVICES" ]; then
-    use_gpu=False
+  use_gpu=False
 else
-    use_gpu=True
+  use_gpu=True
+  #export FLAGS_cudnn_exhaustive_search=true
 fi
 
 run_args="--task ${task} \

--- a/api/run_op_benchmark.sh
+++ b/api/run_op_benchmark.sh
@@ -51,7 +51,7 @@ fi
 
 if [ "${test_module_name}" == "dynamic_tests_v2" ]; then
     testing_mode="dynamic"
-    install_package "torch" "1.8.1"
+    install_package "torch" "1.10.0"
 else
     testing_mode="static"
     install_package "tensorflow" "2.3.1"

--- a/api/tests_v2/model_configs/bmm.json
+++ b/api/tests_v2/model_configs/bmm.json
@@ -11,7 +11,8 @@
             "shape": "[2, 19, 256]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 2000
 }, {
     "op": "bmm",
     "param_info": {
@@ -39,5 +40,6 @@
             "shape": "[2, 256, 19]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 10000
 }]

--- a/api/tests_v2/model_configs/cast.json
+++ b/api/tests_v2/model_configs/cast.json
@@ -62,7 +62,8 @@
             "shape": "[8, 1024, 50257]",
             "type": "Variable"
         }
-    }
+    },
+    "repeat": 5000
 }, {
     "op": "cast",
     "param_info": {

--- a/api/tests_v2/model_configs/dropout.json
+++ b/api/tests_v2/model_configs/dropout.json
@@ -62,6 +62,7 @@
     },
     "op": "dropout"
 }, {
+    "op": "dropout",
     "param_info": {
         "x": {
             "dtype": "float32",
@@ -81,7 +82,7 @@
             "value": "0.1"
         }
     },
-    "op": "dropout"
+    "repeat": 5000
 }, {
     "param_info": {
         "x": {

--- a/api/tests_v2/model_configs/elementwise_div.json
+++ b/api/tests_v2/model_configs/elementwise_div.json
@@ -1,4 +1,5 @@
 [{
+    "op": "elementwise",
     "param_info": {
         "y": {
             "dtype": "float32",
@@ -16,7 +17,7 @@
         }
     },
     "atol": 0.00001,
-    "op": "elementwise"
+    "repeat": 2000
 }, {
     "param_info": {
         "y": {
@@ -46,25 +47,6 @@
         "x": {
             "dtype": "float32",
             "shape": "[8,197,768]",
-            "type": "Variable"
-        },
-        "axis": {
-            "type": "int",
-            "value": "-1"
-        }
-    },
-    "atol": 0.00001,
-    "op": "elementwise"
-}, {
-    "param_info": {
-        "y": {
-            "dtype": "float32",
-            "shape": "[1]",
-            "type": "Variable"
-        },
-        "x": {
-            "dtype": "float32",
-            "shape": "[1]",
             "type": "Variable"
         },
         "axis": {


### PR DESCRIPTION
1. 允许统一通过FLAGS_cudnn_exhaustive_search开启paddle和pytorch的cudnn conv穷举搜索。
2. 新增的通用模型op配置里面，有很多配置初始化HtoD占比太高，需要增大repeat，本pr中修改了几个配置。
3. 删掉elementwise，输入x、y的shape都是[1]的配置，这样的配置对于指导算子性能优化没有意义。