### PR TITLE
add multiplex and qr benchmark

### DIFF
--- a/api/dynamic_tests_v2/multiplex.py
+++ b/api/dynamic_tests_v2/multiplex.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/multiplex.py
+++ b/api/dynamic_tests_v2/multiplex.py
@@ -48,7 +48,7 @@ class PaddleMultiplex(PaddleDynamicAPIBenchmarkBase):
         self.feed_list = [inputs, index]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, [index])
+            self.append_gradients(result, inputs)
 
 
 if __name__ == '__main__':

--- a/api/dynamic_tests_v2/multiplex.py
+++ b/api/dynamic_tests_v2/multiplex.py
@@ -1,0 +1,40 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class MultiplexConfig(APIConfig):
+    def __init__(self):
+        super(MultiplexConfig, self).__init__('multiplex')
+        self.run_torch = False
+        print("[WARNING]: Pytorch dosen`t support multiplex currently.")
+
+
+class PaddleMultiplex(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        inputs = self.variable(
+            name='inputs', shape=config.x_shape, dtype=config.x_dtype)
+        index = self.variable(
+            name='index', shape=config.y_shape, dtype=config.y_dtype)
+        result = paddle.multiplex(inputs=inputs, index=index)
+
+        self.feed_list = [inputs, index]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [inputs])
+
+
+if __name__ == '__main__':
+    test_main(pd_dy_obj=PaddleMultiplex(), config=MultiplexConfig())

--- a/api/dynamic_tests_v2/multiplex.py
+++ b/api/dynamic_tests_v2/multiplex.py
@@ -21,24 +21,34 @@ class MultiplexConfig(APIConfig):
         self.run_torch = False
         print("[WARNING]: Pytorch dosen`t support multiplex currently.")
 
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(MultiplexConfig, self).init_from_json(filename, config_id,
+                                                    unknown_dim)
+
+        index = np.array([[3], [0], [1], [2]])
+        self.index_value = index.astype(self.index_dtype)
+
 
 class PaddleMultiplex(PaddleDynamicAPIBenchmarkBase):
     def build_graph(self, config):
         inputs = []
         for i in range(len(config.inputs_shape)):
             input = self.variable(
-                name='input_' + str(i),
+                name='input' + str(i),
                 shape=config.inputs_shape[i],
                 dtype=config.inputs_dtype[i])
             inputs.append(input)
         index = self.variable(
-            name='index', shape=config.index_shape, dtype=config.index_dtype)
+            name='index',
+            shape=config.index_shape,
+            dtype=config.index_dtype,
+            value=config.index_value)
         result = paddle.multiplex(inputs=inputs, index=index)
 
         self.feed_list = [inputs, index]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, [inputs])
+            self.append_gradients(result, [index])
 
 
 if __name__ == '__main__':

--- a/api/dynamic_tests_v2/multiplex.py
+++ b/api/dynamic_tests_v2/multiplex.py
@@ -31,6 +31,7 @@ class MultiplexConfig(APIConfig):
 
 class PaddleMultiplex(PaddleDynamicAPIBenchmarkBase):
     def build_graph(self, config):
+        # The input of multiplex op is a list
         inputs = []
         for i in range(len(config.inputs_shape)):
             input = self.variable(

--- a/api/dynamic_tests_v2/multiplex.py
+++ b/api/dynamic_tests_v2/multiplex.py
@@ -24,10 +24,15 @@ class MultiplexConfig(APIConfig):
 
 class PaddleMultiplex(PaddleDynamicAPIBenchmarkBase):
     def build_graph(self, config):
-        inputs = self.variable(
-            name='inputs', shape=config.x_shape, dtype=config.x_dtype)
+        inputs = []
+        for i in range(len(config.inputs_shape)):
+            input = self.variable(
+                name='input_' + str(i),
+                shape=config.inputs_shape[i],
+                dtype=config.inputs_dtype[i])
+            inputs.append(input)
         index = self.variable(
-            name='index', shape=config.y_shape, dtype=config.y_dtype)
+            name='index', shape=config.index_shape, dtype=config.index_dtype)
         result = paddle.multiplex(inputs=inputs, index=index)
 
         self.feed_list = [inputs, index]

--- a/api/dynamic_tests_v2/qr.py
+++ b/api/dynamic_tests_v2/qr.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/qr.py
+++ b/api/dynamic_tests_v2/qr.py
@@ -32,7 +32,7 @@ class PaddleQr(PaddleDynamicAPIBenchmarkBase):
         self.fetch_list = [result]
 
         if config.backward:
-            self.append_gradients(result, [x])
+            self.append_gradients(list(result), x)
 
 
 if __name__ == '__main__':

