### PR TITLE
Add default implementation of build_graph.

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -167,6 +167,8 @@ class APIConfig(object):
         self.__framework = "paddle"
         self.__run_tf = True
         self.api_name = self.name
+        self.paddle_api = None
+        self.torch_api = None
         self.params = params
         self.variable_list = None
         self.params_list = None
@@ -258,6 +260,12 @@ class APIConfig(object):
             assert op == self.name or op == self.alias_name, "The op type (%s) in json file is different from the name (%s) and the alias name (%s). " \
                 "The filename: %s, config_id: %d." % (
                     op, self.name, self.alias_name, filename, config_id)
+
+            if data[config_id].get("paddle_api", None) is not None:
+                self.paddle_api = parse_string(data[config_id]["paddle_api"])
+            if data[config_id].get("torch_api", None) is not None:
+                self.torch_api = parse_string(data[config_id]["torch_api"])
+
             self.params = data[config_id]["param_info"]
 
             if data[config_id].get("atol", None) is not None:

--- a/api/common/benchmark.py
+++ b/api/common/benchmark.py
@@ -14,21 +14,23 @@
 
 import abc, six
 import importlib
-import inspect
 
 
 @six.add_metaclass(abc.ABCMeta)
 class BenchmarkBase(object):
     def __init__(self, framework, testing_mode):
         self.name = self.__class__.__name__
+        self._framework = framework
+        self._testing_mode = testing_mode
+        self._task = ""
+        self.reset()
+
+    def reset(self):
         self.feed_list = None
         self.fetch_list = None
         self._backward = False
-        self._framework = framework
-        self._testing_mode = testing_mode
         self._test_func = None
         self._test_kwargs = None
-        self._task = ""
 
     @property
     def backward(self):

--- a/api/common/pytorch_op_benchmark.py
+++ b/api/common/pytorch_op_benchmark.py
@@ -142,7 +142,12 @@ class PytorchAPIBenchmarkBase(BenchmarkBase):
             if self._need_fetch:
                 outputs = []
                 for var in self.fetch_list:
-                    outputs.append(var.to("cpu").detach().numpy())
+                    if isinstance(var, torch.Tensor):
+                        outputs.append(var.to("cpu").detach().numpy())
+                    elif isinstance(var, list):
+                        outputs.append(np.array(var))
+                    else:
+                        outputs.append(np.array([var]))
             return outputs
 
         # warmup run

--- a/api/common/pytorch_op_benchmark.py
+++ b/api/common/pytorch_op_benchmark.py
@@ -50,7 +50,7 @@ def profile_context(name, use_gpu, profiler):
 class PytorchAPIBenchmarkBase(BenchmarkBase):
     def __init__(self):
         super(PytorchAPIBenchmarkBase, self).__init__("pytorch", "dynamic")
-        self._reset()
+        self.reset()
 
     def variable(self, name, shape, dtype, value=None, stop_gradient=False):
         if self._status == BEFORE_RUN:
@@ -169,7 +169,7 @@ class PytorchAPIBenchmarkBase(BenchmarkBase):
     def run(self, config, args):
         self.name = config.api_name
 
-        self._reset()
+        self.reset()
         self._feed_spec = feeder.copy_feed_spec(config.feed_spec)
         self._need_fetch = args.task == "accuracy"
         if args.use_gpu and torch.cuda.is_available():
@@ -183,13 +183,11 @@ class PytorchAPIBenchmarkBase(BenchmarkBase):
             profiler=args.profiler)
         return outputs, stats
 
-    def _reset(self):
-        self.feed_list = None
-        self.fetch_list = None
+    def reset(self):
+        super(PytorchAPIBenchmarkBase, self).reset()
         self._feed_spec = None
         self._generated_feed_values = []
         self._feed_dict = {}
-        self._backward = False
         self._status = BEFORE_RUN
         self._layers_function = None
         self._ones_like_targets = []

--- a/api/dynamic_tests_v2/gather.py
+++ b/api/dynamic_tests_v2/gather.py
@@ -25,9 +25,9 @@ class GatherConfig(APIConfig):
         self.feed_spec = [
             {
                 "range": [8, 10]
-            },  # input
+            },  # x
             {
-                "range": [1, self.input_shape[self.axis]]
+                "range": [1, self.x_shape[self.axis]]
             }  # index
         ]
         if len(self.index_shape) > 1:
