### PR TITLE
Rename  softmax_with_cross_entropy to cross_entropy.

### DIFF
--- a/api/dynamic_tests_v2/cross_entropy.py
+++ b/api/dynamic_tests_v2/cross_entropy.py
@@ -15,25 +15,24 @@
 from common_import import *
 
 
-class SoftmaxWithCrossEntropyConfig(APIConfig):
+class CrossEntropyConfig(APIConfig):
     def __init__(self):
-        super(SoftmaxWithCrossEntropyConfig,
-              self).__init__("softmax_with_cross_entropy")
+        super(CrossEntropyConfig, self).__init__("cross_entropy")
 
     def init_from_json(self, filename, config_id=0, unknown_dim=16):
-        super(SoftmaxWithCrossEntropyConfig, self).init_from_json(
-            filename, config_id, unknown_dim)
+        super(CrossEntropyConfig, self).init_from_json(filename, config_id,
+                                                       unknown_dim)
         self.feed_spec = [
             {
                 "range": [0, 1]
             },  # input
             {
-                "range": [0, self.logits_shape[-1]]
+                "range": [0, self.input_shape[-1]]
             }  # label
         ]
 
-        logits_rank = len(self.logits_shape)
-        if not hasattr(self, "axis") or self.axis == logits_rank - 1:
+        input_rank = len(self.input_shape)
+        if not hasattr(self, "axis") or self.axis == input_rank - 1:
             self.axis = -1
 
         if self.soft_label or self.axis != -1:
@@ -43,10 +42,10 @@ class SoftmaxWithCrossEntropyConfig(APIConfig):
             )
             self.run_torch = False
         else:
-            if logits_rank != 2:
-                self.logits_shape = [
-                    np.prod(self.logits_shape[0:logits_rank - 1]),
-                    self.logits_shape[-1]
+            if input_rank != 2:
+                self.input_shape = [
+                    np.prod(self.input_shape[0:input_rank - 1]),
+                    self.input_shape[-1]
                 ]
 
             label_rank = len(self.label_shape)
@@ -56,7 +55,7 @@ class SoftmaxWithCrossEntropyConfig(APIConfig):
                 ]
 
     def to_pytorch(self):
