### PR TITLE
Add a argument to allow profile from start for debuging purpose.

### DIFF
--- a/api/common/tensorflow_op_benchmark.py
+++ b/api/common/tensorflow_op_benchmark.py
@@ -55,9 +55,9 @@ class Profiler(object):
             import cProfile
             self._profiler_handle = cProfile.Profile()
             self._profiler_handle.enable()
-        elif self.profiler != "none":
+        elif self.profiler == "native":
             self._profiler_handle = model_analyzer.Profiler(
-                graph=self.sess.graph)
+                graph=self._sess.graph)
             self.run_options = tf.compat.v1.RunOptions(
                 trace_level=tf.compat.v1.RunOptions.FULL_TRACE)
             self.run_metadata = tf.compat.v1.RunMetadata()


### PR DESCRIPTION
添加一个参数`profile_from_start`，允许从程序开始就profile，以便做一些性能调试，比如观察conv是否开启了exhaustive search。