### PR TITLE
Update the map of directory name to apis of conv.

### DIFF
--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -1,12 +1,16 @@
 # Paddle repo file name -> op name
 declare -A PADDLE_FILENAME_OP_MAP
 PADDLE_FILENAME_OP_MAP=(
+  # conv, files under phi directory
+  ["conv_kernel.cu"]="conv2d conv3d"
+  ["conv_grad_kernel.cu"]="conv2d conv3d"
+  ["depthwise_conv_kernel.cu"]="depthwise_conv2d"
+  ["depthwise_conv_grad_kernel.cu"]="depthwise_conv2d"
+  # pool
   ["pool_op.cu"]="max_pool2d avg_pool2d"
   ["pool_op.cu.cc"]="max_pool2d avg_pool2d"
-  ["tril_triu_op.cu"]="tril triu"
-  ["conv_op.cu.cc"]="depthwise_conv2d conv2d conv3d"
-  ["conv_cudnn_op.cu"]="conv2d conv3d"
   ["pool_cudnn_op.cu.cc"]="avg_pool2d max_pool2d"
+  ["tril_triu_op.cu"]="tril triu"
   ["activation_op.cu"]="leaky_relu elu relu sqrt rsqrt square exp abs log"
   ["activation_cudnn_op.cu.cc"]="relu relu6 sigmoid tanh"
   ["interpolate_op.cu"]="interp_bilinear interp_nearest interp_trilinear interp_bicubic interp_linear"

--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -1,16 +1,17 @@
 # Paddle repo file name -> op name
 declare -A PADDLE_FILENAME_OP_MAP
 PADDLE_FILENAME_OP_MAP=(
-  # conv, files under phi directory
+  # use names of file under phi directory
   ["conv_kernel.cu"]="conv2d conv3d"
   ["conv_grad_kernel.cu"]="conv2d conv3d"
   ["depthwise_conv_kernel.cu"]="depthwise_conv2d"
   ["depthwise_conv_grad_kernel.cu"]="depthwise_conv2d"
-  # pool
+  ["tril_triu_kernel.cu"]="tril triu"
+  ["tril_triu_grad_kernel.cu"]="tril triu"
+  # use names of file under operators directory
   ["pool_op.cu"]="max_pool2d avg_pool2d"
   ["pool_op.cu.cc"]="max_pool2d avg_pool2d"
   ["pool_cudnn_op.cu.cc"]="avg_pool2d max_pool2d"
-  ["tril_triu_op.cu"]="tril triu"
   ["activation_op.cu"]="leaky_relu elu relu sqrt rsqrt square exp abs log"
   ["activation_cudnn_op.cu.cc"]="relu relu6 sigmoid tanh"
   ["interpolate_op.cu"]="interp_bilinear interp_nearest interp_trilinear interp_bicubic interp_linear"


### PR DESCRIPTION
Paddle中存在一个文件对应多个OP的情况，需要添加文件名到OP名的映射，OP Benchmark CI才能测试到相应的算子。

OP从operators迁移到phi目录后，文件命名方式都不一样了，因此需要修改映射的map。

本PR修改了`conv`和`tril_triu`的映射。