### PR TITLE
Fix wrong marco spell

### DIFF
--- a/static_graph/image_classification/pytorch/run_examples.sh
+++ b/static_graph/image_classification/pytorch/run_examples.sh
@@ -8,7 +8,7 @@ if [ $# -lt 3 ]; then
     exit
 fi
 
-if [ "${BENCHMAKR_ROOT}" == "" ]; then
+if [ "${BENCHMARK_ROOT}" == "" ]; then
     export BENCHMARK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/../../.." && pwd )"
 fi
 


### PR DESCRIPTION
Fix wrong marco spell about `BENCHMARK_ROOT`  in file 'benchmark/static_graph/image_classification/pytorch/run_examples.sh'