-        torch_config = super(SoftmaxWithCrossEntropyConfig, self).to_pytorch()
+        torch_config = super(CrossEntropyConfig, self).to_pytorch()
         if self.label_shape[-1] == 1:
             label_rank = len(self.label_shape)
             torch_config.label_shape = [
@@ -65,36 +64,35 @@ class SoftmaxWithCrossEntropyConfig(APIConfig):
         return torch_config
 
 
-class PDSoftmaxWithCrossEntropy(PaddleDynamicAPIBenchmarkBase):
+class PDCrossEntropy(PaddleDynamicAPIBenchmarkBase):
     def build_graph(self, config):
-        logits = self.variable(
-            name="logits",
-            shape=config.logits_shape,
-            dtype=config.logits_dtype)
+        input = self.variable(
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
         label = self.variable(
             name="label",
             shape=config.label_shape,
             dtype=config.label_dtype,
             stop_gradient=True)
-        result = paddle.nn.functional.softmax_with_cross_entropy(
-            logits=logits,
+        result = paddle.nn.functional.cross_entropy(
+            input=input,
             label=label,
-            soft_label=config.soft_label,
+            weight=None,
             ignore_index=config.ignore_index,
-            numeric_stable_mode=True,
-            return_softmax=False,
-            axis=config.axis)
+            soft_label=config.soft_label,
+            use_softmax=True,
+            axis=config.axis,
+            reduction="none")
 
-        self.feed_list = [logits, label]
+        self.feed_list = [input, label]
         self.fetch_list = [result]
         if config.backward:
-            self.append_gradients(result, [logits])
+            self.append_gradients(result, [input])
 
 
-class TorchSoftmaxWithCrossEntropy(PytorchAPIBenchmarkBase):
+class TorchCrossEntropy(PytorchAPIBenchmarkBase):
     def build_graph(self, config):
         input = self.variable(
-            name="input", shape=config.logits_shape, dtype=config.logits_dtype)
+            name="input", shape=config.input_shape, dtype=config.input_dtype)
         label = self.variable(
             name='label',
             shape=config.label_shape,
@@ -115,6 +113,6 @@ class TorchSoftmaxWithCrossEntropy(PytorchAPIBenchmarkBase):
 
 if __name__ == '__main__':
     test_main(
-        pd_dy_obj=PDSoftmaxWithCrossEntropy(),
-        torch_obj=TorchSoftmaxWithCrossEntropy(),
-        config=SoftmaxWithCrossEntropyConfig())
+        pd_dy_obj=PDCrossEntropy(),
+        torch_obj=TorchCrossEntropy(),
+        config=CrossEntropyConfig())

--- a/api/tests_v2/configs/cross_entropy.json
+++ b/api/tests_v2/configs/cross_entropy.json
@@ -1,5 +1,5 @@
 [{
-    "op": "softmax_with_cross_entropy",
+    "op": "cross_entropy",
     "param_info": {
         "axis": {
             "type": "int",
@@ -14,7 +14,7 @@
             "shape": "[-1L, 37007L]",
             "type": "Variable"
         },
-        "logits": {
+        "input": {
             "dtype": "float32",
             "shape": "[-1L, 37007L]",
             "type": "Variable"
@@ -25,7 +25,7 @@
         }
     }
 }, {
-    "op": "softmax_with_cross_entropy",
+    "op": "cross_entropy",
     "param_info": {
         "axis": {
             "type": "int",
@@ -40,7 +40,7 @@
             "shape": "[8L, 512L, 1024L, 1L]",
             "type": "Variable"
         },
-        "logits": {
+        "input": {
             "dtype": "float32",
             "shape": "[8L, 512L, 1024L, 19L]",
             "type": "Variable"
@@ -53,7 +53,7 @@
     "atol": 1e-3,
     "repeat": 5000
 }, {
-    "op": "softmax_with_cross_entropy",
+    "op": "cross_entropy",
     "param_info": {
         "axis": {
             "type": "int",
@@ -68,7 +68,7 @@
             "shape": "[8L, 1L, 512L, 1024L]",
             "type": "Variable"
         },
-        "logits": {
+        "input": {
             "dtype": "float32",
             "shape": "[8L, 19L, 512L, 1024L]",
             "type": "Variable"

--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -4,6 +4,7 @@ PADDLE_FILENAME_OP_MAP=(
   # use names of file under phi directory
   ["activation_kernel.cu"]="leaky_relu elu relu sqrt rsqrt square exp abs log"
   ["activation_grad_kernel.cu"]="leaky_relu elu relu sqrt rsqrt square exp abs log"
+  ["cum_kernel.cu"]="cumsum logcumsumexp"
   ["conv_kernel.cu"]="conv2d conv3d"
   ["conv_grad_kernel.cu"]="conv2d conv3d"
   ["depthwise_conv_kernel.cu"]="depthwise_conv2d"

--- a/ci/scripts/run_test.sh
+++ b/ci/scripts/run_test.sh
@@ -53,12 +53,12 @@ function prepare_env(){
   for package in "tensorflow==2.3.0" "tensorflow-probability" "pre-commit==1.21" "pylint==1.9.4" "pytest==4.6.9"
   do
     LOG "[INFO] Installing $package, this could take a few minutes ..."
-    env http_proxy="" https_proxy="" pip install $package > /dev/null
+    env http_proxy="" https_proxy="" pip install $package -i https://pypi.tuna.tsinghua.edu.cn/simple > /dev/null
     [ $? -ne 0 ] && LOG "[FATAL] Install $package failed!" && exit -1
   done
   # Install pytorch
   LOG "[INFO] Installing pytorch, this could take a few minutes ..."
-  pip install torch==1.10.0 torchvision torchaudio
+  pip install torch==1.12.0 torchvision -i https://pypi.tuna.tsinghua.edu.cn/simple
   [ $? -ne 0 ] && LOG "[FATAL] Install pytorch failed!" && exit -1
   python -c "import tensorflow as tf; print(tf.__version__)" > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Install tensorflow success, but it can't work!" && exit -1


### PR DESCRIPTION
Paddle主repo中OP Benchmark CI报错如下：
![image](https://user-images.githubusercontent.com/12538138/194688991-92d078f6-4346-44e1-a1f8-4d6222d25130.png)


CI链接：https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/6746927/job/18870645

op benchmark中测试脚本为softmax_with_cross_entropy，故改名。