### PR TITLE
Try to enable precise count of gpu_time with nvprof and use nsight to get gpu_time for ampere gpu.

### DIFF
--- a/api/common/launch.py
+++ b/api/common/launch.py
@@ -22,58 +22,141 @@ from common import system
 from common import api_param
 
 
-def _nvprof(cmd):
-    return system.run_command("nvprof --profile-from-start off {}".format(cmd))
+def is_ampere_gpu():
+    stdout, exit_code = system.run_command("nvidia-smi -L")
+    if exit_code == 0:
+        gpu_list = stdout.split("\n")
+        if len(gpu_list) >= 1:
+            #print(gpu_list[0])
+            return gpu_list[0].find("A100") > 0
+    return False
 
 
-def _nsight(cmd):
-    return system.run_command(
-        "nsys profile -t cublas,cuda,cudnn,nvtx  --capture-range=cudaProfilerApi --stats true {}".
-        format(cmd))
+class NvprofRunner(object):
+    def run(self, cmd):
+        stdout, exit_code = self._nvprof(cmd)
+        if exit_code == 0:
+            parse_status, gpu_time = self._parse_logs(stdout.split("\n"))
+            if parse_status:
+                return gpu_time
+        print("Runing Error:\n {}".format(stdout))
+        return 0.0
 
+    def _nvprof(self, cmd):
+        return system.run_command("nvprof --profile-from-start off {}".format(
+            cmd))
 
-def _parse_gpu_time(line):
-    infos = line.strip().split()
-    percent = float(infos[2].replace("%", "")) * 0.01
-    gpu_time = infos[3]
-    if gpu_time.endswith("us"):
-        gpu_time = float(gpu_time.replace("us", "")) * 0.001
-    elif gpu_time.endswith("ms"):
-        gpu_time = float(gpu_time.replace("ms", ""))
-    elif gpu_time.endswith("s"):
-        gpu_time = float(gpu_time.replace("s", "")) * 1000
-    else:
-        raise ValueError("Invalid time: %s" % gpu_time)
-    calls = int(infos[4])
-    function = infos[8]
-    for i in range(9, len(infos)):
-        function = function + " " + infos[i]
-    print("percent: %.2f; gpu_time: %.4f ms; calls: %d; function: %s" %
-          (percent, gpu_time, calls, function))
+    def _parse_logs(self, logs):
+        line_from = None
+        line_to = None
+        for i in range(len(logs)):
+            line = api_param.parse_string(logs[i])
+            if "GPU activities:" in line:
+                line_from = i - 1
+            if line_from is not None and "API calls:" in line:
+                line_to = i
+                break
+        if line_from is not None and line_to is not None:
+            for i in range(line_from, line_to):
+                print(logs[i])
+            print("")
+            return True, self._parse_gpu_time(logs[line_from + 1])
+        else:
+            return False, 0.0
 
-    total_gpu_time = gpu_time / percent
-    print("total gpu_time: %.4f ms" % total_gpu_time)
-    print("")
-    return total_gpu_time
+    def _parse_gpu_time(self, line):
+        infos = line.strip().split()
+        percent = float(infos[2].replace("%", "")) * 0.01
+        gpu_time = infos[3]
+        if gpu_time.endswith("us"):
+            gpu_time = float(gpu_time.replace("us", "")) * 0.001
+        elif gpu_time.endswith("ms"):
+            gpu_time = float(gpu_time.replace("ms", ""))
+        elif gpu_time.endswith("s"):
+            gpu_time = float(gpu_time.replace("s", "")) * 1000
+        else:
+            raise ValueError("Invalid time: %s" % gpu_time)
+        calls = int(infos[4])
+        function = infos[8]
+        for i in range(9, len(infos)):
+            function = function + " " + infos[i]
+        #print("percent: %.2f; gpu_time: %.4f ms; calls: %d; function: %s" %
+        #      (percent, gpu_time, calls, function))
 
