### PR TITLE
add benchmark for matrix_rank,test=document_fix

### DIFF
--- a/api/dynamic_tests_v2/matrix_rank.py
+++ b/api/dynamic_tests_v2/matrix_rank.py
@@ -1,0 +1,46 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common_import import *
+
+
+class MatrixRankConfig(APIConfig):
+    def __init__(self):
+        super(MatrixRankConfig, self).__init__("matrix_rank")
+        self.feed_spec = [{"range": [-1, 1]}]
+
+
+class PaddleMatrixRank(PaddleDynamicAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.linalg.matrix_rank(
+            x=x, tol=config.tol, hermitian=config.hermitian)
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+class TorchMatrixRank(PytorchAPIBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.linalg.matrix_rank(
+            input=x, tol=config.tol, hermitian=config.hermitian)
+        self.feed_list = [x]
+        self.fetch_list = [result]
+
+
+if __name__ == '__main__':
+    test_main(
+        pd_dy_obj=PaddleMatrixRank(),
+        torch_obj=TorchMatrixRank(),
+        config=MatrixRankConfig())

--- a/api/tests_v2/configs/matrix_rank.json
+++ b/api/tests_v2/configs/matrix_rank.json
@@ -26,7 +26,7 @@
         },
         "hermitian": {
             "type": "bool",
-            "value": "False"
+            "value": "True"
         },
         "x": {
             "dtype": "float32",

--- a/api/tests_v2/configs/matrix_rank.json
+++ b/api/tests_v2/configs/matrix_rank.json
@@ -1,0 +1,37 @@
+[{
+    "config_id": 0,
+    "op": "matrix_rank",
+    "param_info": {
+        "tol": {
+            "type": "float",
+            "value": "0.01"
+        },
+        "hermitian": {
+            "type": "bool",
+            "value": "True"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[3L, 4L, 5L, 5L]",
+            "type": "Variable"
+        }
+    }
+}, {
+    "config_id": 0,
+    "op": "matrix_rank",
+    "param_info": {
+        "tol": {
+            "type": "float",
+            "value": "0.01"
+        },
+        "hermitian": {
+            "type": "bool",
+            "value": "False"
+        },
+        "x": {
+            "dtype": "float32",
+            "shape": "[64L, 24L, 8L, 8L]",
+            "type": "Variable"
+        }
+    }
+}]

--- a/api/tests_v2/configs/matrix_rank.json
+++ b/api/tests_v2/configs/matrix_rank.json
@@ -8,16 +8,16 @@
         },
         "hermitian": {
             "type": "bool",
-            "value": "True"
+            "value": "False"
         },
         "x": {
             "dtype": "float32",
-            "shape": "[3L, 4L, 5L, 5L]",
+            "shape": "[5L, 24L, 10L, 10L]",
             "type": "Variable"
         }
     }
 }, {
-    "config_id": 0,
+    "config_id": 1,
     "op": "matrix_rank",
     "param_info": {
         "tol": {
@@ -30,7 +30,7 @@
         },
         "x": {
             "dtype": "float32",
-            "shape": "[64L, 24L, 8L, 8L]",
+            "shape": "[10L, 12L, 8L, 8L]",
             "type": "Variable"
         }
     }


### PR DESCRIPTION
添加matrix_rank op测试脚本

matrix_rank 迁移前
![image](https://user-images.githubusercontent.com/62974595/157835238-c279879b-aeeb-4547-9505-278d377bc78c.png)

[paddle][matrix_rank] matrix_rank {
  run_tf: True
  run_torch: True
  tol: 0.01
  hermitian: False
  x_shape: [5, 24, 10, 10]
  x_dtype: float32
  atol: 1e-06
}
{"framework": "paddle", "version": "0.0.0", "name": "matrix_rank", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 47.527849917509116, "wall_time": 0, "total_include_wall_time": 47.527849917509116, "gpu_time": 31.667926565874733}, "parameters": "x (Variable) - dtype: float32, shape: [5, 24, 10, 10]\nhermitian (bool): False\ntol (float): 0.01\n"}

matrix_rank迁移后
![image](https://user-images.githubusercontent.com/62974595/157834990-c61af7bd-f917-4ff0-a89f-8f5774decc81.png)

[paddle][matrix_rank] matrix_rank {
  run_tf: True
  run_torch: True
  tol: 0.01
  hermitian: False
  x_shape: [5, 24, 10, 10]
  x_dtype: float32
  atol: 1e-06
}
{"framework": "paddle", "version": "0.0.0", "name": "matrix_rank", "device": "GPU", "backward": false, "speed": {"repeat": 1000, "begin": 10, "end": 990, "total": 47.82208788151644, "wall_time": 0, "total_include_wall_time": 47.82208788151644, "gpu_time": 31.716036036036027}, "parameters": "x (Variable) - dtype: float32, shape: [5, 24, 10, 10]\nhermitian (bool): False\ntol (float): 0.01\n"}

结论：迁移前后，性能保持不变