### PR TITLE
[Op Benchmark] add cumprod op benchmark

### DIFF
--- a/api/dynamic_tests_v2/cumprod.py
+++ b/api/dynamic_tests_v2/cumprod.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/cumprod.py
+++ b/api/dynamic_tests_v2/cumprod.py
@@ -1,0 +1,50 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class CumprodConfig(APIConfig):
+    def __init__(self):
+        super(CumprodConfig, self).__init__('cumprod')
+        self.feed_spec = {"range": [-1, 1]}
+
+
+class PDCumprod(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.cumprod(x=x, dim=config.dim)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+class TorchCumprod(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.cumprod(x=x, dim=config.dim)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+        if config.backward:
+            self.append_gradients(result, [x])
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PDCumprod(),
+        torch_obj=TorchCumprod(),
+        config=CumprodConfig())

--- a/api/tests_v2/configs/cumprod.json
+++ b/api/tests_v2/configs/cumprod.json
@@ -1,0 +1,28 @@
+[{
+    "op": "cumprod",
+    "param_info": {
+        "dim": {
+            "type": "int",
+            "value": "0"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1700971L, 1L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "op": "cumprod",
+    "param_info": {
+        "dim": {
+            "type": "int",
+            "value": "0"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[1700971L, 100L]",
+            "type": "Variable"
+        }
+    },
+    "repeat": 100
+}]


### PR DESCRIPTION
# New features
本地运行结果： 
<img width="1440" alt="截屏2022-03-07 上午11 32 13" src="https://user-images.githubusercontent.com/16025309/156963271-22ee68b5-111a-47cc-b629-ffb9c24a3b17.png">
<img width="1438" alt="截屏2022-03-07 上午11 32 52" src="https://user-images.githubusercontent.com/16025309/156963297-30635c32-1fbe-438b-93be-2d7fc6ef7f27.png">