-
-def _parse_nvprof_logs(logs):
-    line_from = None
-    line_to = None
-    total_gpu_time = 0.0
-    for i in range(len(logs)):
-        line = api_param.parse_string(logs[i])
-        if "GPU activities:" in line:
-            line_from = i - 1
-        if line_from is not None and "API calls:" in line:
-            line_to = i
-    if line_from is not None and line_to is not None:
-        for i in range(line_from, line_to):
-            print(logs[i])
+        total_gpu_time = gpu_time / percent
+        print("total gpu_time: %.4f ms" % total_gpu_time)
         print("")
-        return True, _parse_gpu_time(logs[line_from + 1])
-    else:
-        return False, 0.0
+        return total_gpu_time
+
+
+class NsightRunner(object):
+    def run(self, cmd):
+        stdout, exit_code = self._nsight(cmd)
+        if exit_code == 0:
+            parse_status, gpu_time = self._parse_logs(stdout.split("\n"))
+            if parse_status:
+                return gpu_time
+        print("Runing Error:\n {}".format(stdout))
+        return 0.0
+
+    def _nsight(self, cmd):
+        return system.run_command(
+            "nsys nvprof --profile-from-start=off -o tmp.qdrep {}".format(cmd))
+
+    def _parse_logs(self, logs):
+        kernel_line_from = None
+        kernel_line_to = None
+        memcpy_line_from = None
+        memcpy_line_to = None
+        for i in range(len(logs)):
+            line = api_param.parse_string(logs[i])
+            if "CUDA Kernel Statistics:" in line:
+                kernel_line_from = i
+                for j in range(i + 2, len(logs)):
+                    if logs[j] == "":
+                        kernel_line_to = j
+                        break
+            if "CUDA Memory Operation Statistics (by time):" in line:
+                memcpy_line_from = i
+                for j in range(i + 2, len(logs)):
+                    if logs[j] == "":
+                        memcpy_line_to = j
+                        break
+
+        parse_status = False
+        kernel_gpu_time = 0.0
+        if kernel_line_from is not None and kernel_line_to is not None:
+            for i in range(kernel_line_from, kernel_line_to):
+                print(logs[i])
+            print("")
+            parse_status = True
+            kernel_gpu_time = self._parse_gpu_time(logs[kernel_line_from + 4])
+
+        memcpy_gpu_time = 0.0
+        if memcpy_line_from is not None and memcpy_line_to is not None:
+            for i in range(memcpy_line_from, memcpy_line_to):
+                print(logs[i])
+            print("")
+            parse_status = True
+            memcpy_gpu_time = self._parse_gpu_time(logs[memcpy_line_from + 4])
+
+        total_gpu_time = kernel_gpu_time + memcpy_gpu_time
+        print("total gpu_time: %.4f ms (kernel: %.4f ms; memcpy: %.4f ms)" %
+              (total_gpu_time, kernel_gpu_time, memcpy_gpu_time))
+        print("")
+        return parse_status, total_gpu_time
+
+    def _parse_gpu_time(self, line):
+        infos = line.strip().split()
+        percent = float(infos[0].replace("%", "")) * 0.01
+        gpu_time = float(infos[1].replace(",", "")) * 1E-6
+        calls = int(infos[2].replace(",", ""))
+        function = infos[7]
+        for i in range(8, len(infos)):
+            function = function + " " + infos[i]
+        #print("percent: %.2f; gpu_time: %.4f ms; calls: %d; function: %s" %
+        #      (percent, gpu_time, calls, function))
+        return gpu_time / percent
 
 
 def launch(benchmark_script, benchmark_script_args, with_nvprof=False):
@@ -95,22 +178,18 @@ def launch(benchmark_script, benchmark_script_args, with_nvprof=False):
             args.append("--profiler")
             args.append(value)
 
-    use_gpu = os.environ.get("CUDA_VISIBLE_DEVICES", None) != ""
-    if with_nvprof and use_gpu:
+    if with_nvprof:
         _set_profiler(benchmark_script_args, "nvprof")
     cmd = "{} {} {}".format(sys.executable, benchmark_script,
                             " ".join(benchmark_script_args))
     if with_nvprof:
-        stdout, exit_code = _nvprof(cmd)
+        if is_ampere_gpu():
+            runner = NsightRunner()
+        else:
+            runner = NvprofRunner()
+        gpu_time = runner.run(cmd)
         _set_profiler(benchmark_script_args, "none")
-        if exit_code == 0:
-            parse_status, gpu_time = _parse_nvprof_logs(stdout.split("\n"))
-        else:
-            parse_status = False
-        if parse_status:
-            return gpu_time
-        else:
-            print("Runing Error:\n {}".format(stdout))
+        return gpu_time
     else:
         stdout, exit_code = system.run_command(cmd)
         print(stdout)
@@ -145,7 +224,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     benchmark_args_dict = _args_list_to_dict(args.benchmark_script_args)
     task = benchmark_args_dict.get("task", "speed")
-    use_gpu = system.str2bool(benchmark_args_dict.get("use_gpu", "False"))
+    use_gpu = system.str2bool(benchmark_args_dict.get(
+        "use_gpu", "False")) and os.environ.get("CUDA_VISIBLE_DEVICES",
+                                                None) != ""
     profiler = benchmark_args_dict.get("profiler", "none")
     repeat = benchmark_args_dict.get("repeat", "1")
 

--- a/api/common/launch.py
+++ b/api/common/launch.py
@@ -144,8 +144,11 @@ class NsightRunner(object):
             memcpy_gpu_time = self._parse_gpu_time(logs[memcpy_line_from + 4])
 
         total_gpu_time = kernel_gpu_time + memcpy_gpu_time
-        print("total gpu_time: %.4f ms (kernel: %.4f ms; memcpy: %.4f ms)" %
-              (total_gpu_time, kernel_gpu_time, memcpy_gpu_time))
+        print(
+            "total gpu_time: {:.4f} ms (kernel: {:.4f} ms ({:.2f}%); memcpy: {:.4f} ms ({:.2f}%))".
+            format(total_gpu_time, kernel_gpu_time, kernel_gpu_time * 100 /
+                   total_gpu_time, memcpy_gpu_time, memcpy_gpu_time * 100 /
+                   total_gpu_time))
         print("")
         return parse_status, total_gpu_time
 

--- a/api/common/launch.py
+++ b/api/common/launch.py
@@ -28,6 +28,7 @@ def is_ampere_gpu():
         gpu_list = stdout.split("\n")
         if len(gpu_list) >= 1:
             #print(gpu_list[0])
+            # GPU 0: NVIDIA A100-SXM4-40GB (UUID: xxxx)
             return gpu_list[0].find("A100") > 0
     return False
 
@@ -43,8 +44,9 @@ class NvprofRunner(object):
         return 0.0
 
     def _nvprof(self, cmd):
-        return system.run_command("nvprof --profile-from-start off {}".format(
-            cmd))
+        #return system.run_command("nvprof --profile-from-start off {}".format(
+        #    cmd))
+        return system.run_command("nvprof {}".format(cmd))
 
     def _parse_logs(self, logs):
         line_from = None
@@ -100,8 +102,9 @@ class NsightRunner(object):
         return 0.0
 
     def _nsight(self, cmd):
-        return system.run_command(
-            "nsys nvprof --profile-from-start=off -o tmp.qdrep {}".format(cmd))
+        #return system.run_command(
+        #     "nsys nvprof --profile-from-start=off -o tmp.qdrep {}".format(cmd))
+        return system.run_command("nsys nvprof -o tmp.qdrep {}".format(cmd))
 
     def _parse_logs(self, logs):
         kernel_line_from = None
@@ -178,8 +181,8 @@ def launch(benchmark_script, benchmark_script_args, with_nvprof=False):
             args.append("--profiler")
             args.append(value)
 
