### PR TITLE
Add the 6-th part of unified tests.

### DIFF
--- a/api/tests/conv1d.py
+++ b/api/tests/conv1d.py
@@ -1,0 +1,75 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+@benchmark_registry.register("conv1d")
+class Conv1dConfig(APIConfig):
+    def __init__(self, op_type="conv1d"):
+        super(Conv1dConfig, self).__init__(op_type)
+        self.run_tf = False
+        self.feed_spec = [
+            {
+                "range": [-1, 1]
+            },  # x
+            {
+                "range": [-1, 1],
+            }  # weight
+        ]
+
+
+@benchmark_registry.register("conv1d")
+class PaddleConv1d(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name='weight',
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+        result = paddle.nn.functional.conv1d(
+            x=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            dilation=config.dilation,
+            groups=config.groups,
+            data_format=config.data_format)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])
+
+
+@benchmark_registry.register("conv1d")
+class TorchConv1d(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name='weight', shape=config.weight_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.conv1d(
+            input=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            dilation=config.dilation,
+            groups=config.groups)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])

--- a/api/tests/conv2d.py
+++ b/api/tests/conv2d.py
@@ -1,0 +1,103 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+# TODO(Xreki): to support tf.
+
+
+@benchmark_registry.register("conv2d")
+class Conv2dConfig(APIConfig):
+    def __init__(self, op_type="conv2d"):
+        super(Conv2dConfig, self).__init__(op_type)
+        self.feed_spec = [
+            {
+                "range": [-1, 1]
+            },  # input
+            {
+                "range": [-1, 1],
+            }  # filters
+        ]
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(Conv2dConfig, self).init_from_json(filename, config_id,
+                                                 unknown_dim)
+        if isinstance(self.padding, int):
+            self.padding = [self.padding, self.padding]
+        if isinstance(self.dilation, int):
+            self.dilation = [self.dilation, self.dilation]
+        if self.groups is None:
+            self.groups = 1
+        assert self.get_in_channels(
+        ) % self.groups == 0, "The channel of input must be divisible by groups. "\
+            "But received: the channel of input is {}, the shape of input is {}, the groups is {}".format(
+            self.get_in_channels(), self.x_shape, self.groups)
+        if self.data_format == 'NHWC':
+            print(
+                "Warning:\n"
+                "  1. PyTorch does not have data_format param, it only support NCHW format.\n"
+            )
+            self.run_torch = False
+
+    def get_in_channels(self):
+        return self.x_shape[1] if self.data_format == "NCHW" else self.x_shape[
+            3]
+
+    def get_out_channels(self):
+        return self.weight_shape[0]
+
+
+@benchmark_registry.register("conv2d")
+class PaddleConv2d(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name='weight',
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+        result = paddle.nn.functional.conv2d(
+            x=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            dilation=config.dilation,
+            groups=config.groups,
+            data_format=config.data_format)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])
+
+
+@benchmark_registry.register("conv2d")
+class TorchConv2d(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name='weight', shape=config.weight_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.conv2d(
+            input=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            dilation=config.dilation,
+            groups=config.groups)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])

--- a/api/tests/conv2d_transpose.py
+++ b/api/tests/conv2d_transpose.py
@@ -1,0 +1,89 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+# TODO(Xreki): to support tf.
+
+
+@benchmark_registry.register("conv2d_transpose")
+class Conv2dTransposeConfig(APIConfig):
+    def __init__(self):
+        super(Conv2dTransposeConfig, self).__init__("conv2d_transpose")
+        self.feed_spec = [
+            {
+                "range": [-1, 1]
+            },  # input
+            {
+                "range": [-1, 1],
+            }  # filters
+        ]
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(Conv2dTransposeConfig, self).init_from_json(filename, config_id,
+                                                          unknown_dim)
+        if self.groups == None:
+            self.groups = 1
+
+
+@benchmark_registry.register("conv2d_transpose")
+class PaddleConv2dTranspose(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name="weight",
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+
+        result = paddle.nn.functional.conv2d_transpose(
+            x=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            output_padding=0,
+            dilation=config.dilation,
+            groups=config.groups,
+            output_size=config.output_size,
+            data_format=config.data_format)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])
+
+
+@benchmark_registry.register("conv2d_transpose")
+class TorchConv2dTranspose(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name="weight",
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+
+        result = torch.nn.functional.conv_transpose2d(
+            input=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            output_padding=0,
+            dilation=config.dilation,
+            groups=config.groups)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])

