### PR TITLE
Add benchmark for frobenius_norm OP

### DIFF
--- a/api/tests_v2/configs/p_norm.json
+++ b/api/tests_v2/configs/p_norm.json
@@ -45,4 +45,25 @@
             "type": "Variable"
         }
     }
+}, {
+    "op": "p_norm",
+    "param_info": {
+        "axis": {
+            "type": "int",
+            "value": "-1"
+        },
+        "porder": {
+            "type": "string",
+            "value": "fro"
+        },
+        "keepdim": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[300L, 128L, 128L]",
+            "type": "Variable"
+        }
+    }
 }]


### PR DESCRIPTION
Add benchmark for frobenius_norm OP, test result:
![image](https://user-images.githubusercontent.com/17673696/157398265-e4e31a81-d6c1-485b-bff3-92155de20e8f.png)
![image](https://user-images.githubusercontent.com/17673696/157398286-63cb39cf-7470-4519-8d85-bca5bb2ab196.png)