-    if with_nvprof:
-        _set_profiler(benchmark_script_args, "nvprof")
+    #if with_nvprof:
+    #    _set_profiler(benchmark_script_args, "nvprof")
     cmd = "{} {} {}".format(sys.executable, benchmark_script,
                             " ".join(benchmark_script_args))
     if with_nvprof:
@@ -188,7 +191,7 @@ def launch(benchmark_script, benchmark_script_args, with_nvprof=False):
         else:
             runner = NvprofRunner()
         gpu_time = runner.run(cmd)
-        _set_profiler(benchmark_script_args, "none")
+        #_set_profiler(benchmark_script_args, "none")
         return gpu_time
     else:
         stdout, exit_code = system.run_command(cmd)

--- a/api/common/paddle_api_benchmark.py
+++ b/api/common/paddle_api_benchmark.py
@@ -65,6 +65,10 @@ def profile_context(name, use_gpu, profiler):
         ps = pstats.Stats(profiler_handle, stream=s).sort_stats("cumulative")
         ps.print_stats()
         print(s.getvalue())
+    elif profiler == "nvprof":
+        fluid.core.nvprof_start()
+        yield
+        fluid.core.nvprof_stop()
     else:
         yield
 

--- a/api/run_op_benchmark.sh
+++ b/api/run_op_benchmark.sh
@@ -2,12 +2,12 @@
 
 OP_BENCHMARK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")" && pwd )"
 
-test_module_name=${1:-"dynamic_tests_v2"}  # "tests", "tests_v2", "dynamic_tests_v2"
+test_module_name=${1:-"dynamic_tests_v2"}  # "tests_v2", "dynamic_tests_v2"
 gpu_ids=${2:-"0"}
 op_type=${3:-"all"}  # "all" or specified op_type, such as elementwise
 
-if [ ${test_module_name} != "tests" ] && [ ${test_module_name} != "tests_v2" ] && [ ${test_module_name} != "dynamic_tests_v2" ]; then
-  echo "Please set test_module_name (${test_module_name}) to \"tests\", \"tests_v2\" or \"dynamic_tests_v2\"!"
+if [ ${test_module_name} != "tests_v2" ] && [ ${test_module_name} != "dynamic_tests_v2" ]; then
+  echo "Please set test_module_name (${test_module_name}) to \"tests_v2\" or \"dynamic_tests_v2\"!"
   exit
 fi
 
