### PR TITLE
[PHI] Add arg min max op benchmark.

### DIFF
--- a/api/dynamic_tests_v2/arg_min_max.py
+++ b/api/dynamic_tests_v2/arg_min_max.py
@@ -1,0 +1,49 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class ArgMinMaxConfig(APIConfig):
+    def __init__(self):
+        super(ArgMinMaxConfig, self).__init__('arg_min_max')
+        self.run_torch = False
+        self.api_name = 'argmin'
+        self.api_list = {
+            'argmin': 'argmin',
+            'argmax': 'argmax',
+        }
+
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(ArgMinMaxConfig, self).init_from_json(filename, config_id,
+                                                    unknown_dim)
+        self.feed_spec = [
+            {
+                "range": [0, 1]
+            },  # x
+        ]
+
+
+class PaddleArgMinMax(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+
+        result = self.layers(api_name=config.api_name, x=x, axis=-1)
+
+        self.feed_vars = [x]
+        self.fetch_vars = [result]
+
+
+if __name__ == '__main__':
+    test_main(pd_dy_obj=PaddleArgMinMax(), config=ArgMinMaxConfig())

--- a/api/tests_v2/configs/arg_min_max.json
+++ b/api/tests_v2/configs/arg_min_max.json
@@ -1,0 +1,10 @@
+[{
+    "op": "arg_min_max",
+    "param_info": {
+        "x": {
+            "dtype": "float32",
+            "shape": "[50000, 128]",
+            "type": "Variable"
+        }
+    }
+}]


### PR DESCRIPTION
## 迁移前：
```python
-- Current directory: /workspace/benchmark/api/dynamic_tests_v2
-- Entering /workspace/benchmark/api/common
-- Current directory: /workspace/benchmark/api/common
run command: git rev-parse HEAD
run command: git show -s --format=%ad
-- Current directory: /workspace/benchmark/api/dynamic_tests_v2
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
===========================================================================
-- paddle version             : 0.0.0
-- paddle commit              : 051544b6e8af9cef61ba9870b4ab39af40875ce3
-- pytorch version            : 1.8.2+cu102
-- benchmark commit           : 979b5b179494e3115852091bf7f74779ce69457c
-- benchmark last update time : Tue Mar 8 10:39:26 2022 +0800
===========================================================================
run command: nvidia-smi -L
run command: nvprof --profile-from-start off /usr/local/bin/python /workspace/benchmark/api/dynamic_tests_v2/arg_min_max.py --task speed --framework paddle --testing_mode dynamic --json_file /workspace/benchmark/api/tests_v2/configs/arg_min_max.json --config_id 0 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   50.04%  113.57ms      1000  113.57us  105.18us  116.77us  void paddle::operators::ArgCUDAKernel<float, long, cub::ArgMax, unsigned long=128>(long, long, long, cub::ArgMax, float, cub::ArgMax const *, long*)
                   49.96%  113.38ms      1000  113.38us  105.12us  116.77us  void paddle::operators::ArgCUDAKernel<float, long, cub::ArgMin, unsigned long=128>(long, long, long, cub::ArgMin, float, cub::ArgMin const *, long*)

total gpu_time: 226.9584 ms

run command: /usr/local/bin/python /workspace/benchmark/api/dynamic_tests_v2/arg_min_max.py --task speed --framework paddle --testing_mode dynamic --json_file /workspace/benchmark/api/tests_v2/configs/arg_min_max.json --config_id 0 --profiler none --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0  --gpu_time  226.9584332533973
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
W0308 07:35:27.983525 11685 device_context.cc:447] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 10.2, Runtime API Version: 10.2
W0308 07:35:27.988265 11685 device_context.cc:465] device: 0, cuDNN Version: 7.6.
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=226.9584332533973, json_file='/workspace/benchmark/api/tests_v2/configs/arg_min_max.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
---- Initialize APIConfig from /workspace/benchmark/api/tests_v2/configs/arg_min_max.json, config_id = 0.

Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=226.9584332533973, json_file='/workspace/benchmark/api/tests_v2/configs/arg_min_max.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][arg_min_max] argmin {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  atol: 1e-06
}
Successly import paddle.argmin
{"framework": "paddle", "version": "0.0.0", "name": "argmin", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.13145719255719865, "wall_time": 0, "total_include_wall_time": 0.13145719255719865, "gpu_time": 0.2269584332533973}, "parameters": "x (Variable) - dtype: float32, shape: [50000, 128]\n"}
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=226.9584332533973, json_file='/workspace/benchmark/api/tests_v2/configs/arg_min_max.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][arg_min_max] argmax {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  atol: 1e-06
}
Successly import paddle.argmax
{"framework": "paddle", "version": "0.0.0", "name": "argmax", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.12690753352885342, "wall_time": 0, "total_include_wall_time": 0.12690753352885342, "gpu_time": 0.2269584332533973}, "parameters": "x (Variable) - dtype: float32, shape: [50000, 128]\n"}


```

## 迁移后：
```python
-- Current directory: /workspace/benchmark/api/dynamic_tests_v2
-- Entering /workspace/benchmark/api/common
-- Current directory: /workspace/benchmark/api/common
run command: git rev-parse HEAD
run command: git show -s --format=%ad
-- Current directory: /workspace/benchmark/api/dynamic_tests_v2
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
===========================================================================
-- paddle version             : 0.0.0
-- paddle commit              : 2baaa7736a1c2667bf2ae2798b17cd57a3d6cf2b
-- pytorch version            : 1.8.2+cu102
-- benchmark commit           : 979b5b179494e3115852091bf7f74779ce69457c
-- benchmark last update time : Tue Mar 8 10:39:26 2022 +0800
===========================================================================
run command: nvidia-smi -L
run command: nvprof --profile-from-start off /usr/local/bin/python /workspace/benchmark/api/dynamic_tests_v2/arg_min_max.py --task speed --framework paddle --testing_mode dynamic --json_file /workspace/benchmark/api/tests_v2/configs/arg_min_max.json --config_id 0 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   50.09%  113.96ms      1000  113.96us  112.10us  117.63us  void phi::ArgCUDAKernel<float, long, cub::ArgMin, unsigned long=128>(long, long, long, cub::ArgMin, float, cub::ArgMin const *, long*)
                   49.91%  113.54ms      1000  113.54us  111.58us  117.06us  void phi::ArgCUDAKernel<float, long, cub::ArgMax, unsigned long=128>(long, long, long, cub::ArgMax, float, cub::ArgMax const *, long*)

total gpu_time: 227.5105 ms

run command: /usr/local/bin/python /workspace/benchmark/api/dynamic_tests_v2/arg_min_max.py --task speed --framework paddle --testing_mode dynamic --json_file /workspace/benchmark/api/tests_v2/configs/arg_min_max.json --config_id 0 --profiler none --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --log_level 0  --gpu_time  227.51048113395885
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
W0308 07:37:45.523681 11802 gpu_context.cc:244] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 10.2, Runtime API Version: 10.2
W0308 07:37:45.529253 11802 gpu_context.cc:272] device: 0, cuDNN Version: 7.6.
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=227.51048113395885, json_file='/workspace/benchmark/api/tests_v2/configs/arg_min_max.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
---- Initialize APIConfig from /workspace/benchmark/api/tests_v2/configs/arg_min_max.json, config_id = 0.

Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=227.51048113395885, json_file='/workspace/benchmark/api/tests_v2/configs/arg_min_max.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][arg_min_max] argmin {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  atol: 1e-06
}
Successly import paddle.argmin
{"framework": "paddle", "version": "0.0.0", "name": "argmin", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.14821266641422193, "wall_time": 0, "total_include_wall_time": 0.14821266641422193, "gpu_time": 0.22751048113395886}, "parameters": "x (Variable) - dtype: float32, shape: [50000, 128]\n"}
Namespace(allow_adaptive_repeat=False, api_name=None, backward=True, config_id=0, convert_to_fp16=False, filename=None, framework='paddle', get_status_without_running=False, gpu_time=227.51048113395885, json_file='/workspace/benchmark/api/tests_v2/configs/arg_min_max.json', log_level=0, profiler='none', repeat=1000, scheduling_times='{}', sync_interval=80, task='speed', testing_mode='dynamic', unknown_dim=16, use_gpu=True)
[paddle][arg_min_max] argmax {
  run_tf: True
  run_torch: False
  x_shape: [50000, 128]
  x_dtype: float32
  atol: 1e-06
}
Successly import paddle.argmax
{"framework": "paddle", "version": "0.0.0", "name": "argmax", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 0.13795166599507236, "wall_time": 0, "total_include_wall_time": 0.13795166599507236, "gpu_time": 0.22751048113395886}, "parameters": "x (Variable) - dtype: float32, shape: [50000, 128]\n"}

```

## 结论
Diff 很小，基本可忽略。