### PR TITLE
Add segment pool benchmark. test=document_fix

### DIFF
--- a/api/dynamic_tests_v2/poisson.py
+++ b/api/dynamic_tests_v2/poisson.py
@@ -17,7 +17,7 @@ from common_import import *
 
 class PoissonConfig(APIConfig):
     def __init__(self):
-        super(TriangularSolveConfig, self).__init__('triangular_solve')
+        super(PoissonConfig, self).__init__('triangular_solve')
         self.feed_spec = [{"range": [0, 100]}]
 
 

--- a/api/dynamic_tests_v2/segment_pool.py
+++ b/api/dynamic_tests_v2/segment_pool.py
@@ -1,0 +1,52 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class SegmentPoolConfig(APIConfig):
+    def __init__(self):
+        super(SegmentPoolConfig, self).__init__('segment_pool')
+        self.run_torch = False
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(SegmentPoolConfig, self).init_from_json(filename, config_id,
+                                                      unknown_dim)
+        self.feed_spec = [
+            {
+                "range": [0, 1]
+            },  # x
+            {
+                "range": [1, self.x_shape[0] // 10]
+            },  # segment_ids
+        ]
+
+
+class PaddleSegmentPool(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        segment_ids = self.variable(
+            name='segment_ids',
+            shape=config.segment_ids_shape,
+            dtype=config.segment_ids_dtype)
+        segment_ids_sorted = paddle.sort(segment_ids)
+        result = getattr(paddle.incubate, config.pool_type)(x,
+                                                            segment_ids_sorted)
+
+        self.feed_vars = [x, segment_ids]
+        self.fetch_vars = [result]
+
+
+if __name__ == '__main__':
+    test_main(pd_dy_obj=PaddleSegmentPool(), config=SegmentPoolConfig())

--- a/api/dynamic_tests_v2/segment_pool.py
+++ b/api/dynamic_tests_v2/segment_pool.py
@@ -19,6 +19,13 @@ class SegmentPoolConfig(APIConfig):
     def __init__(self):
         super(SegmentPoolConfig, self).__init__('segment_pool')
         self.run_torch = False
+        self.api_name = 'segment_sum'
+        self.api_list = {
+            'segment_sum': 'segment_sum',
+            'segment_mean': 'segment_mean',
+            'segment_max': 'segment_max',
+            'segment_min': 'segment_min',
+        }
 
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
         super(SegmentPoolConfig, self).init_from_json(filename, config_id,
@@ -43,7 +50,11 @@ class PaddleSegmentPool(PaddleDynamicAPIBenchmarkBase):
             shape=config.segment_ids_shape,
             dtype=config.segment_ids_dtype,
             value=config.segment_ids_value)
-        result = getattr(paddle.incubate, config.pool_type)(x, segment_ids)
+        result = self.layers(
+            api_name=config.api_name,
+            module_name="paddle.incubate",
+            data=x,
+            segment_ids=segment_ids)
 
         self.feed_vars = [x]
         self.fetch_vars = [result]

--- a/api/dynamic_tests_v2/segment_pool.py
+++ b/api/dynamic_tests_v2/segment_pool.py
@@ -27,10 +27,12 @@ class SegmentPoolConfig(APIConfig):
             {
                 "range": [0, 1]
             },  # x
-            {
-                "range": [1, self.x_shape[0] // 10]
-            },  # segment_ids
         ]
+
+        segment = np.random.randint(
+            0, self.x_shape[0] // 20, size=[self.x_shape[0]])
+        segment = np.sort(segment)
+        self.segment_ids_value = segment.astype(self.segment_ids_dtype)
 
 
 class PaddleSegmentPool(PaddleDynamicAPIBenchmarkBase):
@@ -39,12 +41,11 @@ class PaddleSegmentPool(PaddleDynamicAPIBenchmarkBase):
         segment_ids = self.variable(
             name='segment_ids',
             shape=config.segment_ids_shape,
-            dtype=config.segment_ids_dtype)
-        segment_ids_sorted = paddle.sort(segment_ids)
-        result = getattr(paddle.incubate, config.pool_type)(x,
-                                                            segment_ids_sorted)
+            dtype=config.segment_ids_dtype,
+            value=config.segment_ids_value)
+        result = getattr(paddle.incubate, config.pool_type)(x, segment_ids)
 
-        self.feed_vars = [x, segment_ids]
+        self.feed_vars = [x]
         self.fetch_vars = [result]
 
 

--- a/api/tests_v2/configs/segment_pool.json
+++ b/api/tests_v2/configs/segment_pool.json
@@ -10,46 +10,6 @@
             "dtype": "int32",
             "shape": "[50000]",
             "type": "Variable"
-        },
-        "pool_type": {
-            "type": "string",
-            "value": "segment_sum"
-        }
-    }
-}, {
-    "op": "segment_pool",
-    "param_info": {
-        "x": {
-            "dtype": "float32",
-            "shape": "[50000, 128]",
-            "type": "Variable"
-        },
-        "segment_ids": {
-            "dtype": "int32",
-            "shape": "[50000]",
-            "type": "Variable"
-        },
-        "pool_type": {
-            "type": "string",
-            "value": "segment_mean"
-        }
-    }
-}, {
-    "op": "segment_pool",
-    "param_info": {
-        "x": {
-            "dtype": "float32",
-            "shape": "[50000, 128]",
-            "type": "Variable"
-        },
-        "segment_ids": {
-            "dtype": "int32",
-            "shape": "[50000]",
-            "type": "Variable"
-        },
-        "pool_type": {
-            "type": "string",
-            "value": "segment_max"
         }
     }
 }]