@@ -21,7 +21,9 @@ install_package() {
   import_status=$?
   if [ ${import_status} -eq 0 ]; then
     installed_version=`python -c "import ${package_name}; print(${package_name}.__version__)"`
-    if [ ${installed_version} == ${package_version} ]; then
+    if [ "${installed_version}" > "${package_version}" ]; then
+      echo "-- ${package_name} ${installed_version} (newer than ${package_version}) is already installed."
+    elif [ "${installed_version}" = "${package_version}" ]; then
       echo "-- ${package_name} ${package_version} is already installed."
     else
       echo "-- Update ${package_name}: ${installed_version} -> ${package_version}"
@@ -94,6 +96,8 @@ run_specified_op() {
 main() {
   if [ "${test_module_name}" == "dynamic_tests_v2" ]; then
     testing_mode="dynamic"
+    # For ampere, need to install the nightly build cuda11.3 version using the following command:
+    # pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
     install_package "torch" "1.10.0"
   else
     testing_mode="static"


### PR DESCRIPTION
这个PR尝试实现2个功能：

1. Ampere架构上不再支持`nvporf`，需要使用`nsys`代替，来获取Kernel的GPU时间。使用nsys需要注意2点：(1) nsys非系统自带，需要提前手动安装好（2）nsys输出的日志中，Kernel和Memory分开统计，但Kernel和Memory操作都算算子的开销，因此需要统计到gpu_time中。输出如下：
```bash
$ bash run.sh concat
-- Current directory: /work/benchmark/api/dynamic_tests_v2
-- Entering /work/benchmark/api/common
-- Current directory: /work/benchmark/api/common
run command: git rev-parse HEAD
run command: git show -s --format=%ad
-- Current directory: /work/benchmark/api/dynamic_tests_v2
===========================================================================
-- paddle version             : 0.0.0
-- paddle commit              : 8da9eff4e49820e993a47da9555ec96ef70fa70c
-- pytorch version            : 1.11.0.dev20211223+cu113
-- benchmark commit           : c5f138e5a83b1bfc2870d383c45b2d5525d46988
-- benchmark last update time : Fri Dec 24 03:30:00 2021 +0000
===========================================================================
run command: nvidia-smi -L
run command: nsys nvprof -o tmp.qdrep /work/.virtualenvs_cuda11.4/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/concat.py --task speed --framework paddle --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/concat.json --config_id 0 --profiler none --backward False --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
CUDA Kernel Statistics:

 Time(%)  Total Time (ns)  Instances   Average   Minimum  Maximum  StdDev                                                   Name
 -------  ---------------  ---------  ---------  -------  -------  -------  ----------------------------------------------------------------------------------------------------
   100.0      550,250,632      1,001  549,700.9  539,578  568,570  6,679.8  void paddle::operators::math::ConcatKernel<float>(float const**, long const*, int, long, long, floa…

CUDA Memory Operation Statistics (by time):

 Time(%)  Total Time (ns)  Operations  Average   Minimum   Maximum     StdDev        Operation
 -------  ---------------  ----------  --------  -------  ----------  ---------  ------------------
    99.9       42,191,389       2,004  21,053.6    2,367  31,641,196  717,672.5  [CUDA memcpy HtoD]
     0.1           21,695           4   5,423.8    5,152       5,600      206.6  [CUDA memset]

total gpu_time: 592.4843 ms (kernel: 550.2506 ms (92.87%); memcpy: 42.2336 ms (7.13%))

run command: /work/.virtualenvs_cuda11.4/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/concat.py --task speed --framework paddle --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/concat.json --config_id 0 --profiler none --backward False --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0  --gpu_time  592.4842546226226
W1224 04:56:04.888831 109733 device_context.cc:531] Please NOTE: device: 0, GPU Compute Capability: 8.0, Driver API Version: 11.4, Runtime API Version: 11.4
W1224 04:56:04.893246 109733 device_context.cc:549] device: 0, cuDNN Version: 8.2.
Cannot import tensorflow, maybe tensorflow is not installed.
Namespace(allow_adaptive_repeat=False, api_name=None, backward=False, config_id=0, convert_to_fp16=False, framework='paddle', gpu_time=592.4842546226226, json_file='/work/benchmark/api/tests_v2/configs/concat.json', log_level=0, profiler='none', repeat=1000, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
---- Initialize APIConfig from /work/benchmark/api/tests_v2/configs/concat.json, config_id = 0.

Namespace(allow_adaptive_repeat=False, api_name=None, backward=False, config_id=0, convert_to_fp16=False, framework='paddle', gpu_time=592.4842546226226, json_file='/work/benchmark/api/tests_v2/configs/concat.json', log_level=0, profiler='none', repeat=1000, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][concat] concat {
  run_tf: True
  run_torch: True
  repeat: 5000
  axis: 1
  x_shape: [[16, 256, 129, 129], [16, 48, 129, 129]]
  x_dtype: ['float32', 'float32']
  atol: 1e-06
}
{"framework": "paddle", "version": "0.0.0", "name": "concat", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.5836182711075764, "wall_time": 0, "total_include_wall_time": 0.5836182711075764, "gpu_time": 0.5924842546226227}, "parameters": "x (list<Variable>[2]) - dtype: float32, shape: [16, 256, 129, 129]; dtype: float32, shape: [16, 48, 129, 129]; \naxis (int): 1\n"}
```

2. 使用`nvprof --profile-from-start off`和`nsys nvprof --profile-from-start=off -o tmp.qdrep`命令，可以避免统计warmup执行的Kernel时间，可以获得更准确的gpu_time。单独执行单个测试没有问题，log如下，但是批量测试时会挂，下个PR解决。
```bash
$ bash run.sh concat
-- Current directory: /work/benchmark/api/dynamic_tests_v2
-- Entering /work/benchmark/api/common
-- Current directory: /work/benchmark/api/common
run command: git rev-parse HEAD
run command: git show -s --format=%ad
-- Current directory: /work/benchmark/api/dynamic_tests_v2
===========================================================================
-- paddle version             : 0.0.0
-- paddle commit              : 8da9eff4e49820e993a47da9555ec96ef70fa70c
-- pytorch version            : 1.11.0.dev20211223+cu113
-- benchmark commit           : c5f138e5a83b1bfc2870d383c45b2d5525d46988
-- benchmark last update time : Fri Dec 24 03:30:00 2021 +0000
===========================================================================
run command: nvidia-smi -L
run command: nsys nvprof --profile-from-start=off -o tmp.qdrep /work/.virtualenvs_cuda11.4/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/concat.py --task speed --framework paddle --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/concat.json --config_id 0 --profiler nvprof --backward False --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
CUDA Kernel Statistics:

 Time(%)  Total Time (ns)  Instances   Average   Minimum  Maximum  StdDev                                                   Name
 -------  ---------------  ---------  ---------  -------  -------  -------  ----------------------------------------------------------------------------------------------------
   100.0      553,352,367      1,000  553,352.4  540,794  571,450  7,785.9  void paddle::operators::math::ConcatKernel<float>(float const**, long const*, int, long, long, floa…

CUDA Memory Operation Statistics (by time):

 Time(%)  Total Time (ns)  Operations  Average  Minimum  Maximum  StdDev      Operation
 -------  ---------------  ----------  -------  -------  -------  ------  ------------------
   100.0        5,068,306       2,000  2,534.2    2,367    3,808   146.9  [CUDA memcpy HtoD]

total gpu_time: 558.4207 ms (kernel: 553.3524 ms (99.09%); memcpy: 5.0683 ms (0.91%))

run command: /work/.virtualenvs_cuda11.4/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/concat.py --task speed --framework paddle --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/concat.json --config_id 0 --profiler none --backward False --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0  --gpu_time  558.420673
W1224 04:57:37.582360 110060 device_context.cc:531] Please NOTE: device: 0, GPU Compute Capability: 8.0, Driver API Version: 11.4, Runtime API Version: 11.4
W1224 04:57:37.586371 110060 device_context.cc:549] device: 0, cuDNN Version: 8.2.
Cannot import tensorflow, maybe tensorflow is not installed.
Namespace(allow_adaptive_repeat=False, api_name=None, backward=False, config_id=0, convert_to_fp16=False, framework='paddle', gpu_time=558.420673, json_file='/work/benchmark/api/tests_v2/configs/concat.json', log_level=0, profiler='none', repeat=1000, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
---- Initialize APIConfig from /work/benchmark/api/tests_v2/configs/concat.json, config_id = 0.

Namespace(allow_adaptive_repeat=False, api_name=None, backward=False, config_id=0, convert_to_fp16=False, framework='paddle', gpu_time=558.420673, json_file='/work/benchmark/api/tests_v2/configs/concat.json', log_level=0, profiler='none', repeat=1000, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][concat] concat {
  run_tf: True
  run_torch: True
  repeat: 5000
  axis: 1
  x_shape: [[16, 256, 129, 129], [16, 48, 129, 129]]
  x_dtype: ['float32', 'float32']
  atol: 1e-06
}
{"framework": "paddle", "version": "0.0.0", "name": "concat", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.5989201214848733, "wall_time": 0, "total_include_wall_time": 0.5989201214848733, "gpu_time": 0.558420673}, "parameters": "x (list<Variable>[2]) - dtype: float32, shape: [16, 256, 129, 129]; dtype: float32, shape: [16, 48, 129, 129]; \naxis (int): 1\n"}
```