@@ -36,8 +36,7 @@ class GatherConfig(APIConfig):
 
 class PDGather(PaddleDynamicAPIBenchmarkBase):
     def build_graph(self, config):
-        x = self.variable(
-            name='x', shape=config.input_shape, dtype=config.input_dtype)
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         index = self.variable(
             name='index',
             shape=config.index_shape,
@@ -53,11 +52,10 @@ class PDGather(PaddleDynamicAPIBenchmarkBase):
 
 class TorchGather(PytorchAPIBenchmarkBase):
     def build_graph(self, config):
-        x = self.variable(
-            name='x', shape=config.input_shape, dtype=config.input_dtype)
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         index = self.variable(
             name='index', shape=config.index_shape, dtype="int64")
-        result = torch.index_select(input=x, index=index, dim=config.axis)
+        result = torch.index_select(x=x, index=index, dim=config.axis)
 
         self.feed_list = [x, index]
         self.fetch_list = [result]

--- a/api/dynamic_tests_v2/run.sh
+++ b/api/dynamic_tests_v2/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[ -z "$(set | grep '^CUDA_VISIBLE_DEVICES=')" ] && export CUDA_VISIBLE_DEVICES="2"   # Set to "" if testing CPU
+[ -z "$(set | grep '^CUDA_VISIBLE_DEVICES=')" ] && export CUDA_VISIBLE_DEVICES="0"   # Set to "" if testing CPU
 
 NVCC=`which nvcc`
 if [ ${NVCC} != "" ]; then
@@ -13,7 +13,7 @@ export PYTHONPATH=${OP_BENCHMARK_ROOT}:${PYTHONPATH}
 
 name=${1:-"abs"}
 config_id=${2:-"0"}
-task=${3:-"accuracy"} # "accuracy" or "speed" or "scheduling"
+task=${3:-"speed"} # "accuracy" or "speed" or "scheduling"
 
 testing_mode="dynamic" # "static" or "dynamic"
 framework="paddle"  # "paddle" or "tensorflow" or "pytorch"

--- a/api/tests/allclose.py
+++ b/api/tests/allclose.py
@@ -27,7 +27,12 @@ class PaddleAllclose(PaddleOpBenchmarkBase):
     def build_graph(self, config):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
-        result = paddle.allclose(x=x, y=y)
+        result = paddle.allclose(
+            x=x,
+            y=y,
+            rtol=config.rtol,
+            atol=config.atol,
+            equal_nan=config.equal_nan)
 
         self.feed_list = [x, y]
         self.fetch_list = [result]

--- a/api/tests/gather.py
+++ b/api/tests/gather.py
@@ -28,7 +28,7 @@ class GatherConfig(APIConfig):
                 "range": [8, 10]
             },  # input
             {
-                "range": [1, self.input_shape[self.axis]]
+                "range": [1, self.x_shape[self.axis]]
             }  # index
         ]
         if len(self.index_shape) > 1:
@@ -38,8 +38,7 @@ class GatherConfig(APIConfig):
 @benchmark_registry.register("gather")
 class PaddleGather(PaddleOpBenchmarkBase):
     def build_graph(self, config):
-        x = self.variable(
-            name='x', shape=config.input_shape, dtype=config.input_dtype)
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         index = self.variable(
             name='index',
             shape=config.index_shape,
@@ -56,8 +55,7 @@ class PaddleGather(PaddleOpBenchmarkBase):
 @benchmark_registry.register("gather")
 class TorchGather(PytorchOpBenchmarkBase):
     def build_graph(self, config):
-        x = self.variable(
-            name='x', shape=config.input_shape, dtype=config.input_dtype)
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         index = self.variable(
             name='index', shape=config.index_shape, dtype="int64")
         result = torch.index_select(input=x, index=index, dim=config.axis)
@@ -72,7 +70,7 @@ class TorchGather(PytorchOpBenchmarkBase):
 class TFGather(TensorflowOpBenchmarkBase):
     def build_graph(self, config):
         params = self.variable(
-            name='params', shape=config.input_shape, dtype=config.input_dtype)
+            name='params', shape=config.x_shape, dtype=config.x_dtype)
         indices = self.variable(
             name='indices', shape=config.index_shape, dtype=config.index_dtype)
         result = tf.gather(params=params, indices=indices, axis=config.axis)

