### PR TITLE
Support only run gpu.

### DIFF
--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -79,6 +79,7 @@ NO_BACKWARD_OPS = [
     "eye",
     "floor_divide",
     "full",
+    "gaussian_random",
     "greater",
     "isclose",
     "less",

--- a/api/deploy/op_benchmark_unit.py
+++ b/api/deploy/op_benchmark_unit.py
@@ -296,6 +296,27 @@ class CompareResult(object):
         return compare_result_str
 
 
+def count_results_for_devices(benchmark_result_list):
+    def _calc_num_values(arg):
+        num_values = 0
+        if isinstance(arg, dict):
+            for v in arg.values():
+                if v != "--":
+                    num_values += 1
+        return num_values
+
+    num_gpu_results = 0
+    num_cpu_results = 0
+    for op_unit in benchmark_result_list:
+        if _calc_num_values(op_unit.gpu_forward) > 0 or _calc_num_values(
+                op_unit.gpu_backward) > 0:
+            num_gpu_results += 1
+        if _calc_num_values(op_unit.cpu_forward) > 0 or _calc_num_values(
+                op_unit.cpu_backward) > 0:
+            num_gpu_results += 1
+    return num_gpu_results, num_cpu_results
+
+
 def summary_compare_result(benchmark_result_list, op_type=None):
     compare_result = CompareResult()
 

--- a/api/deploy/write_excel.py
+++ b/api/deploy/write_excel.py
@@ -315,9 +315,20 @@ def dump_excel(benchmark_result_list,
     _write_summary_worksheet(benchmark_result_list, ws, title_format,
                              cell_formats)
 
+    num_gpu_results, num_cpu_results = op_benchmark_unit.count_results_for_devices(
+        benchmark_result_list)
+    print("-- num_gpu_results={}, num_cpu_results={}".format(num_gpu_results,
+                                                             num_cpu_results))
+
+    device_types = []
+    if num_gpu_results > 0:
+        device_types.append("gpu")
+    if num_cpu_results > 0:
+        device_types.append("cpu")
+
     if url_prefix:
         print("url prefix: ", url_prefix)
-    for device in ["gpu", "cpu"]:
+    for device in device_types:
         for direction in ["forward", "backward", "backward_forward"]:
             worksheet_name = device + "_" + direction
             ws = wb.add_worksheet(worksheet_name)

--- a/api/run_op_benchmark.sh
+++ b/api/run_op_benchmark.sh
@@ -5,9 +5,15 @@ OP_BENCHMARK_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")" && pwd )"
 test_module_name=${1:-"dynamic_tests_v2"}  # "tests", "tests_v2", "dynamic_tests_v2"
 gpu_ids=${2:-"0"}
 op_type=${3:-"all"}  # "all" or specified op_type, such as elementwise
+device_type=${4:-"both"}
 
 if [ ${test_module_name} != "tests" ] && [ ${test_module_name} != "tests_v2" ] && [ ${test_module_name} != "dynamic_tests_v2" ]; then
   echo "Please set test_module_name (${test_module_name}) to \"tests\", \"tests_v2\" or \"dynamic_tests_v2\"!"
+  exit
+fi
+
+if [ ${device_type} != "both" ] && [ ${device_type} != "gpu" ] && [ ${device_type} != "cpu" ]; then
+  echo "Please set device_type (${device_type}) to \"both\", \"cpu\" or \"gpu\"!"
   exit
 fi
 
@@ -26,8 +32,12 @@ install_package() {
     elif [ "${installed_version}" == "${package_version}" ]; then
       echo "-- ${package_name} ${package_version} is already installed."
     else
-      echo "-- Update ${package_name}: ${installed_version} -> ${package_version}"
-      pip install -U ${package_name}==${package_version}
+      if [ "${package_version}" != "" ]; then
+        echo "-- Update ${package_name}: ${installed_version} -> ${package_version}"
+        pip install -U ${package_name}==${package_version}
+      else
+        pip install -U ${package_name}
+      fi
     fi
   else
     echo "-- Install ${package_name} ${package_version}"
@@ -56,7 +66,7 @@ run_op_benchmark() {
   tests_dir=${OP_BENCHMARK_ROOT}/${test_module_name}
   echo "-- tests_dir: ${tests_dir}"
   log_path=${OUTPUT_ROOT}/log_${test_module_name}_${timestamp}.txt
-  bash ${OP_BENCHMARK_ROOT}/deploy/main_control.sh ${tests_dir} ${config_dir} ${output_dir} ${gpu_ids} "both" "both" "none" "both" "${testing_mode}" > ${log_path} 2>&1 &
+  bash ${OP_BENCHMARK_ROOT}/deploy/main_control.sh ${tests_dir} ${config_dir} ${output_dir} ${gpu_ids} ${device_type} "both" "none" "both" "${testing_mode}" > ${log_path} 2>&1 &
 }
 
 run_specified_op() {
@@ -89,8 +99,8 @@ main() {
     testing_mode="dynamic"
     # For ampere, need to install the nightly build cuda11.3 version using the following command:
     # pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
-    install_package "torch" "1.11.0"
-    install_package "torchvision" "0.12.0"
+    install_package "torch" "1.13.0"
+    install_package "torchvision"
   else
     testing_mode="static"
     install_package "tensorflow" "2.3.1"


### PR DESCRIPTION
全量测试脚本`run_op_benchmark.sh`支持通过第4个参数，设置只跑cpu或gpu测试；相应地`summary.py`解析脚本生成excel时，也支持只生成cpu、gpu的选项卡数据。