--- a/api/tests/conv3d.py
+++ b/api/tests/conv3d.py
@@ -1,0 +1,77 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+@benchmark_registry.register("conv3d")
+class Conv3dConfig(APIConfig):
+    def __init__(self, op_type="conv3d"):
+        super(Conv3dConfig, self).__init__(op_type)
+        self.run_tf = False
+        self.feed_spec = [
+            {
+                "range": [-1, 1]
+            },  # x
+            {
+                "range": [-1, 1],
+            }  # weight
+        ]
+
+
+@benchmark_registry.register("conv3d")
+class PaddleConv3d(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name='weight',
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+        result = paddle.nn.functional.conv3d(
+            x=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            dilation=config.dilation,
+            groups=config.groups,
+            data_format=config.data_format)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])
+
+
+@benchmark_registry.register("conv3d")
+class TorchConv3d(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name='weight',
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+        result = torch.nn.functional.conv3d(
+            input=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            dilation=config.dilation,
+            groups=config.groups)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])

--- a/api/tests/conv3d_transpose.py
+++ b/api/tests/conv3d_transpose.py
@@ -1,0 +1,102 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+# TODO(Xreki): to support tf.
+
+
+@benchmark_registry.register("conv3d_transpose")
+class Conv3dTransposeConfig(APIConfig):
+    def __init__(self, op_type="conv3d_transpose"):
+        super(Conv3dTransposeConfig, self).__init__(op_type)
+        self.feed_spec = [
+            {
+                "range": [-1, 1]
+            },  # x
+            {
+                "range": [-1, 1],
+            }  # weight
+        ]
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(Conv3dTransposeConfig, self).init_from_json(filename, config_id,
+                                                          unknown_dim)
+        if isinstance(self.padding, int):
+            self.padding = [self.padding, self.padding, self.padding]
+        if self.data_format == "NCDHW":
+            self.num_channels = self.input_shape[1]
+        elif self.data_format == "NDHWC":
+            self.num_channels = self.input_shape[4]
+        if isinstance(self.filter_size, int):
+            self.filter_size = [
+                self.filter_size, self.filter_size, self.filter_size
+            ]
+        if self.groups is None:
+            self.groups = 1
+        if self.num_channels % self.groups != 0:
+            raise ValueError(
+                "the channel of input must be divisible by groups,"
+                "received: the channel of input is {}, the shape of input is {}"
+                ", the groups is {}".format(self.num_channels,
+                                            self.input_shape, self.groups))
+        self.filter_shape = [
+            self.num_channels // self.groups, self.num_filters,
+            self.filter_size[0], self.filter_size[1], self.filter_size[2]
+        ]
+
+
+@benchmark_registry.register("conv3d_transpose")
+class PaddleConv3dTranspose(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(
+            name='x', shape=config.input_shape, dtype=config.input_dtype)
+        weight = self.variable(
+            name='weight', shape=config.filter_shape, dtype=config.input_dtype)
+        result = paddle.nn.functional.conv3d_transpose(
+            x=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            dilation=config.dilation,
+            groups=config.groups,
+            data_format=config.data_format)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])
+
+
+@benchmark_registry.register("conv3d_transpose")
+class TorchConv3dTranspose(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(
+            name='x', shape=config.input_shape, dtype=config.input_dtype)
+        weight = self.variable(
+            name='weight', shape=config.filter_shape, dtype=config.input_dtype)
+        result = torch.nn.functional.conv_transpose3d(
+            input=x,
+            weight=weight,
+            bias=None,
+            stride=config.stride,
+            padding=config.padding,
+            dilation=config.dilation,
+            groups=config.groups)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])

