### PR TITLE
fix eigh backward test case

### DIFF
--- a/api/tests/eigh.py
+++ b/api/tests/eigh.py
@@ -31,7 +31,7 @@ class PaddleEigh(PaddleOpBenchmarkBase):
         self.feed_list = [x]
         self.fetch_list = [out_w, out_v]
         if config.backward:
-            self.append_gradients(out_w, [x])
+            self.append_gradients(out_w.sum() + paddle.abs(out_v).sum(), [x])
 
 
 @benchmark_registry.register("eigh")
@@ -43,4 +43,4 @@ class TorchEigh(PytorchOpBenchmarkBase):
         self.feed_list = [x]
         self.fetch_list = [out_w, out_v]
         if config.backward:
-            self.append_gradients(out_w, [x])
+            self.append_gradients(out_w.sum() + torch.abs(out_v).sum(), [x])


### PR DESCRIPTION
Eigh API反向传播的时候，使用单独的W或者V对X求导都是没有意义的.