--- a/api/tests_v2/configs/segment_pool.json
+++ b/api/tests_v2/configs/segment_pool.json
@@ -1,0 +1,37 @@
+[{
+    "op": "segment_pool",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[50000, 128]",
+            "type": "Variable"
+        },
+        "segment_ids": {
+            "dtype": "int32",
+            "shape": "[50000]",
+            "type": "Variable"
+        },
+        "pool_type": {
+            "type": "string",
+            "value": "segment_mean"
+        }
+    }
+}, {
+    "op": "segment_pool",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[50000, 128]",
+            "type": "Variable"
+        },
+        "segment_ids": {
+            "dtype": "int32",
+            "shape": "[50000]",
+            "type": "Variable"
+        },
+        "pool_type": {
+            "type": "string",
+            "value": "segment_max"
+        }
+    }
+}]

--- a/api/tests_v2/configs/segment_pool.json
+++ b/api/tests_v2/configs/segment_pool.json
@@ -13,6 +13,24 @@
         },
         "pool_type": {
             "type": "string",
+            "value": "segment_sum"
+        }
+    }
+}, {
+    "op": "segment_pool",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[50000, 128]",
+            "type": "Variable"
+        },
+        "segment_ids": {
+            "dtype": "int32",
+            "shape": "[50000]",
+            "type": "Variable"
+        },
+        "pool_type": {
+            "type": "string",
             "value": "segment_mean"
         }
     }