--- a/api/tests/deformable_conv.py
+++ b/api/tests/deformable_conv.py
@@ -1,0 +1,108 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+@benchmark_registry.register("deformable_conv")
+class DeformableConvConfig(APIConfig):
+    def __init__(self, op_type="deformable_conv"):
+        super(DeformableConvConfig, self).__init__(op_type)
+        self.run_tf = False
+        self.feed_spec = [
+            {
+                "range": [0, 1]
+            },  # input
+            {
+                "range": [0, 1],
+            },  # weight
+            {
+                "range": [0, 1],
+            },  # offset
+            {
+                "range": [0, 1],
+            }  # mask
+        ]
+
+    def to_pytorch(self):
+        torch_config = super(DeformableConvConfig, self).to_pytorch()
+        if isinstance(self.stride, int):
+            torch_config.stride = [self.stride, self.stride]
+        if isinstance(self.dilation, int):
+            torch_config.dilation = [self.dilation, self.dilation]
+        if isinstance(self.padding, int):
+            torch_config.padding = [self.padding, self.padding]
+        return torch_config
+
+
+@benchmark_registry.register("deformable_conv")
+class PaddleDeformableConv(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name='weight',
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+        offset = self.variable(
+            name='offset',
+            shape=config.offset_shape,
+            dtype=config.offset_dtype)
+        mask = self.variable(
+            name='mask', shape=config.mask_shape, dtype=config.mask_dtype)
+
+        result = paddle.vision.ops.deform_conv2d(
+            x=x,
+            offset=offset,
+            weight=weight,
+            stride=config.stride,
+            dilation=config.dilation,
+            padding=config.padding,
+            deformable_groups=config.deformable_groups,
+            groups=config.groups,
+            mask=mask)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])
+
+
+@benchmark_registry.register("deformable_conv")
+class TorchDeformableConv(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        import torchvision
+
+        input = self.variable(
+            name='x', shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name='weight', shape=config.weight_shape, dtype=config.x_dtype)
+        offset = self.variable(
+            name='offset',
+            shape=config.offset_shape,
+            dtype=config.offset_dtype)
+        mask = self.variable(
+            name='mask', shape=config.mask_shape, dtype=config.mask_dtype)
+        result = torchvision.ops.deform_conv2d(
+            input=input,
+            offset=offset,
+            weight=weight,
+            stride=config.stride,
+            padding=config.padding,
+            dilation=config.dilation,
+            mask=mask)
+
+        self.feed_list = [input, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [input, weight])

--- a/api/tests/depthwise_conv2d.py
+++ b/api/tests/depthwise_conv2d.py
@@ -1,0 +1,29 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+from conv2d import Conv2dConfig, PDConv2d, TorchConv2d
+
+
+@benchmark_registry.register("depthwise_conv2d", reuse="conv2d")
+class DepthwiseConv2dConfig(Conv2dConfig):
+    def __init__(self):
+        super(DepthwiseConv2dConfig, self).__init__("depthwise_conv2d")
+        self.run_tf = False
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(DepthwiseConv2dConfig, self).init_from_json(filename, config_id,
+                                                          unknown_dim)
+        assert self.get_in_channels() == self.groups and self.get_out_channels(
+        ) % self.get_in_channels() == 0

--- a/api/tests/depthwise_conv2d_transpose.py
+++ b/api/tests/depthwise_conv2d_transpose.py
@@ -1,0 +1,75 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+@benchmark_registry.register("depthwise_conv2d_transpose")
+class DepthwiseConv2dTransposeConfig(APIConfig):
+    def __init__(self):
+        super(DepthwiseConv2dTransposeConfig,
+              self).__init__("depthwise_conv2d_transpose")
+        self.run_tf = False
+        self.run_torch = False
+        self.feed_spec = [
+            {
+                "range": [-1, 1]
+            },  # input
+            {
+                "range": [-1, 1],
+            }  # filters
+        ]
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(DepthwiseConv2dTransposeConfig, self).init_from_json(
+            filename, config_id, unknown_dim)
+        if isinstance(self.padding, int):
+            self.padding = [self.padding, self.padding]
+        if self.data_format == "NCHW":
+            self.num_channels = self.input_shape[1]
+        elif self.data_format == "NHWC":
+            self.num_channels = self.input_shape[3]
+        if isinstance(self.filter_size, int):
+            self.filter_size = [self.filter_size, self.filter_size]
+
+        assert self.num_filters == self.groups and self.num_channels != 1
+
+        self.filter_shape = [
+            self.num_channels, self.num_filters // self.groups,
+            self.filter_size[0], self.filter_size[1]
+        ]
+
+
+@benchmark_registry.register("depthwise_conv2d_transpose")
+class PaddleDepthwiseConv2dTranspose(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(
+            name='x', shape=config.input_shape, dtype=config.input_dtype)
+        weight = self.variable(
+            name='weight', shape=config.filter_shape, dtype=config.input_dtype)
+
+        result = paddle.nn.functional.conv2d_transpose(
+            x=x,
+            weight=weight,
+            output_size=config.output_size,
+            stride=config.stride,
+            padding=config.padding,
+            data_format=config.data_format,
+            groups=config.groups,
+            dilation=config.dilation)
+
+        self.feed_list = [x, weight]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight])

