### PR TITLE
Enable the float16 cases for maximum, minimum and divide.

### DIFF
--- a/api/deploy/write_excel.py
+++ b/api/deploy/write_excel.py
@@ -191,12 +191,12 @@ def _write_detail_worksheet(benchmark_result_list, worksheet, device,
             column_width.append(16)
             column_width.append(16)
             column_width.append(16)
-        if device == "gpu" and direction == "forward":
+        if device == "gpu" and direction in ["forward", "backward"]:
             title_names.append("paddle(gflops)")
             title_names.append("paddle(gbs)")
         title_names.append("accuracy")
         title_names.append("parameters")
-        if device == "gpu" and direction == "forward":
+        if device == "gpu" and direction in ["forward", "backward"]:
             column_width.append(16)
             column_width.append(16)
         column_width.append(10)

--- a/api/dynamic_tests_v2/elementwise.py
+++ b/api/dynamic_tests_v2/elementwise.py
@@ -29,8 +29,7 @@ class ElementwiseConfig(APIConfig):
         self.feed_spec = [{"range": [-1, 1]}, {"range": [-1, 1]}]
 
     def disabled(self):
-        if self.api_name in ["pow", "maximum", "minimum"
-                             ] and self.x_dtype == "float16":
+        if self.api_name in ["pow"] and self.x_dtype == "float16":
             print(
                 "Warning:\n"
                 "  1. This config is disabled because float16 is not supported for %s.\n"

--- a/api/tests_v2/elementwise.py
+++ b/api/tests_v2/elementwise.py
@@ -30,8 +30,7 @@ class ElementwiseConfig(APIConfig):
         self.feed_spec = [{"range": [-1, 1]}, {"range": [-1, 1]}]
 
     def disabled(self):
-        if self.api_name in ["pow", "maximum", "minimum", "divide"
-                             ] and self.x_dtype == "float16":
+        if self.api_name in ["pow"] and self.x_dtype == "float16":
             print(
                 "Warning:\n"
                 "  1. This config is disabled because float16 is not supported for %s.\n"


### PR DESCRIPTION
修复https://github.com/PaddlePaddle/benchmark/pull/1184#discussion_r779994622 ，maximum和minimum已经支持了float16，故不再disable。