### PR DESCRIPTION
## 迁移前：
```python
===========================================================================
-- paddle version             : 0.0.0
-- paddle commit              : 051544b6e8af9cef61ba9870b4ab39af40875ce3
-- pytorch version            : 1.8.2+cu102
-- benchmark commit           : 02e0f11b3274e2c299c68ed4a4dc8bd4d4cac9cb
-- benchmark last update time : Fri Mar 4 04:17:08 2022 +0000
===========================================================================
run command: nvidia-smi -L
run command: nvprof --profile-from-start off /usr/local/bin/python /workspace/benchmark/api/dynamic_tests_v2/segment_pool.py --task speed --framework paddle --testing_mode dynamic --json_file /workspace/benchmark/api/tests_v2/configs/segment_pool.json --config_id 0 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   31.45%  107.03ms      1000  107.03us  100.93us  116.90us  void paddle::operators::SegmentOpsKernel<float, int, paddle::operators::ArrangeHelper<int>, paddle::operators::MinPool<float>>(int const *, float const *, int const **, int, paddle::operators::ArrangeHelper<int>)
                   29.25%  99.537ms      1000  99.536us  93.472us  107.68us  void paddle::operators::SegmentOpsKernel<float, int, paddle::operators::ArrangeHelper<int>, paddle::operators::MaxPool<float>>(int const *, float const *, int const **, int, paddle::operators::ArrangeHelper<int>)
                   16.86%  57.387ms      1000  57.387us  55.680us  63.392us  void paddle::operators::SegmentOpsKernel<float, int, paddle::operators::ArrangeHelper<int>, paddle::operators::SumPool<float>>(int const *, float const *, int const **, int, paddle::operators::ArrangeHelper<int>)
                   16.17%  55.049ms      1000  55.049us  53.248us  58.400us  void paddle::operators::SegmentMeanKernel<float, int, int=8>(int const *, float const *, int const **, float const *, paddle::operators::SegmentMeanKernel<float, int, int=8>, paddle::operators::SegmentMeanKernel<float, int, int=8>, paddle::operators::SegmentMeanKernel<float, int, int=8>, paddle::operators::SegmentMeanKernel<float, int, int=8>)
                    2.66%  9.0595ms      5000  1.8110us  1.2160us  3.2000us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                    2.17%  7.3960ms      4000  1.8490us  1.4080us  2.9440us  [CUDA memcpy DtoH]
                    1.44%  4.8906ms      1000  4.8900us  4.7040us  5.2800us  void paddle::operators::SegmentSumIdsKernel<float, int, int=8>(int const *, float*, paddle::operators::SegmentSumIdsKernel<float, int, int=8>, paddle::operators::SegmentSumIdsKernel<float, int, int=8>)

total gpu_time: 340.3180 ms

run command: /usr/local/bin/python /workspace/benchmark/api/dynamic_tests_v2/segment_pool.py --task speed --framework paddle --testing_mode dynamic --json_file /workspace/benchmark/api/tests_v2/configs/segment_pool.json --config_id 0 --profiler none --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0  --gpu_time  340.31796502384736
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
W0304 06:57:19.122053 18286 device_context.cc:447] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 10.2, Runtime API Version: 10.2
W0304 06:57:19.127651 18286 device_context.cc:465] device: 0, cuDNN Version: 7.6.
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=340.31796502384736, json_file='/workspace/benchmark/api/tests_v2/configs/segment_pool.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
---- Initialize APIConfig from /workspace/benchmark/api/tests_v2/configs/segment_pool.json, config_id = 0.

Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=340.31796502384736, json_file='/workspace/benchmark/api/tests_v2/configs/segment_pool.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][segment_pool] segment_sum {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  segment_ids_shape: [50000]
  segment_ids_dtype: int32
  atol: 1e-06
  segment_ids_value: np.ndarray(shape=(50000,), dtype=int32)
}
Failed to import paddle.segment_sum
Failed to import paddle.nn.functional.segment_sum
Successly import paddle.incubate.segment_sum
{"framework": "paddle", "version": "0.0.0", "name": "segment_sum", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.11187743167487943, "wall_time": 0, "total_include_wall_time": 0.11187743167487943, "gpu_time": 0.34031796502384737}, "parameters": "segment_ids (Variable) - dtype: int32, shape: [50000]\nx (Variable) - dtype: float32, shape: [50000, 128]\n"}
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=340.31796502384736, json_file='/workspace/benchmark/api/tests_v2/configs/segment_pool.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][segment_pool] segment_mean {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  segment_ids_shape: [50000]
  segment_ids_dtype: int32
  atol: 1e-06
  segment_ids_value: np.ndarray(shape=(50000,), dtype=int32)
}
Failed to import paddle.segment_mean
Failed to import paddle.nn.functional.segment_mean
Successly import paddle.incubate.segment_mean
{"framework": "paddle", "version": "0.0.0", "name": "segment_mean", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.11749997430918169, "wall_time": 0, "total_include_wall_time": 0.11749997430918169, "gpu_time": 0.34031796502384737}, "parameters": "segment_ids (Variable) - dtype: int32, shape: [50000]\nx (Variable) - dtype: float32, shape: [50000, 128]\n"}
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=340.31796502384736, json_file='/workspace/benchmark/api/tests_v2/configs/segment_pool.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][segment_pool] segment_max {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  segment_ids_shape: [50000]
  segment_ids_dtype: int32
  atol: 1e-06
  segment_ids_value: np.ndarray(shape=(50000,), dtype=int32)
}
Failed to import paddle.segment_max
Failed to import paddle.nn.functional.segment_max
Successly import paddle.incubate.segment_max
{"framework": "paddle", "version": "0.0.0", "name": "segment_max", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.1505798223067303, "wall_time": 0, "total_include_wall_time": 0.1505798223067303, "gpu_time": 0.34031796502384737}, "parameters": "segment_ids (Variable) - dtype: int32, shape: [50000]\nx (Variable) - dtype: float32, shape: [50000, 128]\n"}
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=340.31796502384736, json_file='/workspace/benchmark/api/tests_v2/configs/segment_pool.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][segment_pool] segment_min {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  segment_ids_shape: [50000]
  segment_ids_dtype: int32
  atol: 1e-06
  segment_ids_value: np.ndarray(shape=(50000,), dtype=int32)
}
Failed to import paddle.segment_min
Failed to import paddle.nn.functional.segment_min
Successly import paddle.incubate.segment_min
{"framework": "paddle", "version": "0.0.0", "name": "segment_min", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.14961884946239237, "wall_time": 0, "total_include_wall_time": 0.14961884946239237, "gpu_time": 0.34031796502384737}, "parameters": "segment_ids (Variable) - dtype: int32, shape: [50000]\nx (Variable) - dtype: float32, shape: [50000, 128]\n"}

```