--- a/api/dynamic_tests_v2/qr.py
+++ b/api/dynamic_tests_v2/qr.py
@@ -1,0 +1,39 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class QrConfig(APIConfig):
+    def __init__(self):
+        super(QrConfig, self).__init__('qr')
+        self.run_torch = False
+        print("[WARNING]: Pytorch dosen`t support qr currently.")
+
+
+class PaddleQr(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+
+        result = paddle.linalg.qr(x=x, mode=config.mode)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(pd_dy_obj=PaddleQr(), config=QrConfig())

--- a/api/tests_v2/configs/multiplex.json
+++ b/api/tests_v2/configs/multiplex.json
@@ -1,0 +1,57 @@
+[{
+    "op": "multiplex",
+    "param_info": {
+        "inputs": {
+            "dtype": "int32",
+            "shape": "[8L, 1024L, 1024L]",
+            "type": "Variable"
+        },
+        "indexs": {
+            "dtype": "int32",
+            "shape": "[8L, 1L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "multiplex",
+    "param_info": {
+        "inputs": {
+            "dtype": "int64",
+            "shape": "[8L, 1024L, 1024L]",
+            "type": "Variable"
+        },
+        "indexs": {
+            "dtype": "int32",
+            "shape": "[8L, 1L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "multiplex",
+    "param_info": {
+        "inputs": {
+            "dtype": "float32",
+            "shape": "[8L, 1024L, 1024L]",
+            "type": "Variable"
+        },
+        "indexs": {
+            "dtype": "int32",
+            "shape": "[8L, 1L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "multiplex",
+    "param_info": {
+        "inputs": {
+            "dtype": "float64",
+            "shape": "[8L, 1024L, 1024L]",
+            "type": "Variable"
+        },
+        "indexs": {
+            "dtype": "int32",
+            "shape": "[8L, 1L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/configs/multiplex.json
+++ b/api/tests_v2/configs/multiplex.json
@@ -2,13 +2,31 @@
     "op": "multiplex",
     "param_info": {
         "inputs": {
-            "dtype": "int32",
-            "shape": "[8L, 1024L, 1024L]",
-            "type": "Variable"
+            "type": "list<Variable>",
+            "input0": {
+                "dtype": "int32",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input1": {
+                "dtype": "int32",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input2": {
+                "dtype": "int32",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input3": {
+                "dtype": "int32",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            }
         },
-        "indexs": {
+        "index": {
             "dtype": "int32",
-            "shape": "[8L, 1L]",
+            "shape": "[4L, 1L]",
             "type": "Variable"
         }
     }
@@ -16,13 +34,31 @@
     "op": "multiplex",
     "param_info": {
         "inputs": {
-            "dtype": "int64",
-            "shape": "[8L, 1024L, 1024L]",
-            "type": "Variable"
+            "type": "list<Variable>",
+            "input0": {
+                "dtype": "int64",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input1": {
+                "dtype": "int64",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input2": {
+                "dtype": "int64",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input3": {
+                "dtype": "int64",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            }
         },
-        "indexs": {
+        "index": {
             "dtype": "int32",
-            "shape": "[8L, 1L]",
+            "shape": "[4L, 1L]",
             "type": "Variable"
         }
     }
@@ -30,13 +66,31 @@
     "op": "multiplex",
     "param_info": {
         "inputs": {
-            "dtype": "float32",
-            "shape": "[8L, 1024L, 1024L]",
-            "type": "Variable"
+            "type": "list<Variable>",
+            "input0": {
+                "dtype": "float32",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input1": {
+                "dtype": "float32",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input2": {
+                "dtype": "float32",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input3": {
+                "dtype": "float32",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            }
         },
-        "indexs": {
+        "index": {
             "dtype": "int32",
-            "shape": "[8L, 1L]",
+            "shape": "[4L, 1L]",
             "type": "Variable"
         }
     }
@@ -44,13 +98,31 @@
     "op": "multiplex",
     "param_info": {
         "inputs": {
-            "dtype": "float64",
-            "shape": "[8L, 1024L, 1024L]",
-            "type": "Variable"
+            "type": "list<Variable>",
+            "input0": {
+                "dtype": "float64",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input1": {
+                "dtype": "float64",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input2": {
+                "dtype": "float64",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            },
+            "input3": {
+                "dtype": "float64",
+                "shape": "[512L, 512L]",
+                "type": "Variable"
+            }
         },
-        "indexs": {
+        "index": {
             "dtype": "int32",
-            "shape": "[8L, 1L]",
+            "shape": "[4L, 1L]",
             "type": "Variable"
         }
     }

--- a/api/tests_v2/configs/multiplex.json
+++ b/api/tests_v2/configs/multiplex.json
@@ -5,22 +5,22 @@
             "type": "list<Variable>",
             "input0": {
                 "dtype": "int32",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input1": {
                 "dtype": "int32",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input2": {
                 "dtype": "int32",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input3": {
                 "dtype": "int32",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             }
         },
@@ -37,22 +37,22 @@
             "type": "list<Variable>",
             "input0": {
                 "dtype": "int64",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input1": {
                 "dtype": "int64",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input2": {
                 "dtype": "int64",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input3": {
                 "dtype": "int64",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             }
         },
@@ -69,22 +69,22 @@
             "type": "list<Variable>",
             "input0": {
                 "dtype": "float32",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input1": {
                 "dtype": "float32",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input2": {
                 "dtype": "float32",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input3": {
                 "dtype": "float32",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             }
         },
@@ -101,22 +101,22 @@
             "type": "list<Variable>",
             "input0": {
                 "dtype": "float64",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input1": {
                 "dtype": "float64",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input2": {
                 "dtype": "float64",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             },
             "input3": {
                 "dtype": "float64",
-                "shape": "[512L, 512L]",
+                "shape": "[4L, 4L]",
                 "type": "Variable"
             }
         },

--- a/api/tests_v2/configs/multiplex.json
+++ b/api/tests_v2/configs/multiplex.json
@@ -5,22 +5,22 @@
             "type": "list<Variable>",
             "input0": {
                 "dtype": "int32",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input1": {
                 "dtype": "int32",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input2": {
                 "dtype": "int32",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input3": {
                 "dtype": "int32",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             }
         },
@@ -37,22 +37,22 @@
             "type": "list<Variable>",
             "input0": {
                 "dtype": "int64",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input1": {
                 "dtype": "int64",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input2": {
                 "dtype": "int64",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input3": {
                 "dtype": "int64",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             }
         },
@@ -69,22 +69,22 @@
             "type": "list<Variable>",
             "input0": {
                 "dtype": "float32",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input1": {
                 "dtype": "float32",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input2": {
                 "dtype": "float32",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input3": {
                 "dtype": "float32",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             }
         },
@@ -101,22 +101,22 @@
             "type": "list<Variable>",
             "input0": {
                 "dtype": "float64",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input1": {
                 "dtype": "float64",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input2": {
                 "dtype": "float64",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             },
             "input3": {
                 "dtype": "float64",
-                "shape": "[4L, 4L]",
+                "shape": "[256L, 256L]",
                 "type": "Variable"
             }
         },

--- a/api/tests_v2/configs/qr.json
+++ b/api/tests_v2/configs/qr.json
@@ -1,0 +1,53 @@
+[{
+    "op": "qr",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 256L, 512L]",
+            "type": "Variable"
+        },
+        "mode": {
+            "type": "string",
+            "value": "reduced"
+        }
+    }
+}, {
+    "op": "qr",
+    "param_info": {
+        "x": {
+            "dtype": "float64",
+            "shape": "[-1L, 256L, 512L]",
+            "type": "Variable"
+        },
+        "mode": {
+            "type": "string",
+            "value": "reduced"
+        }
+    }
+}, {
+    "op": "qr",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[-1L, 256L, 512L]",
+            "type": "Variable"
+        },
+        "mode": {
+            "type": "string",
+            "value": "complete"
+        }
+    }
+}, {
+    "op": "qr",
+    "param_info": {
+        "x": {
+            "dtype": "float64",
+            "shape": "[-1L, 256L, 512L]",
+            "type": "Variable"
+        },
+        "mode": {
+            "type": "string",
+            "value": "complete"
+        }
+    }
+}]

--- a/api/tests_v2/configs/qr.json
+++ b/api/tests_v2/configs/qr.json
@@ -3,7 +3,7 @@
     "param_info": {
         "x": {
             "dtype": "float32",
-            "shape": "[-1L, 256L, 512L]",
+            "shape": "[-1L, 128L, 128L]",
             "type": "Variable"
         },
         "mode": {
@@ -16,7 +16,7 @@
     "param_info": {
         "x": {
             "dtype": "float64",
-            "shape": "[-1L, 256L, 512L]",
+            "shape": "[-1L, 128L, 128L]",
             "type": "Variable"
         },
         "mode": {
@@ -29,7 +29,7 @@
     "param_info": {
         "x": {
             "dtype": "float32",
-            "shape": "[-1L, 256L, 512L]",
+            "shape": "[-1L, 128L, 128L]",
             "type": "Variable"
         },
         "mode": {
@@ -42,7 +42,7 @@
     "param_info": {
         "x": {
             "dtype": "float64",
-            "shape": "[-1L, 256L, 512L]",
+            "shape": "[-1L, 128L, 128L]",
             "type": "Variable"
         },
         "mode": {


### PR DESCRIPTION
This pr adds multiplex and qr benchmark.
multiplex result：
![multiplex_v2](https://user-images.githubusercontent.com/48191911/158509455-ae519c49-c79e-4943-8945-a62318039993.jpg)

qr result:
![qr_v3_1](https://user-images.githubusercontent.com/48191911/158536473-e2ce6812-32a5-4ffb-9678-92bccaebb932.jpg)
<img width="1438" alt="qr_v3_2" src="https://user-images.githubusercontent.com/48191911/158536643-a5b42663-b00d-40fe-98ae-2b280ab2fbde.png">

