### PR TITLE
Correct the setting of profiler to nvprof to get precise gpu_time.

### DIFF
--- a/api/common/launch.py
+++ b/api/common/launch.py
@@ -40,13 +40,12 @@ class NvprofRunner(object):
             parse_status, gpu_time = self._parse_logs(stdout.split("\n"))
             if parse_status:
                 return gpu_time
-        print("Runing Error:\n {}".format(stdout))
+        print("Running Error:\n {}".format(stdout))
         return 0.0
 
     def _nvprof(self, cmd):
-        #return system.run_command("nvprof --profile-from-start off {}".format(
-        #    cmd))
-        return system.run_command("nvprof {}".format(cmd))
+        return system.run_command("nvprof --profile-from-start off {}".format(
+            cmd))
 
     def _parse_logs(self, logs):
         line_from = None
@@ -98,13 +97,12 @@ class NsightRunner(object):
             parse_status, gpu_time = self._parse_logs(stdout.split("\n"))
             if parse_status:
                 return gpu_time
-        print("Runing Error:\n {}".format(stdout))
+        print("Running Error:\n {}".format(stdout))
         return 0.0
 
     def _nsight(self, cmd):
-        #return system.run_command(
-        #     "nsys nvprof --profile-from-start=off -o tmp.qdrep {}".format(cmd))
-        return system.run_command("nsys nvprof -o tmp.qdrep {}".format(cmd))
+        return system.run_command(
+            "nsys nvprof --profile-from-start=off -o tmp.qdrep {}".format(cmd))
 
     def _parse_logs(self, logs):
         kernel_line_from = None
@@ -176,16 +174,17 @@ def launch(benchmark_script, benchmark_script_args, with_nvprof=False):
     """
 
     def _set_profiler(args, value):
-        for i in range(len(args)):
-            if args[i] == "--profiler":
-                args[i + 1] = value
-                break
-        if i >= len(args):
+        if "--profiler" in args:
+            for i in range(len(args)):
+                if args[i] == "--profiler":
+                    args[i + 1] = value
+                    break
+        else:
             args.append("--profiler")
             args.append(value)
 
-    #if with_nvprof:
-    #    _set_profiler(benchmark_script_args, "nvprof")
+    if with_nvprof:
+        _set_profiler(benchmark_script_args, "nvprof")
     cmd = "{} {} {}".format(sys.executable, benchmark_script,
                             " ".join(benchmark_script_args))
     if with_nvprof:
@@ -194,7 +193,7 @@ def launch(benchmark_script, benchmark_script_args, with_nvprof=False):
         else:
             runner = NvprofRunner()
         gpu_time = runner.run(cmd)
-        #_set_profiler(benchmark_script_args, "none")
+        _set_profiler(benchmark_script_args, "none")
         return gpu_time
     else:
         stdout, exit_code = system.run_command(cmd)

--- a/api/run_op_benchmark.sh
+++ b/api/run_op_benchmark.sh
@@ -23,7 +23,7 @@ install_package() {
     installed_version=`python -c "import ${package_name}; print(${package_name}.__version__)"`
     if [ "${installed_version}" > "${package_version}" ]; then
       echo "-- ${package_name} ${installed_version} (newer than ${package_version}) is already installed."
-    elif [ "${installed_version}" = "${package_version}" ]; then
+    elif [ "${installed_version}" == "${package_version}" ]; then
       echo "-- ${package_name} ${package_version} is already installed."
     else
       echo "-- Update ${package_name}: ${installed_version} -> ${package_version}"


### PR DESCRIPTION
修复#1203 中，设置`--profiler nvprof`以获取准确的`gpu_time`碰到的问题。还是代码的问题，在原来的`args`中没有`--profiler`时，未能成功地设置`--profiler nvprof`。