### PR TITLE
Change the 2-nd config of lerp.

### DIFF
--- a/api/tests_v2/configs/lerp.json
+++ b/api/tests_v2/configs/lerp.json
@@ -20,13 +20,13 @@
     "op": "lerp",
     "param_info": {
         "x": {
-            "dtype": "float64",
-            "shape": "[-1L, 204800L]",
+            "dtype": "float32",
+            "shape": "[16L, 1L, 1L, 1L]",
             "type": "Variable"
         },
         "y": {
-            "dtype": "float64",
-            "shape": "[-1L, 204800L]",
+            "dtype": "float32",
+            "shape": "[16L, 3L, 224L, 224L]",
             "type": "Variable"
         },
         "w": {


### PR DESCRIPTION
该配置在文生图模型中用到，性能差于pytorch 150+倍。详情如下：

**[16, 1, 1, 1] [16, 3, 224, 224]**

- paddle
```
run command: nvprof --profile-from-start off /work/.virtualenvs_cuda11.2/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/lerp.py --task speed --framework paddle --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/lerp.json --config_id 2 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --unknown_dim 16 --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   99.86%  165.087s      1000  165.09ms  164.94ms  169.69ms  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=4, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorReshapingOp<Eigen::DSizes<long, int=4> const , Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DSizes<int, int=4> const , Eigen::TensorReshapingOp<Eigen::DSizes<int, int=8> const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float, float>, Eigen::TensorCwiseUnaryOp<Eigen::internal::bind1st_op<Eigen::internal::scalar_difference_op<float const , float const >>, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=4)
                    0.08%  137.83ms      1000  137.83us  136.57us  146.27us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=4, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_sum_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const > const > const , Eigen::GpuDevice>, long>(float, int=4)
                    0.06%  99.623ms      1000  99.622us  98.622us  101.15us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=4, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorReshapingOp<Eigen::DSizes<long, int=4> const , Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DSizes<int, int=4> const , Eigen::TensorReshapingOp<Eigen::DSizes<int, int=8> const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=4)
                    0.00%  1.6588ms      1000  1.6580us  1.6000us  2.0160us  [CUDA memcpy HtoD]

total gpu_time: 165318.4458 ms
```

- pytorch
```
run command: nvprof --profile-from-start off /work/.virtualenvs_cuda11.2/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/lerp.py --task speed --framework pytorch --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/lerp.json --config_id 2 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --unknown_dim 16 --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   52.96%  54.269ms      2000  27.134us  26.368us  28.608us  void at::native::vectorized_elementwise_kernel<int=4, at::native::BUnaryFunctor<float, float, float, at::native::MulFunctor<float>>, at::detail::Array<char*, int=2>>(int, float, float)
                   25.71%  26.346ms      1000  26.346us  25.888us  27.040us  _ZN2at6native18elementwise_kernelILi128ELi2EZNS0_15gpu_kernel_implIZZZNS0_75_GLOBAL__N__51_tmpxft_0000073e_00000000_12_Lerp_compute_70_cpp1_ii_7468be9318lerp_scalar_kernelERNS_18TensorIteratorBaseERKN3c106ScalarEENKUlvE_clEvENKUlvE2_clEvEUlffE_EEvS5_RKT_EUliE_EEviT1_
                   19.66%  20.145ms      1000  20.145us  19.456us  21.536us  _ZN2at6native13reduce_kernelILi512ELi1ENS0_8ReduceOpIfNS0_14func_wrapper_tIfZNS0_11sum_functorIfffEclERNS_14TensorIteratorEEUlffE_EEjfLi4EEEEEvT1_
                    1.67%  1.7162ms      1000  1.7160us  1.6640us  2.0480us  [CUDA memset]

total gpu_time: 102.4717 ms
```

其他几个配置也差于pytorch，没有加入默认测试配置，在pr中记录一下：

**配置一（在OP Benchmark中）：[16, 102400] [16, 102400]**

- paddle
```
run command: nvprof --profile-from-start off /work/.virtualenvs_cuda11.2/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/lerp.py --task speed --framework paddle --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/lerp.json --config_id 0 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --unknown_dim 16 --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   37.21%  47.044ms      1000  47.044us  45.728us  48.607us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=2, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorReshapingOp<Eigen::DSizes<long, int=2> const , Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DSizes<int, int=2> const , Eigen::TensorReshapingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float, float>, Eigen::TensorCwiseUnaryOp<Eigen::internal::bind1st_op<Eigen::internal::scalar_difference_op<float const , float const >>, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=2)
                   37.12%  46.935ms      1000  46.934us  45.248us  49.152us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=2, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorReshapingOp<Eigen::DSizes<long, int=2> const , Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DSizes<int, int=2> const , Eigen::TensorReshapingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=2)
                   24.30%  30.724ms      1000  30.724us  29.376us  33.088us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=2, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_sum_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=2> const , Eigen::TensorMap<Eigen::Tensor<float const , int=2, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const > const > const , Eigen::GpuDevice>, long>(float, int=2)
                    1.37%  1.7364ms      1000  1.7360us  1.6960us  2.1120us  [CUDA memcpy HtoD]

total gpu_time: 126.4284 ms
```

- pytorch
```
run command: nvprof --profile-from-start off /work/.virtualenvs_cuda11.2/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/lerp.py --task speed --framework pytorch --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/lerp.json --config_id 0 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --unknown_dim 16 --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   58.96%  39.690ms      2000  19.844us  18.976us  21.280us  void at::native::vectorized_elementwise_kernel<int=4, at::native::BUnaryFunctor<float, float, float, at::native::MulFunctor<float>>, at::detail::Array<char*, int=2>>(int, float, float)
                   41.04%  27.628ms      1000  27.628us  27.136us  28.415us  _ZN2at6native29vectorized_elementwise_kernelILi4EZZZNS0_75_GLOBAL__N__51_tmpxft_0000073e_00000000_12_Lerp_compute_70_cpp1_ii_7468be9318lerp_scalar_kernelERNS_18TensorIteratorBaseERKN3c106ScalarEENKUlvE_clEvENKUlvE2_clEvEUlffE_NS_6detail5ArrayIPcLi3EEEEEviT0_T1_

total gpu_time: 67.3168 ms
```

**配置二：[16, 3, 224, 224] [16, 3, 224, 224]**

- paddle

```
run command: nvprof --profile-from-start off /work/.virtualenvs_cuda11.2/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/lerp.py --task speed --framework paddle --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/lerp.json --config_id 1 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --unknown_dim 16 --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   38.58%  103.63ms      1000  103.63us  98.495us  115.94us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=4, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorReshapingOp<Eigen::DSizes<long, int=4> const , Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DSizes<int, int=4> const , Eigen::TensorReshapingOp<Eigen::DSizes<int, int=8> const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=4)
                   38.53%  103.50ms      1000  103.50us  98.464us  115.62us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=4, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorReshapingOp<Eigen::DSizes<long, int=4> const , Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DSizes<int, int=4> const , Eigen::TensorReshapingOp<Eigen::DSizes<int, int=8> const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float, float>, Eigen::TensorCwiseUnaryOp<Eigen::internal::bind1st_op<Eigen::internal::scalar_difference_op<float const , float const >>, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=4)
                   22.25%  59.775ms      1000  59.775us  54.720us  68.064us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=4, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_sum_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const > const > const , Eigen::GpuDevice>, long>(float, int=4)
                    0.63%  1.6985ms      1000  1.6980us  1.6320us  2.1120us  [CUDA memcpy HtoD]

total gpu_time: 268.6107 ms
```

- pytorch

```
run command: nvprof --profile-from-start off /work/.virtualenvs_cuda11.2/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/lerp.py --task speed --framework pytorch --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/lerp.json --config_id 1 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --unknown_dim 16 --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   58.32%  54.055ms      2000  27.027us  26.208us  28.320us  void at::native::vectorized_elementwise_kernel<int=4, at::native::BUnaryFunctor<float, float, float, at::native::MulFunctor<float>>, at::detail::Array<char*, int=2>>(int, float, float)
                   41.68%  38.628ms      1000  38.627us  38.144us  39.328us  _ZN2at6native29vectorized_elementwise_kernelILi4EZZZNS0_75_GLOBAL__N__51_tmpxft_0000073e_00000000_12_Lerp_compute_70_cpp1_ii_7468be9318lerp_scalar_kernelERNS_18TensorIteratorBaseERKN3c106ScalarEENKUlvE_clEvENKUlvE2_clEvEUlffE_NS_6detail5ArrayIPcLi3EEEEEviT0_T1_

total gpu_time: 92.6869 ms
```

**配置三：[16, 1, 224, 224] [16, 3, 224, 224]**

- paddle

```
run command: nvprof --profile-from-start off /work/.virtualenvs_cuda11.2/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/lerp.py --task speed --framework paddle --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/lerp.json --config_id 3 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --unknown_dim 16 --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   43.74%  150.79ms      1000  150.79us  137.09us  161.15us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=4, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_sum_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const > const > const > const , Eigen::GpuDevice>, long>(float, int=4)
                   31.49%  108.56ms      1000  108.56us  99.231us  116.06us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=4, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorReshapingOp<Eigen::DSizes<long, int=4> const , Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DSizes<int, int=4> const , Eigen::TensorReshapingOp<Eigen::DSizes<int, int=8> const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float const , float const >, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=4)
                   24.27%  83.661ms      1000  83.661us  76.672us  89.216us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<float, int=4, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorReshapingOp<Eigen::DSizes<long, int=4> const , Eigen::TensorReductionOp<Eigen::internal::SumReducer<float>, Eigen::DSizes<int, int=4> const , Eigen::TensorReshapingOp<Eigen::DSizes<int, int=8> const , Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_product_op<float, float>, Eigen::TensorCwiseUnaryOp<Eigen::internal::bind1st_op<Eigen::internal::scalar_difference_op<float const , float const >>, Eigen::TensorBroadcastingOp<Eigen::DSizes<int, int=4> const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::TensorMap<Eigen::Tensor<float const , int=4, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(float, int=4)
                    0.49%  1.7063ms      1000  1.7060us  1.6310us  2.1120us  [CUDA memcpy HtoD]

total gpu_time: 344.7417 ms
```

- pytorch

```
run command: nvprof --profile-from-start off /work/.virtualenvs_cuda11.2/paddle_py38/bin/python /work/benchmark/api/dynamic_tests_v2/lerp.py --task speed --framework pytorch --testing_mode dynamic --json_file /work/benchmark/api/tests_v2/configs/lerp.json --config_id 3 --profiler nvprof --backward True --use_gpu True --repeat 1000 --allow_adaptive_repeat False --unknown_dim 16 --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   48.37%  54.286ms      2000  27.143us  26.335us  28.736us  void at::native::vectorized_elementwise_kernel<int=4, at::native::BUnaryFunctor<float, float, float, at::native::MulFunctor<float>>, at::detail::Array<char*, int=2>>(int, float, float)
                   28.40%  31.876ms      1000  31.875us  31.072us  32.832us  _ZN2at6native18elementwise_kernelILi128ELi2EZNS0_15gpu_kernel_implIZZZNS0_75_GLOBAL__N__51_tmpxft_0000073e_00000000_12_Lerp_compute_70_cpp1_ii_7468be9318lerp_scalar_kernelERNS_18TensorIteratorBaseERKN3c106ScalarEENKUlvE_clEvENKUlvE2_clEvEUlffE_EEvS5_RKT_EUliE_EEviT1_
                   23.23%  26.072ms      1000  26.071us  22.112us  28.800us  _ZN2at6native13reduce_kernelILi128ELi4ENS0_8ReduceOpIfNS0_14func_wrapper_tIfZNS0_11sum_functorIfffEclERNS_14TensorIteratorEEUlffE_EEjfLi4EEEEEvT1_

total gpu_time: 112.2307 ms
```