## 迁移后

```python
===========================================================================
-- paddle version             : 0.0.0
-- paddle commit              : 2fa07ef9e1730fd354387c08d9863527c353154b
-- pytorch version            : 1.8.2+cu102
-- benchmark commit           : 02e0f11b3274e2c299c68ed4a4dc8bd4d4cac9cb
-- benchmark last update time : Fri Mar 4 04:17:08 2022 +0000
===========================================================================
run command: nvidia-smi -L
run command: nvprof --profile-from-start off /usr/local/bin/python /workspace/benchmark/api/dynamic_tests_v2/segment_pool.py --task speed --framework paddle --testing_mode dynamic --json_file /workspace/benchmark/api/tests_v2/configs/segment_pool.json --config_id 0 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   25.88%  61.541ms      1000  61.541us  60.768us  64.863us  void phi::funcs::SegmentOpsKernel<float, int, phi::funcs::ArrangeHelper<int>, phi::funcs::MaxPool<float>>(int const *, float const *, int const **, int, phi::funcs::ArrangeHelper<int>)
                   25.83%  61.416ms      1000  61.416us  60.640us  64.480us  void phi::funcs::SegmentOpsKernel<float, int, phi::funcs::ArrangeHelper<int>, phi::funcs::MinPool<float>>(int const *, float const *, int const **, int, phi::funcs::ArrangeHelper<int>)
                   20.87%  49.630ms      1000  49.630us  49.119us  53.088us  void phi::funcs::SegmentOpsKernel<float, int, phi::funcs::ArrangeHelper<int>, phi::funcs::SumPool<float>>(int const *, float const *, int const **, int, phi::funcs::ArrangeHelper<int>)
                   18.82%  44.737ms      1000  44.737us  44.160us  47.392us  void phi::funcs::SegmentMeanKernel<float, int, int=8>(int const *, float const *, int const **, float const *, phi::funcs::SegmentMeanKernel<float, int, int=8>, phi::funcs::SegmentMeanKernel<float, int, int=8>, phi::funcs::SegmentMeanKernel<float, int, int=8>, phi::funcs::SegmentMeanKernel<float, int, int=8>)
                    4.00%  9.5069ms      5000  1.9010us  1.2470us  3.0080us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<float>, Eigen::TensorMap<Eigen::Tensor<float, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=1)
                    3.17%  7.5287ms      4000  1.8820us  1.4720us  3.2320us  [CUDA memcpy DtoH]
                    1.43%  3.4013ms      1000  3.4010us  3.2960us  4.0960us  void phi::funcs::SegmentSumIdsKernel<float, int, int=8>(int const *, float*, phi::funcs::SegmentSumIdsKernel<float, int, int=8>, phi::funcs::SegmentSumIdsKernel<float, int, int=8>)

total gpu_time: 237.7937 ms

run command: /usr/local/bin/python /workspace/benchmark/api/dynamic_tests_v2/segment_pool.py --task speed --framework paddle --testing_mode dynamic --json_file /workspace/benchmark/api/tests_v2/configs/segment_pool.json --config_id 0 --profiler none --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0  --gpu_time  237.79366306027822
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
W0304 07:00:38.545823 18472 gpu_context.cc:240] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 10.2, Runtime API Version: 10.2
W0304 07:00:38.550472 18472 gpu_context.cc:268] device: 0, cuDNN Version: 7.6.
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=237.79366306027822, json_file='/workspace/benchmark/api/tests_v2/configs/segment_pool.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
---- Initialize APIConfig from /workspace/benchmark/api/tests_v2/configs/segment_pool.json, config_id = 0.

Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=237.79366306027822, json_file='/workspace/benchmark/api/tests_v2/configs/segment_pool.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][segment_pool] segment_sum {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  segment_ids_shape: [50000]
  segment_ids_dtype: int32
  atol: 1e-06
  segment_ids_value: np.ndarray(shape=(50000,), dtype=int32)
}
Failed to import paddle.segment_sum
Failed to import paddle.nn.functional.segment_sum
Successly import paddle.incubate.segment_sum
{"framework": "paddle", "version": "0.0.0", "name": "segment_sum", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.12763130421541174, "wall_time": 0, "total_include_wall_time": 0.12763130421541174, "gpu_time": 0.23779366306027822}, "parameters": "segment_ids (Variable) - dtype: int32, shape: [50000]\nx (Variable) - dtype: float32, shape: [50000, 128]\n"}
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=237.79366306027822, json_file='/workspace/benchmark/api/tests_v2/configs/segment_pool.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][segment_pool] segment_mean {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  segment_ids_shape: [50000]
  segment_ids_dtype: int32
  atol: 1e-06
  segment_ids_value: np.ndarray(shape=(50000,), dtype=int32)
}
Failed to import paddle.segment_mean
Failed to import paddle.nn.functional.segment_mean
Successly import paddle.incubate.segment_mean
{"framework": "paddle", "version": "0.0.0", "name": "segment_mean", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.12356067190364915, "wall_time": 0, "total_include_wall_time": 0.12356067190364915, "gpu_time": 0.23779366306027822}, "parameters": "segment_ids (Variable) - dtype: int32, shape: [50000]\nx (Variable) - dtype: float32, shape: [50000, 128]\n"}
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=237.79366306027822, json_file='/workspace/benchmark/api/tests_v2/configs/segment_pool.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][segment_pool] segment_max {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  segment_ids_shape: [50000]
  segment_ids_dtype: int32
  atol: 1e-06
  segment_ids_value: np.ndarray(shape=(50000,), dtype=int32)
}
Failed to import paddle.segment_max
Failed to import paddle.nn.functional.segment_max
Successly import paddle.incubate.segment_max
{"framework": "paddle", "version": "0.0.0", "name": "segment_max", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.12825484178504165, "wall_time": 0, "total_include_wall_time": 0.12825484178504165, "gpu_time": 0.23779366306027822}, "parameters": "segment_ids (Variable) - dtype: int32, shape: [50000]\nx (Variable) - dtype: float32, shape: [50000, 128]\n"}
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=237.79366306027822, json_file='/workspace/benchmark/api/tests_v2/configs/segment_pool.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][segment_pool] segment_min {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  segment_ids_shape: [50000]
  segment_ids_dtype: int32
  atol: 1e-06
  segment_ids_value: np.ndarray(shape=(50000,), dtype=int32)
}
Failed to import paddle.segment_min
Failed to import paddle.nn.functional.segment_min
Successly import paddle.incubate.segment_min
{"framework": "paddle", "version": "0.0.0", "name": "segment_min", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.1266637626959353, "wall_time": 0, "total_include_wall_time": 0.1266637626959353, "gpu_time": 0.23779366306027822}, "parameters": "segment_ids (Variable) - dtype: int32, shape: [50000]\nx (Variable) - dtype: float32, shape: [50000, 128]\n"}

```