### PR TITLE
Add shard_index op benchmark

### DIFF
--- a/api/dynamic_tests_v2/shard_index.py
+++ b/api/dynamic_tests_v2/shard_index.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/api/dynamic_tests_v2/shard_index.py
+++ b/api/dynamic_tests_v2/shard_index.py
@@ -1,0 +1,35 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class ShardIndexConfig(APIConfig):
+    def __init__(self):
+        super(ShardIndexConfig, self).__init__("shard_index")
+        self.feed_spec = {"range": [0, 999]}
+        self.run_torch = False
+
+
+class PDShardIndex(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        input = self.variable(
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
+        result = paddle.shard_index(input=input, index_num=1000, nshards=10, shard_id=0)
+        self.feed_list = [input]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(pd_dy_obj=PDShardIndex(), config=ShardIndexConfig())

--- a/api/dynamic_tests_v2/shard_index.py
+++ b/api/dynamic_tests_v2/shard_index.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ from common_import import *
 class ShardIndexConfig(APIConfig):
     def __init__(self):
         super(ShardIndexConfig, self).__init__("shard_index")
-        self.feed_spec = {"range": [0, 999]}
+        self.feed_spec = {"range": [0, 99999]}
         self.run_torch = False
 
 
@@ -26,7 +26,7 @@ class PDShardIndex(PaddleDynamicAPIBenchmarkBase):
     def build_graph(self, config):
         input = self.variable(
             name="input", shape=config.input_shape, dtype=config.input_dtype)
-        result = paddle.shard_index(input=input, index_num=1000, nshards=10, shard_id=0)
+        result = paddle.shard_index(input=input, index_num=100000, nshards=100, shard_id=0)
         self.feed_list = [input]
         self.fetch_list = [result]
 

--- a/api/tests_v2/configs/shard_index.json
+++ b/api/tests_v2/configs/shard_index.json
@@ -5,7 +5,7 @@
         "input": {
           "type": "Variable",
           "dtype": "int64",
-          "shape": "[100000L, 1L]"
+          "shape": "[10000L, 5000L, 1L]"
         }
       },
       "repeat": 5000
@@ -16,7 +16,7 @@
           "input": {
             "type": "Variable",
             "dtype": "int32",
-            "shape": "[100000L, 1L]"
+            "shape": "[10000L, 10000L, 1L]"
           }
         },
         "repeat": 5000

--- a/api/tests_v2/configs/shard_index.json
+++ b/api/tests_v2/configs/shard_index.json
@@ -1,0 +1,24 @@
+[
+    {
+      "op": "shard_index",
+      "param_info": {
+        "input": {
+          "type": "Variable",
+          "dtype": "int64",
+          "shape": "[1000L, 1L]"
+        }
+      },
+      "repeat": 5000
+    },
+    {
+        "op": "shard_index",
+        "param_info": {
+          "input": {
+            "type": "Variable",
+            "dtype": "int32",
+            "shape": "[1000L, 1L]"
+          }
+        },
+        "repeat": 5000
+      }
+  ]

--- a/api/tests_v2/configs/shard_index.json
+++ b/api/tests_v2/configs/shard_index.json
@@ -5,7 +5,7 @@
         "input": {
           "type": "Variable",
           "dtype": "int64",
-          "shape": "[1000L, 1L]"
+          "shape": "[100000L, 1L]"
         }
       },
       "repeat": 5000
@@ -16,7 +16,7 @@
           "input": {
             "type": "Variable",
             "dtype": "int32",
-            "shape": "[1000L, 1L]"
+            "shape": "[100000L, 1L]"
           }
         },
         "repeat": 5000


### PR DESCRIPTION
添加 shard_index 算子 benchmark 测试脚本，TF和touch中无该算子的对照。
![截屏2022-03-07 下午4 57 10](https://user-images.githubusercontent.com/21302167/156999585-99cee9f7-786c-4d0c-b045-5a0f8e2b7940.png)


