### PR TITLE
Enhance the static mode of unified tests.

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -165,13 +165,13 @@ class APIConfig(object):
     def __init__(self, op_type, params=None):
         self.__name = op_type
         self.__framework = "paddle"
+        self.__run_tf = True
         self.api_name = self.name
         self.params = params
         self.variable_list = None
         self.params_list = None
         self.backward = False
         self.feed_spec = None
-        self.run_tf = True
         self.run_torch = True
         self.alias_name = None
 
@@ -202,6 +202,14 @@ class APIConfig(object):
     @property
     def framework(self):
         return self.__framework
+
+    @property
+    def run_tf(self):
+        return self.__run_tf
+
+    @run_tf.setter
+    def run_tf(self, value):
+        self.__run_tf = value
 
     def compute_dtype(self):
         dtype = None
@@ -315,7 +323,7 @@ class APIConfig(object):
         ]
         if self.framework != "paddle":
             exclude_attrs.append("run_torch")
-            exclude_attrs.append("run_tf")
+            exclude_attrs.append("_APIConfig__run_tf")
         prefix = ""
         debug_str = ('[%s][%s] %s {\n') % (self.framework, self.name,
                                            self.api_name)
@@ -326,8 +334,8 @@ class APIConfig(object):
                         '  %s: np.ndarray(shape=%s, dtype=%s)\n') % (
                             name, str(value.shape), value.dtype)
                 else:
-                    debug_str = debug_str + ('  %s%s: %s\n') % (prefix, name,
-                                                                value)
+                    debug_str = debug_str + ('  %s%s: %s\n') % (
+                        prefix, name.replace("_APIConfig__", ""), value)
         debug_str = debug_str + prefix + '}'
         return debug_str
 

--- a/api/common/paddle_op_benchmark.py
+++ b/api/common/paddle_op_benchmark.py
@@ -367,8 +367,8 @@ class PaddleOpBenchmarkBase(BenchmarkBase):
             self._backward = True
             if self._testing_mode == "static":
                 print("Gradients: ", gradients)
-                if not hasattr(self, "fetch_vars") and hasattr(self,
-                                                               "fetch_list"):
+                if not hasattr(self,
+                               "fetch_vars") and self.fetch_list is not None:
                     self.fetch_vars = self.fetch_list
                 _append_to_list(gradients, self.fetch_vars)
             else:
@@ -388,6 +388,8 @@ class PaddleOpBenchmarkBase(BenchmarkBase):
     def run(self, config, args, use_feed_fetch=True, feeder_adapter=None):
         self._layers_function = None
         self._task = args.task
+        self.feed_list = None
+        self.fetch_list = None
         if self._testing_mode == "dynamic":
             self._helper = DynamicHelper()
             return self._run_dynamic(config, args, feeder_adapter)

--- a/api/common/paddle_op_benchmark.py
+++ b/api/common/paddle_op_benchmark.py
@@ -367,6 +367,9 @@ class PaddleOpBenchmarkBase(BenchmarkBase):
             self._backward = True
             if self._testing_mode == "static":
                 print("Gradients: ", gradients)
+                if not hasattr(self, "fetch_vars") and hasattr(self,
+                                                               "fetch_list"):
+                    self.fetch_vars = self.fetch_list
                 _append_to_list(gradients, self.fetch_vars)
             else:
                 _append_to_list(gradients, self.fetch_list)

--- a/api/common/tensorflow_op_benchmark.py
+++ b/api/common/tensorflow_op_benchmark.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import sys
 import json
 import time
@@ -56,14 +54,9 @@ class Profiler(object):
         elif self.profiler != "none":
             self.profiler_handle = model_analyzer.Profiler(
                 graph=self.sess.graph)
-            if tf.__version__ < "1.15.0":
-                self.run_options = tf.RunOptions(
-                    trace_level=tf.RunOptions.FULL_TRACE)
-                self.run_metadata = tf.RunMetadata()
-            else:
-                self.run_options = tf.compat.v1.RunOptions(
-                    trace_level=tf.compat.v1.RunOptions.FULL_TRACE)
-                self.run_metadata = tf.compat.v1.RunMetadata()
+            self.run_options = tf.compat.v1.RunOptions(
+                trace_level=tf.compat.v1.RunOptions.FULL_TRACE)
+            self.run_metadata = tf.compat.v1.RunMetadata()
         return self
 
     def add_step(self, step):