--- a/api/tests/interp_area.py
+++ b/api/tests/interp_area.py
@@ -1,0 +1,59 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+@benchmark_registry.register("interp_area")
+class InterpAreaConfig(APIConfig):
+    def __init__(self):
+        super(InterpAreaConfig, self).__init__('interp_area')
+        self.run_tf = False
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(InterpAreaConfig, self).init_from_json(filename, config_id,
+                                                     unknown_dim)
+        if self.data_format == 'NHWC' or self.data_format == 'NDHWC':
+            self.run_torch = False
+
+
+@benchmark_registry.register("interp_area")
+class PaddleInterpArea(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        # align_corners option can only be set with the interpolating modes: linear, area, bicubic, trilinear
+        result = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="area",
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+@benchmark_registry.register("interp_area")
+class TorchInterpArea(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x, size=config.size, mode="area", scale_factor=config.scale_factor)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])

--- a/api/tests/interp_bicubic.py
+++ b/api/tests/interp_bicubic.py
@@ -1,0 +1,63 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+@benchmark_registry.register("interp_bicubic")
+class InterpBicubicConfig(APIConfig):
+    def __init__(self):
+        super(InterpBicubicConfig, self).__init__('interp_bicubic')
+        self.run_tf = False
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(InterpBicubicConfig, self).init_from_json(filename, config_id,
+                                                        unknown_dim)
+        if self.data_format == 'NHWC':
+            self.run_torch = False
+
+
+@benchmark_registry.register("interp_bicubic")
+class PaddleInterpBicubic(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="bilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+@benchmark_registry.register("interp_bicubic")
+class TorchInterpBicubic(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="bilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])

--- a/api/tests/interp_bilinear.py
+++ b/api/tests/interp_bilinear.py
@@ -1,0 +1,67 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+@benchmark_registry.register("interp_bilinear")
+class InterpBilinearConfig(APIConfig):
+    def __init__(self):
+        super(InterpBilinearConfig, self).__init__('interp_bilinear')
+        self.run_tf = False
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(InterpBilinearConfig, self).init_from_json(filename, config_id,
+                                                         unknown_dim)
+        if self.data_format == 'NHWC':
+            print(
+                "Warning:\n"
+                "  1. PyTorch does not have data_format param, it only support NCHW format.\n"
+            )
+            self.run_torch = False
+
+
+@benchmark_registry.register("interp_bilinear")
+class PaddleInterpBilinear(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="bilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+@benchmark_registry.register("interp_bilinear")
+class TorchInterpBilinear(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="bilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])

--- a/api/tests/interp_linear.py
+++ b/api/tests/interp_linear.py
@@ -1,0 +1,57 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+@benchmark_registry.register("interp_linear")
+class InterpLinearConfig(APIConfig):
+    def __init__(self):
+        super(InterpLinearConfig, self).__init__("interp_linear")
+        self.run_tf = False
+
+
+@benchmark_registry.register("interp_linear")
+class PaddleInterpLinear(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="linear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+@benchmark_registry.register("interp_linear")
+class TorchInterpLinear(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="linear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])

--- a/api/tests/interp_nearest.py
+++ b/api/tests/interp_nearest.py
@@ -1,0 +1,61 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+@benchmark_registry.register("interp_nearest")
+class InterpNearestConfig(APIConfig):
+    def __init__(self):
+        super(InterpNearestConfig, self).__init__('interp_nearest')
+        self.run_tf = False
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(InterpNearestConfig, self).init_from_json(filename, config_id,
+                                                        unknown_dim)
+        if self.data_format == 'NHWC':
+            self.run_torch = False
+
+
+@benchmark_registry.register("interp_nearest")
+class PaddleInterpNearest(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="nearest",
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+@benchmark_registry.register("interp_nearest")
+class TorchInterpNearest(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="nearest",
+            scale_factor=config.scale_factor)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])

--- a/api/tests/interp_trilinear.py
+++ b/api/tests/interp_trilinear.py
@@ -1,0 +1,57 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+@benchmark_registry.register("interp_trilinear")
+class InterpTrilinearConfig(APIConfig):
+    def __init__(self):
+        super(InterpTrilinearConfig, self).__init__("interp_trilinear")
+        self.run_tf = False
+
+
+@benchmark_registry.register("interp_trilinear")
+class PaddleInterpTrilinear(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = paddle.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="trilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor,
+            data_format=config.data_format)
+
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])
+
+
+@benchmark_registry.register("interp_trilinear")
+class TorchInterpTrilinear(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.interpolate(
+            x,
+            size=config.size,
+            mode="trilinear",
+            align_corners=config.align_corners,
+            scale_factor=config.scale_factor)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])

--- a/api/tests/linear.py
+++ b/api/tests/linear.py
@@ -1,0 +1,84 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+# TODO(Xreki): to support tf.
+
+
+@benchmark_registry.register("linear")
+class LinearConfig(APIConfig):
+    def __init__(self):
+        super(LinearConfig, self).__init__('linear')
+        self.feed_spec = [
+            {
+                "range": [-1, 1]
+            },  # x
+            {
+                "range": [-1, 1],
+                "permute": [1, 0]
+            },  # weight
+            {
+                "range": [-1, 1]
+            }  # bias
+        ]
+
+    def to_pytorch(self):
+        torch_config = super(LinearConfig, self).to_pytorch()
+        torch_config.weight_shape = [
+            self.weight_shape[1], self.weight_shape[0]
+        ]
+        return torch_config
+
+
+@benchmark_registry.register("linear")
+class PaddleLinear(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name="weight",
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+        if hasattr(config, "bias") and config.bias is None:
+            bias = None
+        else:
+            bias = self.variable(
+                name="bias", shape=config.bias_shape, dtype=config.bias_dtype)
+        result = paddle.nn.functional.linear(x=x, weight=weight, bias=bias)
+
+        self.feed_list = [x, weight, bias]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight, bias])
+
+
+@benchmark_registry.register("linear")
+class TorchLinear(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name="x", shape=config.x_shape, dtype=config.x_dtype)
+        weight = self.variable(
+            name="weight",
+            shape=config.weight_shape,
+            dtype=config.weight_dtype)
+        if hasattr(config, "bias") and config.bias is None:
+            bias = None
+        else:
+            bias = self.variable(
+                name="bias", shape=config.bias_shape, dtype=config.bias_dtype)
+        result = torch.nn.functional.linear(input=x, weight=weight, bias=bias)
+
+        self.feed_list = [x, weight, bias]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x, weight, bias])


### PR DESCRIPTION
迁移第6批动、静态图统一测试脚本。

CI执行情况如下：
```
2022-02-19 20:53:54 [ci/scripts/run_test.sh:132] [FATAL] ============================================
2022-02-19 20:53:54 [ci/scripts/run_test.sh:133] [FATAL] Summary problems:
2022-02-19 20:53:54 [ci/scripts/run_test.sh:139] [FATAL] There is 1 error: API test error.
2022-02-19 20:53:54 [ci/scripts/run_test.sh:141] [FATAL] ============================================
2022-02-19 20:53:54 [ci/scripts/run_test.sh:149] [FATAL] === API test error - Please fix the failed API tests accroding to fatal log:
2022-02-19 20:53:54 [ci/scripts/run_test.sh:150] [FATAL] tests/conv3d(Run on CPU) tests/depthwise_conv2d(Run on GPU) tests/depthwise_conv2d(Run on CPU) tests/interp_linear(Run on GPU) tests/interp_trilinear(Run on GPU) tests/linear(Run on GPU) tests/linear(Run on CPU)
```