### PR TITLE
update TimeSformer and prepare.sh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,9 +35,6 @@
 [submodule "frame_benchmark/pytorch/dynamic/PaddleSpeech/models/wenet"]
 	path = frame_benchmark/pytorch/dynamic/PaddleSpeech/models/wenet
 	url = https://github.com/wenet-e2e/wenet.git
-[submodule "frame_benchmark/pytorch/dynamic/PaddleVideo/models/TimeSformer"]
-	path = frame_benchmark/pytorch/dynamic/PaddleVideo/models/TimeSformer
-	url = git@github.com:PaddleBenchmark/TimeSformer.git
 [submodule "frame_benchmark/pytorch/dynamic/PaddleDetection/models/mmdetection"]
 	path = frame_benchmark/pytorch/dynamic/PaddleDetection/models/mmdetection
 	url = https://github.com/open-mmlab/mmdetection.git
@@ -85,3 +82,6 @@
 
 
 
+[submodule "frame_benchmark/pytorch/dynamic/PaddleVideo/models/TimeSformer"]
+	path = frame_benchmark/pytorch/dynamic/PaddleVideo/models/TimeSformer
+	url = https://github.com/PaddleBenchmark/TimeSformer.git

--- a/frame_benchmark/pytorch/dynamic/PaddleVideo/scripts/TimeSformer/benchmark_common/prepare.sh
+++ b/frame_benchmark/pytorch/dynamic/PaddleVideo/scripts/TimeSformer/benchmark_common/prepare.sh
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
-
+# 在TimeSformer目录下执行
 echo "*******prepare benchmark start ***********"
 ################################# 安装最新版pip
 pip install -U pip
 echo `pip --version`
-################################# 安装torch 1.8.1
-pip install torch==1.8.1+cu102 -f https://download.pytorch.org/whl/torch_stable.html
 
 ################################# 安装TimeSformer的环境依赖
-pip install -r requirements.txt  -i https://pypi.tuna.tsinghua.edu.cn/simple --no-deps --no-cache-dir
+pip install -r requirements.txt  -i https://pypi.tuna.tsinghua.edu.cn/simple --no-cache-dir
+pip install simplejson
 
-################################# 安装TimeSformer到sitepackages
-python setup.py build develop
+################################# 安装torch 1.8.1
+pip install torch==1.8.1 -i https://pypi.tuna.tsinghua.edu.cn/simple --force-reinstall
+
+################################# 以包的形式安装TimeSformer(使用pip安装)
+python setup.py build
+pip install ./
 
 ################################# 下载预训练模型到目录下
-wget -nc https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_base_p16_224-80ecf9dd.pth
+wget -nc https://videotag.bj.bcebos.com/PaddleVideo-release2.2/jx_vit_base_p16_224-80ecf9dd.pth
 
 ################################# 准备训练数据
 wget -nc https://videotag.bj.bcebos.com/Data/k400_videos_small.tar


### PR DESCRIPTION
1. 防止req的deps覆盖torch 1.8，因此将torch安装顺序后置并设为强制安装
2. TimeSformer链接从git@更新为https
3. TimeSformer用pip安装代替build develop.
4. 预训练模型链接更换，加快下载速度