--- a/api/tests/gather.py
+++ b/api/tests/gather.py
@@ -26,7 +26,7 @@ class GatherConfig(APIConfig):
         self.feed_spec = [
             {
                 "range": [8, 10]
-            },  # input
+            },  # x
             {
                 "range": [1, self.x_shape[self.axis]]
             }  # index
@@ -58,7 +58,7 @@ class TorchGather(PytorchOpBenchmarkBase):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         index = self.variable(
             name='index', shape=config.index_shape, dtype="int64")
-        result = torch.index_select(input=x, index=index, dim=config.axis)
+        result = torch.index_select(x=x, index=index, dim=config.axis)
 
         self.feed_list = [x, index]
         self.fetch_list = [result]

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -15,8 +15,8 @@ name=${1:-"abs"}
 config_id=${2:-"0"}
 task=${3:-"speed"} # "accuracy" or "speed"
 
-testing_mode="static" # "static" or "dynamic"
-framework="paddle"  # "paddle" or "tensorflow" or "pytorch"
+testing_mode="dynamic" # "static" or "dynamic"
+framework="pytorch"  # "paddle" or "tensorflow" or "pytorch"
 filename="${OP_BENCHMARK_ROOT}/tests_v2/configs/${name}.json"
 if [ -z "$CUDA_VISIBLE_DEVICES" ]; then
   use_gpu=False
@@ -32,7 +32,7 @@ run_args="--filename ${name}
           --json_file ${filename} \
           --config_id ${config_id} \
           --profiler none \
-          --backward True \
+          --backward False \
           --use_gpu ${use_gpu} \
           --repeat 1000 \
           --allow_adaptive_repeat False \

--- a/api/tests/run.sh
+++ b/api/tests/run.sh
@@ -16,7 +16,7 @@ config_id=${2:-"0"}
 task=${3:-"speed"} # "accuracy" or "speed"
 
 testing_mode="dynamic" # "static" or "dynamic"
-framework="pytorch"  # "paddle" or "tensorflow" or "pytorch"
+framework="paddle"  # "paddle" or "tensorflow" or "pytorch"
 filename="${OP_BENCHMARK_ROOT}/tests_v2/configs/${name}.json"
 if [ -z "$CUDA_VISIBLE_DEVICES" ]; then
   use_gpu=False
@@ -32,7 +32,7 @@ run_args="--filename ${name}
           --json_file ${filename} \
           --config_id ${config_id} \
           --profiler none \
-          --backward False \
+          --backward True \
           --use_gpu ${use_gpu} \
           --repeat 1000 \
           --allow_adaptive_repeat False \

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -20,6 +20,7 @@ sys.path.append(package_path)
 
 from common.main import parse_args, is_paddle_enabled, is_tensorflow_enabled, is_torch_enabled, test_main, test_main_without_json
 from common.registry import benchmark_registry
+from common.pytorch_op_benchmark import PytorchAPIBenchmarkBase as PytorchOpBenchmarkBase
 
 
 def import_tests(filename=None):
@@ -72,7 +73,8 @@ def main():
         if is_paddle_enabled(args, config):
             pd_dy_obj = info.paddle_class("dynamic")
         if is_torch_enabled(args, config):
-            torch_obj = info.pytorch_class()
+            torch_obj = info.pytorch_class(
+            ) if info.pytorch_class is not None else PytorchOpBenchmarkBase()
     elif args.testing_mode == "static":
         if is_paddle_enabled(args, config):
             pd_obj = info.paddle_class("static")

