### PR TITLE
Fix CI and add the mapping of argmin and argmax.

### DIFF
--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -4,6 +4,7 @@ PADDLE_FILENAME_OP_MAP=(
   # use names of file under phi directory
   ["activation_kernel.cu"]="leaky_relu elu relu sqrt rsqrt square exp abs log"
   ["activation_grad_kernel.cu"]="leaky_relu elu relu sqrt rsqrt square exp abs log"
+  ["arg_min_max_kernel.cu"] = "argmax, argmin"
   ["cum_kernel.cu"]="cumsum logcumsumexp"
   ["conv_kernel.cu"]="conv2d conv3d"
   ["conv_grad_kernel.cu"]="conv2d conv3d"

--- a/ci/scripts/op_benchmark.config
+++ b/ci/scripts/op_benchmark.config
@@ -4,7 +4,7 @@ PADDLE_FILENAME_OP_MAP=(
   # use names of file under phi directory
   ["activation_kernel.cu"]="leaky_relu elu relu sqrt rsqrt square exp abs log"
   ["activation_grad_kernel.cu"]="leaky_relu elu relu sqrt rsqrt square exp abs log"
-  ["arg_min_max_kernel.cu"] = "argmax, argmin"
+  ["arg_min_max_kernel.cu"] = "argmax argmin"
   ["cum_kernel.cu"]="cumsum logcumsumexp"
   ["conv_kernel.cu"]="conv2d conv3d"
   ["conv_grad_kernel.cu"]="conv2d conv3d"

--- a/ci/scripts/run_test.sh
+++ b/ci/scripts/run_test.sh
@@ -36,16 +36,17 @@ function prepare_env(){
   env http_proxy="" https_proxy="" pip install -U pip > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Update pip failed!" && exit -1
 
-  # Install latest paddle
   PADDLE_WHL="paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl"
   if [ ! -f "${PADDLE_WHL}" ]
   then
-    PADDLE_URL="https://paddle-wheel.bj.bcebos.com/0.0.0-gpu-cuda10-cudnn7-mkl/${PADDLE_WHL}"
+    # if develop compiling failed, install the latest nightly built paddle
+    PADDLE_WHL="paddlepaddle_gpu-0.0.0.post101-cp37-cp37m-linux_x86_64.whl"
+    PADDLE_URL="https://paddle-wheel.bj.bcebos.com/develop/linux/linux-gpu-cuda10.1-cudnn7-mkl-gcc5.4-avx/${PADDLE_WHL}"
     LOG "[INFO] Downloading paddle wheel from ${PADDLE_URL}, this could take a few minutes ..."
     wget -q -O ${PADDLE_WHL} ${PADDLE_URL}
     [ $? -ne 0 ] && LOG "[FATAL] Download paddle wheel failed!" && exit -1
   fi
-  LOG "[INFO] Installing paddle, this could take a few minutes ..."
+  LOG "[INFO] Installing paddlepaddle, this could take a few minutes ..."
   env http_proxy="" https_proxy="" pip install -U ${PADDLE_WHL} > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Install paddle failed!" && exit -1
   
@@ -58,7 +59,7 @@ function prepare_env(){
   done
   # Install pytorch
   LOG "[INFO] Installing pytorch, this could take a few minutes ..."
-  pip install torch==1.12.0 torchvision -i https://pypi.tuna.tsinghua.edu.cn/simple
+  env http_proxy="" https_proxy="" pip install torch==1.12.0 torchvision -i https://pypi.tuna.tsinghua.edu.cn/simple > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Install pytorch failed!" && exit -1
   python -c "import tensorflow as tf; print(tf.__version__)" > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Install tensorflow success, but it can't work!" && exit -1
@@ -96,7 +97,7 @@ function run_api(){
     for device_type in "GPU" "CPU"
     do
       [ $device_type == "GPU" ] && device_limit="" || device_limit="env CUDA_VISIBLE_DEVICES="
-      ${device_limit} bash ${BENCHMARK_ROOT}/api/${name%/*}/run.sh ${name##*/} -1 >&2
+      ${device_limit} bash ${BENCHMARK_ROOT}/api/${name%/*}/run.sh ${name##*/} -1 accuracy >&2
       [ $? -ne 0 ] && fail_name[${#fail_name[@]}]="${name}(Run on ${device_type})"
     done
   done


### PR DESCRIPTION
1. 修复CI问题，更新nightly编译Paddle WHL包的下载链接。
2. 增加`arg_min_max_kernel.cu`到`argmax`、`argmin`的映射，修复Paddle主repo中OP Benchmark CI无法正确识别和测试argmax、argmin性能的问题：
![image](https://user-images.githubusercontent.com/12538138/194805672-ce6b25cc-d435-4be3-a37c-c87f2eba1bc5.png)

