### PR TITLE
[OpBenchmark] add op_benchmark for  selu, nll_loss

### DIFF
--- a/api/dynamic_tests_v2/nll_loss.py
+++ b/api/dynamic_tests_v2/nll_loss.py
@@ -17,7 +17,7 @@ from common_import import *
 
 class NllLossConfig(APIConfig):
     def __init__(self):
-        super(NllLossConfig, self).__init__("nll_loss")
+        super(NllLossConfig, self).__init__("nll_loss") 
 
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
         super(NllLossConfig, self).init_from_json(filename, config_id,

--- a/api/dynamic_tests_v2/selu.py
+++ b/api/dynamic_tests_v2/selu.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/selu.py
+++ b/api/dynamic_tests_v2/selu.py
@@ -1,0 +1,48 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class SeluConfig(APIConfig):
+    def __init__(self):
+        super(SeluConfig, self).__init__("selu")
+        self.feed_spec = {"range": [-1, 1]}
+
+
+class PDSelu(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.nn.functional.selu(
+            x=x, scale=config.scale, alpha=config.alpha)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchSelu(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.nn.functional.selu(input=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(pd_dy_obj=PDSelu(), torch_obj=TorchSelu(), config=SeluConfig())

--- a/api/tests_v2/configs/nll_loss.json
+++ b/api/tests_v2/configs/nll_loss.json
@@ -1,0 +1,37 @@
+[{
+    "op": "nll_loss",
+    "param_info": {
+        "ignore_index": {
+            "type": "int",
+            "value": "-100"
+        },
+        "label": {
+            "dtype": "int64",
+            "shape": "[5100L]",
+            "type": "Variable"
+        },
+        "input": {
+            "dtype": "float32",
+            "shape": "[5100L, 38506L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "nll_loss",
+    "param_info": {
+        "ignore_index": {
+            "type": "int",
+            "value": "-100"
+        },
+        "label": {
+            "dtype": "int64",
+            "shape": "[5100L]",
+            "type": "Variable"
+        },
+        "input": {
+            "dtype": "float16",
+            "shape": "[5100L, 38506L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/configs/selu.json
+++ b/api/tests_v2/configs/selu.json
@@ -1,0 +1,37 @@
+[{
+    "op": "selu",
+    "param_info": {
+        "scale": {
+            "type": "float32",
+            "value": "1.05070"
+        },
+        "alpha": {
+            "type": "float32",
+            "value": "1.673263"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8L, 1024L, 3072L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 10000
+}, {
+    "op": "selu",
+    "param_info": {
+        "scale": {
+            "type": "float32",
+            "value": "2.05070"
+        },
+        "alpha": {
+            "type": "float32",
+            "value": "2.673263"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[8L, 1024L, 3072L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 10000
+}]


### PR DESCRIPTION
为 selu 和 nll_loss 添加了 op benchmark

selu 测试结果： 
![image](https://user-images.githubusercontent.com/16025309/156511866-20f5b01b-e115-4bea-ae31-3673744664eb.png)

nll_loss 测试结果： 
![image](https://user-images.githubusercontent.com/16025309/156741934-a92c1a55-a0cc-4272-85a5-45cf0197db80.png)