@@ -104,8 +97,9 @@ class TensorflowAPIBenchmarkBase(BenchmarkBase):
         try:
             import tensorflow as tf
             self.graph = tf.Graph()
-            if tf.__version__ > "1.15.0":
-                tf.compat.v1.disable_eager_execution()
+            assert tf.__version__ >= "1.15.0", "The installed tensorflow's version is expected to be newer than 1.15.0, but recieved {}".format(
+                tf.__version__)
+            tf.compat.v1.disable_eager_execution()
         except Exception as e:
             sys.stderr.write(
                 "Cannot import tensorflow, maybe tensorflow is not installed.\n"
@@ -113,11 +107,7 @@ class TensorflowAPIBenchmarkBase(BenchmarkBase):
 
     def placeholder(self, name, shape, dtype):
         tf_dtype = tf.as_dtype(dtype)
-        if tf.__version__ >= "1.15.0":
-            var = tf.compat.v1.placeholder(
-                name=name, shape=shape, dtype=tf_dtype)
-        else:
-            var = tf.placeholder(name=name, shape=shape, dtype=tf_dtype)
+        var = tf.compat.v1.placeholder(name=name, shape=shape, dtype=tf_dtype)
         return var
 
     def variable(self, name, shape, dtype, value=None):
@@ -200,8 +190,6 @@ class TensorflowAPIBenchmarkBase(BenchmarkBase):
 
     def run_impl(self, use_gpu, config, feed, repeat=1, profiler="none"):
         sess = self._init_session(use_gpu)
-
-        #tf.debugging.set_log_device_placement(True)
 
         def _run_main_iter(run_options=None, run_metadata=None):
             feed_dict = feed if self._need_feed else None
@@ -308,23 +296,16 @@ class TensorflowAPIBenchmarkBase(BenchmarkBase):
         return outputs, stats
 
     def _init_session(self, use_gpu):
-        if tf.__version__ >= "1.15.0":
-            config = tf.compat.v1.ConfigProto()
-            if use_gpu:
-                config.gpu_options.allow_growth = self.allow_growth
-            else:
-                # In default, TF use full cpu cores, but Paddle use one cpu core.
-                # To make the same experiment, set TF use one cpu core as well.
-                # See https://github.com/PaddlePaddle/Paddle/issues/18665#issuecomment-513780210
-                config.intra_op_parallelism_threads = 1
-                config.inter_op_parallelism_threads = 1
-            sess = tf.compat.v1.Session(config=config)
-            sess.run(tf.compat.v1.global_variables_initializer())
-            sess.run(tf.compat.v1.local_variables_initializer())
-        else:
-            config = tf.ConfigProto()
+        config = tf.compat.v1.ConfigProto()
+        if use_gpu:
             config.gpu_options.allow_growth = self.allow_growth
-            sess = tf.Session(config=config)
-            sess.run(tf.global_variables_initializer())
-            sess.run(tf.local_variables_initializer())
+        else:
+            # In default, TF use full cpu cores, but Paddle use one cpu core.
+            # To make the same experiment, set TF use one cpu core as well.
+            # See https://github.com/PaddlePaddle/Paddle/issues/18665#issuecomment-513780210
+            config.intra_op_parallelism_threads = 1
+            config.inter_op_parallelism_threads = 1
+        sess = tf.compat.v1.Session(config=config)
+        sess.run(tf.compat.v1.global_variables_initializer())
+        sess.run(tf.compat.v1.local_variables_initializer())
         return sess

--- a/api/common/utils.py
+++ b/api/common/utils.py
@@ -77,7 +77,7 @@ class ArrayComparator(object):
 def _check_type(output, target):
     def _is_numpy_dtype(value):
         if type(value) in [
-                np.float32, np.float16, np.int32, np.int64, np.bool, np.bool_
+                np.float32, np.float16, np.int32, np.int64, bool, np.bool_
         ]:
             return True
         else:
@@ -177,13 +177,17 @@ def check_outputs(output_list,
             target = target_list[i]
 
             if testing_mode == "static":
-                if isinstance(
-                        target,
-                        tf.python.framework.indexed_slices.IndexedSlicesValue):
-                    print(
-                        "---- Warning: Th %d-th target's type is IndexedSlicesValue and the check is skipped. "
-                        "It will be fixed later." % i)
-                    continue
+                try:
+                    if isinstance(target, tf.python.framework.indexed_slices.
+                                  IndexedSlicesValue):
+                        print(
+                            "---- Warning: Th %d-th target's type is IndexedSlicesValue and the check is skipped. "
+                            "It will be fixed later." % i)
+                        continue
+                except Exception as e:
+                    if tf.__version__ < "2.4.0":
+                        # I am not sure about the exact version
+                        print("Meets an exception: {}".format(e))
 
             output, target = _check_type(output, target)
             output, target = _check_shape(name, output, target, i)

--- a/api/tests/activation.py
+++ b/api/tests/activation.py
@@ -34,12 +34,20 @@ class ActivationConfig(APIConfig):
             'softshrink': 'softshrink',
             'softsign': 'softsign'
         }
-        # TODO(Xreki): hardsigmoid, hardswish, tanhshrink, softshrink are not supported in tf.
+
+    @property
+    def run_tf(self):
+        if self.api_name in [
+                "hardsigmoid", "hardswish", "tanhshrink", "softshrink"
+        ]:
+            print("-- %s is not supported in tf." % self.api_name)
+            return False
+        return True
 
     def disabled(self):
         if self.api_name in ["selu"] and self.x_dtype == "float16":
             print(
-                "Warning:\n"
+                "-- Warning:\n"
                 "  1. This config is disabled because float16 is not supported for %s.\n"
                 % (self.api_name))
             return True

--- a/api/tests/activation.py
+++ b/api/tests/activation.py
@@ -22,13 +22,8 @@ class ActivationConfig(APIConfig):
         self.api_name = 'sigmoid'
         self.api_list = {
             'sigmoid': 'sigmoid',
-            'relu': 'relu',
-            'relu6': 'relu6',
-            'leaky_relu': 'leaky_relu',
-            'elu': 'elu',
             'hardsigmoid': 'hardsigmoid',
             'hardswish': 'hardswish',
-            'selu': 'selu',
             'softplus': 'softplus',
             'tanhshrink': 'tanhshrink',
             'softshrink': 'softshrink',
@@ -43,15 +38,6 @@ class ActivationConfig(APIConfig):
             print("-- %s is not supported in tf." % self.api_name)
             return False
         return True
-
-    def disabled(self):
-        if self.api_name in ["selu"] and self.x_dtype == "float16":
-            print(
-                "-- Warning:\n"
-                "  1. This config is disabled because float16 is not supported for %s.\n"
-                % (self.api_name))
-            return True
-        return super(ActivationConfig, self).disabled()
 
 
 @benchmark_registry.register("activation")

--- a/api/tests/common_import.py
+++ b/api/tests/common_import.py
@@ -75,8 +75,9 @@ def unsqueeze_short(short, long):
 
 
 def numel(shape):
-    assert isinstance(
-        shape, list), "Expect shape to be a list, but recieved {}".format(
+    assert isinstance(shape, list) or isinstance(
+        shape,
+        tuple), "Expect shape to be a list or tuple, but recieved {}".format(
             type(shape))
     return np.prod(np.array(shape))
 

--- a/api/tests/compare.py
+++ b/api/tests/compare.py
@@ -29,16 +29,18 @@ class CompareConfig(APIConfig):
             'equal': 'eq'
         }
 
-        # TODO(Xreki): the api of tf and pytorch is different.
-
-    #        self.api_list = {
-    #            'less_than': 'less',
-    #            'less_equal': 'less_equal',
-    #            'not_equal': 'not_equal',
-    #            'greater_than': 'greater',
-    #            'greater_equal': 'greater_equal',
-    #            'equal': 'equal'
-    #        }
+    def to_tensorflow(self):
+        # The change of self.api_list should be in front of the calling of parent's function.
+        self.api_list = {
+            'less_than': 'less',
+            'less_equal': 'less_equal',
+            'not_equal': 'not_equal',
+            'greater_than': 'greater',
+            'greater_equal': 'greater_equal',
+            'equal': 'equal'
+        }
+        tf_config = super(CompareConfig, self).to_tensorflow()
+        return tf_config
 
 
 @benchmark_registry.register("compare")

--- a/api/tests/elementwise.py
+++ b/api/tests/elementwise.py
@@ -30,8 +30,7 @@ class ElementwiseConfig(APIConfig):
         self.feed_spec = [{"range": [-1, 1]}, {"range": [-1, 1]}]
 
     def disabled(self):
-        if self.api_name in ["pow", "maximum", "minimum", "divide"
-                             ] and self.x_dtype == "float16":
+        if self.api_name in ["pow"] and self.x_dtype == "float16":
             print(
                 "Warning:\n"
                 "  1. This config is disabled because float16 is not supported for %s.\n"

--- a/api/tests/isfinite_nan_inf.py
+++ b/api/tests/isfinite_nan_inf.py
@@ -25,13 +25,16 @@ class IsfiniteNanInfConfig(APIConfig):
             'isnan': 'isnan',
             'isinf': 'isinf'
         }
-        # TODO(Xreki): the tf's api are different.
 
-    #        self.api_list = {
-    #            'isfinite': 'is_finite',
-    #            'isnan': 'is_nan',
-    #            'isinf': 'is_inf'
-    #        }
+    def to_tensorflow(self):
+        # The change of self.api_list should be in front of the calling of parent's function.
+        self.api_list = {
+            'isfinite': 'is_finite',
+            'isnan': 'is_nan',
+            'isinf': 'is_inf'
+        }
+        tf_config = super(IsfiniteNanInfConfig, self).to_tensorflow()
+        return tf_config
 
 
 @benchmark_registry.register("isfinite_nan_inf")

--- a/api/tests/reduce.py
+++ b/api/tests/reduce.py
@@ -21,22 +21,41 @@ class ReduceConfig(APIConfig):
         super(ReduceConfig, self).__init__('reduce')
         self.feed_spec = {"range": [-1, 1]}
         self.api_name = 'sum'
-        self.api_list = {'sum': 'sum', 'mean': 'mean'}
-        # TODO(Xreki): the api is different in tf.
+        self.api_list = {
+            'sum': 'sum',
+            'mean': 'mean',
+            'max': 'max',
+            'min': 'min',
+            'prod': 'prod'
+        }
 
-    #        self.api_list = {
-    #            'max': 'reduce_max',
-    #            'mean': 'reduce_mean',
-    #            'min': 'reduce_min',
-    #            'sum': 'reduce_sum',
-    #            'prod': 'reduce_prod'
-    #        }
+    def disabled(self):
+        if self.api_name in ["max", "min", "prod"
+                             ] and self.x_dtype == "float16":
+            print(
+                "Warning:\n"
+                "  1. This config is disabled because float16 is not supported for %s.\n"
+                % (self.api_name))
+            return True
+        return super(ReduceConfig, self).disabled()
 
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
         super(ReduceConfig, self).init_from_json(filename, config_id,
                                                  unknown_dim)
         if self.axis == None:
             self.axis = []
+
+    def to_tensorflow(self):
+        # The change of self.api_list should be in front of the calling of parent's function.
+        self.api_list = {
+            'max': 'reduce_max',
+            'mean': 'reduce_mean',
+            'min': 'reduce_min',
+            'sum': 'reduce_sum',
+            'prod': 'reduce_prod'
+        }
+        tf_config = super(ReduceConfig, self).to_tensorflow()
+        return tf_config
 
 
 @benchmark_registry.register("reduce")

--- a/api/tests/reduce.py
+++ b/api/tests/reduce.py
@@ -48,10 +48,10 @@ class ReduceConfig(APIConfig):
     def to_tensorflow(self):
         # The change of self.api_list should be in front of the calling of parent's function.
         self.api_list = {
-            'max': 'reduce_max',
-            'mean': 'reduce_mean',
-            'min': 'reduce_min',
             'sum': 'reduce_sum',
+            'mean': 'reduce_mean',
+            'max': 'reduce_max',
+            'min': 'reduce_min',
             'prod': 'reduce_prod'
         }
         tf_config = super(ReduceConfig, self).to_tensorflow()

--- a/api/tests/reduce_all_any.py
+++ b/api/tests/reduce_all_any.py
@@ -23,17 +23,17 @@ class ReduceAllAnyConfig(APIConfig):
         self.api_name = 'all'
         self.api_list = {'all': 'all', 'any': 'any'}
 
-    def init_from_json(self, filename, config_id=3, unknown_dim=16):
-        super(ReduceAllAnyConfig, self).init_from_json(filename, config_id,
-                                                       unknown_dim)
-        if self.axis == None:
-            self.axis = []
-
     def to_tensorflow(self):
         # The change of self.api_list should be in front of the calling of parent's function.
         self.api_list = {'all': 'reduce_all', 'any': 'reduce_any'}
         tf_config = super(ReduceAllAnyConfig, self).to_tensorflow()
         return tf_config
+
+    def to_pytorch(self):
+        torch_config = super(ReduceAllAnyConfig, self).to_pytorch()
+        if torch_config.axis == None:
+            torch_config.axis = []
+        return torch_config
 
     def squeeze_shape(self):
         if len(self.axis) == 1:

--- a/api/tests/reduce_all_any.py
+++ b/api/tests/reduce_all_any.py
@@ -14,8 +14,6 @@
 
 from common_import import *
 
-# TODO(Xreki): to support tf.
-
 
 @benchmark_registry.register("reduce_all_any")
 class ReduceAllAnyConfig(APIConfig):
@@ -30,6 +28,12 @@ class ReduceAllAnyConfig(APIConfig):
                                                        unknown_dim)
         if self.axis == None:
             self.axis = []
+
+    def to_tensorflow(self):
+        # The change of self.api_list should be in front of the calling of parent's function.
+        self.api_list = {'all': 'reduce_all', 'any': 'reduce_any'}
+        tf_config = super(ReduceAllAnyConfig, self).to_tensorflow()
+        return tf_config
 
     def squeeze_shape(self):
         if len(self.axis) == 1:
@@ -80,6 +84,21 @@ class TorchReduceAllAny(PytorchOpBenchmarkBase):
         else:
             result = self.layers(
                 config.api_name, input=x, dim=axis, keepdim=config.keepdim)
+
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+@benchmark_registry.register("reduce_all_any")
+class TFReduceAllAny(TensorflowOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = self.layers(
+            config.api_name,
+            module_name="tensorflow.math",
+            input_tensor=x,
+            axis=config.axis,
+            keepdims=config.keepdim)
 
         self.feed_list = [x]
         self.fetch_list = [result]

--- a/api/tests/relu.py
+++ b/api/tests/relu.py
@@ -1,0 +1,54 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+from activation import PaddleActivation, TorchActivation
+
+
+@benchmark_registry.register("relu", reuse="activation")
+class ReluConfig(APIConfig):
+    def __init__(self):
+        super(ReluConfig, self).__init__('relu')
+        self.api_name = 'relu'
+        self.api_list = {
+            'elu': 'elu',
+            'leaky_relu': 'leaky_relu',
+            'relu': 'relu',
+            'relu6': 'relu6',
+            'selu': 'selu',
+        }
+        # relu belongs to activation op series which only has one variable
+        # thus relu can reuse activation parameters 
+        self.alias_name = "activation"
+
+    def disabled(self):
+        if self.api_name in ["selu"] and self.x_dtype == "float16":
+            print(
+                "-- Warning:\n"
+                "  1. This config is disabled because float16 is not supported for %s.\n"
+                % (self.api_name))
+            return True
+        return super(ReluConfig, self).disabled()
+
+
+@benchmark_registry.register("relu")
+class TFRelu(TensorflowOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        out = self.layers(config.api_name, features=x)
+
+        self.feed_list = [x]
+        self.fetch_list = [out]
+        if config.backward:
+            self.append_gradients(out, [x])

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[ -z "$(set | grep '^CUDA_VISIBLE_DEVICES=')" ] && export CUDA_VISIBLE_DEVICES="2"   # Set to "" if testing CPU
+[ -z "$(set | grep '^CUDA_VISIBLE_DEVICES=')" ] && export CUDA_VISIBLE_DEVICES="0"   # Set to "" if testing CPU
 
 NVCC=`which nvcc`
 if [ ${NVCC} != "" ]; then
@@ -15,7 +15,7 @@ name=${1:-"abs"}
 config_id=${2:-"0"}
 task=${3:-"accuracy"} # "accuracy" or "speed"
 
-testing_mode="dynamic" # "static" or "dynamic"
+testing_mode="static" # "static" or "dynamic"
 framework="paddle"  # "paddle" or "tensorflow" or "pytorch"
 filename="${OP_BENCHMARK_ROOT}/tests_v2/configs/${name}.json"
 if [ -z "$CUDA_VISIBLE_DEVICES" ]; then


### PR DESCRIPTION
1. tf移除1.15.0以下的版本支持，要求必须大于1.15.0。
2. 支持tf测试的精确计时。
3. 统一测试脚本里面，对一些复杂情况添加tf测试的支持。