### PR TITLE
Enable the compute of gflop and byte for batch_norm, transpose.

### DIFF
--- a/api/dynamic_tests_v2/transpose.py
+++ b/api/dynamic_tests_v2/transpose.py
@@ -48,6 +48,16 @@ class PDTranspose(PaddleDynamicAPIBenchmarkBase):
         if config.backward:
             self.append_gradients(result, [x])
 
+    def compute_flop_and_byte(self, config):
+        x_shape = config.x_shape
+        forward_flop = numel(x_shape)
+        forward_byte = 2 * numel(x_shape) * sizeof(config.x_dtype)
+        if not config.backward:
+            return forward_flop, forward_byte
+        else:
+            # To be implemented.
+            return None, None
+
 
 class TorchTranspose(PytorchAPIBenchmarkBase):
     def build_graph(self, config):

--- a/api/dynamic_tests_v2/transpose.py
+++ b/api/dynamic_tests_v2/transpose.py
@@ -50,7 +50,7 @@ class PDTranspose(PaddleDynamicAPIBenchmarkBase):
 
     def compute_flop_and_byte(self, config):
         x_shape = config.x_shape
-        forward_flop = numel(x_shape)
+        forward_flop = 0
         forward_byte = 2 * numel(x_shape) * sizeof(config.x_dtype)
         if not config.backward:
             return forward_flop, forward_byte


### PR DESCRIPTION
添加batch_norm、transpose前向flop、byte的计算函数。

batch_norm log如下：
```cpp
Namespace(allow_adaptive_repeat=False, api_name=None, backward=False, config_id=1, convert_to_fp16=False, framework='paddle', gpu_time=15.986928104575165, json_file='/work/benchmark/api/tests_v2/configs/batch_norm.json', log_level=0, profiler='none', repeat=1000, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][batch_norm] batch_norm {
  run_tf: True
  run_torch: True
  data_format: NCHW
  epsilon: 1e-05
  training: True
  momentum: 0.9
  x_shape: [16, 32768]
  x_dtype: float32
  atol: 1e-06
  num_channels: 32768
  param_dtype: float32
}
{"framework": "paddle", "version": "0.0.0", "name": "batch_norm", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.10284671978074678, "wall_time": 0, "total_include_wall_time": 0.10284671978074678, "gpu_time": 0.015986928104575165, "gflops": 282.8550907604251, "gbs": 327.9479313164349}, "parameters": "x (Variable) - dtype: float32, shape: [16, 32768]\ndata_format (string): NCHW\nepsilon (float): 1e-05\nmomentum (float): 0.9\ntraining (bool): True\n"}
```