### PR TITLE
Fix the failure of running all scripts and update torch's version.

### DIFF
--- a/api/deploy/collect_api_info.py
+++ b/api/deploy/collect_api_info.py
@@ -82,7 +82,7 @@ def main(args):
     subclass_dict = collect_subclass_dict(test_cases_dict)
 
     specified_op_list = None
-    if args.specified_op_list:
+    if args.specified_op_list is not None and args.specified_op_list != "None":
         specified_op_list = args.specified_op_list.split(",")
         print("-- Speficified op list: ", specified_op_list)
 

--- a/api/deploy/main_control.sh
+++ b/api/deploy/main_control.sh
@@ -30,7 +30,7 @@ function print_arguments() {
     echo "op_list_file    : ${OP_LIST_FILE}"
     echo "framework       : ${FRAMEWORK_SET[@]}"
     echo "testing_mode    : ${TESTING_MODE}"
-    echo "op_name    : ${OP_NAME}"
+    echo "op_name         : ${OP_NAME}"
     echo ""
 }
 

--- a/api/dynamic_tests_v2/deformable_conv.py
+++ b/api/dynamic_tests_v2/deformable_conv.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from common_import import *
-import torchvision
 
 
 class DeformableConvConfig(APIConfig):
@@ -78,6 +77,8 @@ class PDDeformableConv(PaddleDynamicAPIBenchmarkBase):
 
 class TorchDeformableConv(PytorchAPIBenchmarkBase):
     def build_graph(self, config):
+        import torchvision
+
         input = self.variable(
             name='x', shape=config.x_shape, dtype=config.x_dtype)
         weight = self.variable(

--- a/api/run_op_benchmark.sh
+++ b/api/run_op_benchmark.sh
@@ -98,7 +98,8 @@ main() {
     testing_mode="dynamic"
     # For ampere, need to install the nightly build cuda11.3 version using the following command:
     # pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
-    install_package "torch" "1.10.0"
+    install_package "torch" "1.11.0"
+    install_package "torchvision" "0.12.0"
   else
     testing_mode="static"
     install_package "tensorflow" "2.3.1"


### PR DESCRIPTION
修复一键运行脚本run_op_benchmark.sh无法启动全量测试的问题。https://github.com/PaddlePaddle/benchmark/pull/1410 给main_control.sh新增了OP_NAME参数，默认值为"None"，run_op_benchmark.sh没有设置该参数，导致生成的op_list为空。