--- a/api/tests_v2/configs/allclose.json
+++ b/api/tests_v2/configs/allclose.json
@@ -1,5 +1,7 @@
 [{
     "op": "allclose",
+    "paddle_api": "paddle.allclose(x, y, rtol, atol, equal_nan)",
+    "torch_api": "torch.allclose(input, other, rtol, atol, equal_nan)",
     "param_info": {
         "x": {
             "dtype": "float32",
@@ -26,6 +28,8 @@
     }
 }, {
     "op": "allclose",
+    "paddle_api": "paddle.allclose(x, y, rtol, atol, equal_nan)",
+    "torch_api": "torch.allclose(input, other, rtol, atol, equal_nan)",
     "param_info": {
         "x": {
             "dtype": "float64",

--- a/api/tests_v2/configs/gather.json
+++ b/api/tests_v2/configs/gather.json
@@ -6,7 +6,7 @@
             "shape": "[-1L]",
             "type": "Variable"
         },
-        "input": {
+        "x": {
             "dtype": "float32",
             "shape": "[-1L, 1L]",
             "type": "Variable"
@@ -24,7 +24,7 @@
             "shape": "[-1L, 1L]",
             "type": "Variable"
         },
-        "input": {
+        "x": {
             "dtype": "float32",
             "shape": "[-1L, 256L, 14L, 14L]",
             "type": "Variable"

--- a/api/tests_v2/gather.py
+++ b/api/tests_v2/gather.py
@@ -25,17 +25,16 @@ class GatherConfig(APIConfig):
         self.feed_spec = [
             {
                 "range": [8, 10]
-            },  # input
+            },  # x
             {
-                "range": [1, self.input_shape[self.axis]]
+                "range": [1, self.x_shape[self.axis]]
             }  # index
         ]
 
 
 class PDGather(PaddleAPIBenchmarkBase):
     def build_program(self, config):
-        x = self.variable(
-            name='x', shape=config.input_shape, dtype=config.input_dtype)
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         index = self.variable(
             name='index',
             shape=config.index_shape,
@@ -52,7 +51,7 @@ class PDGather(PaddleAPIBenchmarkBase):
 class TFGather(TensorflowAPIBenchmarkBase):
     def build_graph(self, config):
         params = self.variable(
-            name='params', shape=config.input_shape, dtype=config.input_dtype)
+            name='params', shape=config.x_shape, dtype=config.x_dtype)
         indices = self.variable(
             name='indices', shape=config.index_shape, dtype=config.index_dtype)
         result = tf.gather(params=params, indices=indices, axis=config.axis)

--- a/api/tests_v2/run.sh
+++ b/api/tests_v2/run.sh
@@ -13,7 +13,7 @@ export PYTHONPATH=${OP_BENCHMARK_ROOT}:${PYTHONPATH}
 
 name=${1:-"abs"}
 config_id=${2:-"0"}
-task=${3:-"accuracy"} # "accuracy" or "speed"
+task=${3:-"speed"} # "accuracy" or "speed"
 
 framework="paddle"  # "paddle" or "tensorflow"
 filename="${OP_BENCHMARK_ROOT}/tests_v2/configs/${name}.json"

--- a/ci/scripts/run_test.sh
+++ b/ci/scripts/run_test.sh
@@ -50,19 +50,17 @@ function prepare_env(){
   env http_proxy="" https_proxy="" pip install -U ${PADDLE_WHL} > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Install paddle failed!" && exit -1
   
-  # Install tensorflow and other packages
-  for package in "tensorflow==2.3.0" "tensorflow-probability" "pre-commit==1.21" "pylint==1.9.4" "pytest==4.6.9"
+  # Install tensorflow, pytorch and other packages
+  for package in "torch==1.12.0" "torchvision" "tensorflow==2.3.0" "tensorflow-probability" "pre-commit==1.21" "pylint==1.9.4" "pytest==4.6.9"
   do
     LOG "[INFO] Installing $package, this could take a few minutes ..."
     env http_proxy="" https_proxy="" pip install $package -i https://pypi.tuna.tsinghua.edu.cn/simple > /dev/null
     [ $? -ne 0 ] && LOG "[FATAL] Install $package failed!" && exit -1
   done
-  # Install pytorch
-  LOG "[INFO] Installing pytorch, this could take a few minutes ..."
-  env http_proxy="" https_proxy="" pip install torch==1.12.0 torchvision -i https://pypi.tuna.tsinghua.edu.cn/simple > /dev/null
-  [ $? -ne 0 ] && LOG "[FATAL] Install pytorch failed!" && exit -1
   python -c "import tensorflow as tf; print(tf.__version__)" > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Install tensorflow success, but it can't work!" && exit -1
+  python -c "import torch ; print(torch.__version__)" > /dev/null
+  [ $? -ne 0 ] && LOG "[FATAL] Install pytorch success, but it can't work!" && exit -1
   
   apt-get update > /dev/null 2> /dev/null
 }

--- a/ci/scripts/run_test.sh
+++ b/ci/scripts/run_test.sh
@@ -36,16 +36,17 @@ function prepare_env(){
   env http_proxy="" https_proxy="" pip install -U pip > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Update pip failed!" && exit -1
 
-  # Install latest paddle
-  PADDLE_WHL="paddlepaddle_gpu-0.0.0.post101-cp37-cp37m-linux_x86_64.whl"
+  PADDLE_WHL="paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl"
   if [ ! -f "${PADDLE_WHL}" ]
   then
+    # if develop compiling failed, install the latest nightly built paddle
+    PADDLE_WHL="paddlepaddle_gpu-0.0.0.post101-cp37-cp37m-linux_x86_64.whl"
     PADDLE_URL="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/${PADDLE_WHL}"
     LOG "[INFO] Downloading paddle wheel from ${PADDLE_URL}, this could take a few minutes ..."
     wget -q -O ${PADDLE_WHL} ${PADDLE_URL}
     [ $? -ne 0 ] && LOG "[FATAL] Download paddle wheel failed!" && exit -1
   fi
-  LOG "[INFO] Installing paddle, this could take a few minutes ..."
+  LOG "[INFO] Installing paddlepaddle, this could take a few minutes ..."
   env http_proxy="" https_proxy="" pip install -U ${PADDLE_WHL} > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Install paddle failed!" && exit -1
   
@@ -58,7 +59,7 @@ function prepare_env(){
   done
   # Install pytorch
   LOG "[INFO] Installing pytorch, this could take a few minutes ..."
-  pip install torch==1.12.0 torchvision -i https://pypi.tuna.tsinghua.edu.cn/simple
+  env http_proxy="" https_proxy="" pip install torch==1.12.0 torchvision -i https://pypi.tuna.tsinghua.edu.cn/simple > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Install pytorch failed!" && exit -1
   python -c "import tensorflow as tf; print(tf.__version__)" > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Install tensorflow success, but it can't work!" && exit -1

--- a/ci/scripts/run_test.sh
+++ b/ci/scripts/run_test.sh
@@ -37,10 +37,10 @@ function prepare_env(){
   [ $? -ne 0 ] && LOG "[FATAL] Update pip failed!" && exit -1
 
   # Install latest paddle
-  PADDLE_WHL="paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl"
+  PADDLE_WHL="paddlepaddle_gpu-0.0.0.post101-cp37-cp37m-linux_x86_64.whl"
   if [ ! -f "${PADDLE_WHL}" ]
   then
-    PADDLE_URL="https://paddle-wheel.bj.bcebos.com/0.0.0-gpu-cuda10-cudnn7-mkl/${PADDLE_WHL}"
+    PADDLE_URL="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/${PADDLE_WHL}"
     LOG "[INFO] Downloading paddle wheel from ${PADDLE_URL}, this could take a few minutes ..."
     wget -q -O ${PADDLE_WHL} ${PADDLE_URL}
     [ $? -ne 0 ] && LOG "[FATAL] Download paddle wheel failed!" && exit -1

--- a/ci/scripts/run_test.sh
+++ b/ci/scripts/run_test.sh
@@ -97,7 +97,7 @@ function run_api(){
     for device_type in "GPU" "CPU"
     do
       [ $device_type == "GPU" ] && device_limit="" || device_limit="env CUDA_VISIBLE_DEVICES="
-      ${device_limit} bash ${BENCHMARK_ROOT}/api/${name%/*}/run.sh ${name##*/} -1 >&2
+      ${device_limit} bash ${BENCHMARK_ROOT}/api/${name%/*}/run.sh ${name##*/} -1 accuracy >&2
       [ $? -ne 0 ] && fail_name[${#fail_name[@]}]="${name}(Run on ${device_type})"
     done
   done


### PR DESCRIPTION
1. 增加`build_graph`的默认实现，通过在json中配置paddle_api、torch_api的函数签名（包括参数列表，并且paddle与pytorch的参数需要一一对应），自动加载、调用相应函数，目前只支持前向。