### PR TITLE
Disable view for some torch api tests.

### DIFF
--- a/api/common/api_param.py
+++ b/api/common/api_param.py
@@ -166,6 +166,7 @@ class APIConfig(object):
         self.__name = op_type
         self.__framework = "paddle"
         self.__run_tf = True
+        self.__run_torch = True
         self.api_name = self.name
         self.paddle_api = None
         self.torch_api = None
@@ -174,7 +175,6 @@ class APIConfig(object):
         self.params_list = None
         self.backward = False
         self.feed_spec = None
-        self.run_torch = True
         self.alias_name = None
 
     @classmethod
@@ -212,6 +212,14 @@ class APIConfig(object):
     @run_tf.setter
     def run_tf(self, value):
         self.__run_tf = value
+
+    @property
+    def run_torch(self):
+        return self.__run_torch
+
+    @run_torch.setter
+    def run_torch(self, value):
+        self.__run_torch = value
 
     def compute_dtype(self):
         dtype = None
@@ -336,7 +344,7 @@ class APIConfig(object):
             'feed_spec', 'alias_name'
         ]
         if self.framework != "paddle":
-            exclude_attrs.append("run_torch")
+            exclude_attrs.append("_APIConfig__run_torch")
             exclude_attrs.append("_APIConfig__run_tf")
         prefix = ""
         debug_str = ('[%s][%s] %s {\n') % (self.framework, self.name,

--- a/api/common/benchmark.py
+++ b/api/common/benchmark.py
@@ -26,6 +26,9 @@ class BenchmarkBase(object):
         self.reset()
 
     def reset(self):
+        if hasattr(self, "extra_tensors") and self.extra_tensors is not None:
+            del self.extra_tensors
+        self.extra_tensors = None
         self.feed_list = None
         self.fetch_list = None
         self._backward = False

--- a/api/common/paddle_op_benchmark.py
+++ b/api/common/paddle_op_benchmark.py
@@ -316,8 +316,8 @@ class PaddleOpBenchmarkBase(BenchmarkBase):
         else:
             paddle.disable_static()
         flags = paddle.get_flags(['FLAGS_use_autotune'])
-        self.use_autotune = flags['FLAGS_use_autotune']
-        if self.use_autotune:
+        self._use_autotune = flags['FLAGS_use_autotune']
+        if self._use_autotune:
             config = {
                 "kernel": {
                     "enable": True,
@@ -448,7 +448,7 @@ class PaddleOpBenchmarkBase(BenchmarkBase):
                         outputs.append(var)
                     else:
                         outputs.append(var.numpy())
-            if self.use_autotune and not self.backward:
+            if self._use_autotune and not self.backward:
                 paddle.fluid.core.update_autotune_status()
             return outputs
 

--- a/api/common/paddle_op_benchmark.py
+++ b/api/common/paddle_op_benchmark.py
@@ -661,8 +661,3 @@ class PaddleAPIBenchmarkBase(PaddleOpBenchmarkBase):
         self.build_program(config)
         self.feed_list = self.feed_vars
         self.fetch_list = self.fetch_vars
-
-
-class PaddleDynamicAPIBenchmarkBase(PaddleOpBenchmarkBase):
-    def __init__(self):
-        super(PaddleDynamicAPIBenchmarkBase, self).__init__("dynamic")

--- a/api/common/special_op_list.py
+++ b/api/common/special_op_list.py
@@ -85,6 +85,7 @@ NO_BACKWARD_OPS = [
     "less",
     "linspace",
     "remainder",
+    "set_value",
     "shard_index",
     "size",
     "truncated_gaussian_random",

--- a/api/tests/activation.py
+++ b/api/tests/activation.py
@@ -23,6 +23,7 @@ class ActivationConfig(APIConfig):
         self.api_list = {
             'sigmoid': 'sigmoid',
             'hardsigmoid': 'hardsigmoid',
+            'swish': 'swish',
             'hardswish': 'hardswish',
             'softplus': 'softplus',
             'tanhshrink': 'tanhshrink',

--- a/api/tests/activation.py
+++ b/api/tests/activation.py
@@ -40,6 +40,13 @@ class ActivationConfig(APIConfig):
             return False
         return True
 
+    @property
+    def run_torch(self):
+        if self.api_name in ["swish"]:
+            print("-- %s is not supported in torch." % self.api_name)
+            return False
+        return True
+
 
 @benchmark_registry.register("activation")
 class PaddleActivation(PaddleOpBenchmarkBase):

--- a/api/tests/batch_norm.py
+++ b/api/tests/batch_norm.py
@@ -45,7 +45,9 @@ class BatchNormConfig(APIConfig):
     def convert_to_fp16(self):
         super(BatchNormConfig, self).convert_to_fp16()
         if self.data_format == "NHWC":
-            paddle.set_flags({'FLAGS_cudnn_batchnorm_spatial_persistent': 1})
+            paddle.fluid.set_flags({
+                'FLAGS_cudnn_batchnorm_spatial_persistent': 1
+            })
         self._set_param_dtype()
 
 
@@ -96,7 +98,6 @@ class PaddleBatchNorm(PaddleOpBenchmarkBase):
             training=config.training,
             data_format=config.data_format)
 
-        self.extra_tensors = [self._running_mean, self._running_var]
         self.feed_list = [x, weight, bias]
         self.fetch_list = [result]
         if config.backward:
@@ -168,7 +169,6 @@ class TorchBatchNorm(PytorchOpBenchmarkBase):
             momentum=config.momentum,
             eps=config.epsilon)
 
-        self.extra_tensors = [self._running_mean, self._running_var]
         self.feed_list = [x, weight, bias]
         self.fetch_list = [result]
         if config.backward:

--- a/api/tests/batch_norm.py
+++ b/api/tests/batch_norm.py
@@ -45,9 +45,7 @@ class BatchNormConfig(APIConfig):
     def convert_to_fp16(self):
         super(BatchNormConfig, self).convert_to_fp16()
         if self.data_format == "NHWC":
-            paddle.fluid.set_flags({
-                'FLAGS_cudnn_batchnorm_spatial_persistent': 1
-            })
+            paddle.set_flags({'FLAGS_cudnn_batchnorm_spatial_persistent': 1})
         self._set_param_dtype()
 
 

--- a/api/tests/batch_norm.py
+++ b/api/tests/batch_norm.py
@@ -96,6 +96,7 @@ class PaddleBatchNorm(PaddleOpBenchmarkBase):
             training=config.training,
             data_format=config.data_format)
 
+        self.extra_tensors = [self._running_mean, self._running_var]
         self.feed_list = [x, weight, bias]
         self.fetch_list = [result]
         if config.backward:
@@ -167,6 +168,7 @@ class TorchBatchNorm(PytorchOpBenchmarkBase):
             momentum=config.momentum,
             eps=config.epsilon)
 
+        self.extra_tensors = [self._running_mean, self._running_var]
         self.feed_list = [x, weight, bias]
         self.fetch_list = [result]
         if config.backward:

--- a/api/tests/concat.py
+++ b/api/tests/concat.py
@@ -32,6 +32,17 @@ class PaddleConcat(PaddleOpBenchmarkBase):
         if config.backward:
             self.append_gradients(result, xs)
 
+    def compute_flop_and_byte(self, config):
+        forward_flop = 0
+        forward_byte = 0
+        for shape in config.x_shape:
+            forward_byte += numel(shape) * sizeof(config.x_dtype[0]) * 2
+        if not config.backward:
+            return forward_flop, forward_byte
+        else:
+            # To be implemented.
+            return None, None
+
 
 @benchmark_registry.register("concat")
 class TorchConcat(PytorchOpBenchmarkBase):

--- a/api/tests/expand_as.py
+++ b/api/tests/expand_as.py
@@ -36,7 +36,7 @@ class TorchExpandAs(PytorchOpBenchmarkBase):
         x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
         y = self.variable(name='y', shape=config.y_shape, dtype=config.y_dtype)
         y.requires_grad = False
-        result = x.expand_as(y)
+        result = x.expand_as(y).contiguous()
 
         self.feed_list = [x]
         self.fetch_list = [result]

--- a/api/tests/set_value.py
+++ b/api/tests/set_value.py
@@ -16,35 +16,52 @@ from common_import import *
 
 
 @benchmark_registry.register("set_value")
-class SetValueConfig(APIConfig):
-    def __init__(self):
-        super(SetValueConfig, self).__init__("set_value")
-        self.run_torch = False
-
-    def init_from_json(self, filename, config_id=0, unknown_dim=16):
-        super(SetValueConfig, self).init_from_json(filename, config_id,
-                                                   unknown_dim)
-
-
-@benchmark_registry.register("set_value")
 class PaddleSetValue(PaddleOpBenchmarkBase):
     def build_graph(self, config):
-        input = self.variable(
-            name='input', shape=config.input_shape, dtype=config.input_dtype)
-        input.stop_gradient = True
+        x = self.variable(
+            name='x',
+            shape=config.x_shape,
+            dtype=config.x_dtype,
+            stop_gradient=True)
 
         if config.is_tensor_value:
             value = self.variable(
                 name='value',
                 shape=config.value_shape,
-                dtype=config.value_dtype)
-            input[:, 10:500:2] = value
+                dtype=config.value_dtype,
+                stop_gradient=True)
+            x[:, 10:500:2] = value
 
-            self.feed_list = [input, value]
-            self.fetch_list = [input]
-
+            self.feed_list = [x, value]
+            self.fetch_list = [x]
         else:
-            input[:, 0:20, ::2] = 10000
+            x[:, 0:20, ::2] = 10000
 
-            self.feed_list = [input]
-            self.fetch_list = [input]
+            self.feed_list = [x]
+            self.fetch_list = [x]
+
+
+@benchmark_registry.register("set_value")
+class TorchSetValue(PytorchOpBenchmarkBase):
+    def build_graph(self, config):
+        x = self.variable(
+            name='x',
+            shape=config.x_shape,
+            dtype=config.x_dtype,
+            stop_gradient=True)
+
+        if config.is_tensor_value:
+            value = self.variable(
+                name='value',
+                shape=config.value_shape,
+                dtype=config.value_dtype,
+                stop_gradient=True)
+            x[:, 10:500:2] = value
+
+            self.feed_list = [x, value]
+            self.fetch_list = [x.contiguous()]
+        else:
+            x[:, 0:20, ::2] = 10000
+
+            self.feed_list = [x]
+            self.fetch_list = [x.contiguous()]

--- a/api/tests/size.py
+++ b/api/tests/size.py
@@ -18,20 +18,18 @@ from common_import import *
 @benchmark_registry.register("size")
 class PaddleSize(PaddleOpBenchmarkBase):
     def build_graph(self, config):
-        input = self.variable(
-            name='input', shape=config.input_shape, dtype=config.input_dtype)
-        result = paddle.fluid.layers.size(input)
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = paddle.numel(x)
 
-        self.feed_list = [input]
+        self.feed_list = [x]
         self.fetch_list = [result]
 
 
 @benchmark_registry.register("size")
 class TorchSize(PytorchOpBenchmarkBase):
     def build_graph(self, config):
-        input = self.variable(
-            name='input', shape=config.input_shape, dtype=config.input_dtype)
-        result = torch.numel(input=input)
+        x = self.variable(name='x', shape=config.x_shape, dtype=config.x_dtype)
+        result = torch.numel(x=x)
 
-        self.feed_list = [input]
+        self.feed_list = [x]
         self.fetch_list = [result]

--- a/api/tests/slice.py
+++ b/api/tests/slice.py
@@ -90,7 +90,7 @@ class TorchSlice(PytorchOpBenchmarkBase):
             input=x,
             dim=config.axes[0],
             start=config.starts[0],
-            length=config.length)
+            length=config.length).contiguous()
 
         self.feed_list = [x]
         self.fetch_list = [result]

--- a/api/tests/split.py
+++ b/api/tests/split.py
@@ -45,6 +45,15 @@ class PaddleSplit(PaddleOpBenchmarkBase):
         if config.backward:
             self.append_gradients(result, [x])
 
+    def compute_flop_and_byte(self, config):
+        forward_flop = 0
+        forward_byte = numel(config.x_shape) * sizeof(config.x_dtype) * 2
+        if not config.backward:
+            return forward_flop, forward_byte
+        else:
+            # To be implemented.
+            return None, None
+
 
 @benchmark_registry.register("split")
 class TorchSplit(PytorchOpBenchmarkBase):

--- a/api/tests/split.py
+++ b/api/tests/split.py
@@ -62,6 +62,7 @@ class TorchSplit(PytorchOpBenchmarkBase):
             config.backward = False
         else:
             self.fetch_list = [result]
+
         self.feed_list = [x]
         if config.backward:
             self.append_gradients(result, [x])

--- a/api/tests/stack.py
+++ b/api/tests/stack.py
@@ -32,6 +32,17 @@ class PaddleStack(PaddleOpBenchmarkBase):
         if config.backward:
             self.append_gradients(result, xs)
 
+    def compute_flop_and_byte(self, config):
+        num_xs = len(config.x_shape)
+        forward_flop = 0
+        forward_byte = num_xs * numel(config.x_shape[0]) * sizeof(
+            config.x_dtype[0]) * 2
+        if not config.backward:
+            return forward_flop, forward_byte
+        else:
+            # To be implemented.
+            return None, None
+
 
 @benchmark_registry.register("stack")
 class TorchStack(PytorchOpBenchmarkBase):

--- a/api/tests/unstack.py
+++ b/api/tests/unstack.py
@@ -38,3 +38,12 @@ class PaddleUnStack(PaddleOpBenchmarkBase):
             self.fetch_list = [result]
         if config.backward:
             self.append_gradients(result, [x])
+
+    def compute_flop_and_byte(self, config):
+        forward_flop = 0
+        forward_byte = numel(config.x_shape) * sizeof(config.x_dtype) * 2
+        if not config.backward:
+            return forward_flop, forward_byte
+        else:
+            # To be implemented.
+            return None, None

--- a/api/tests_v2/configs/set_value.json
+++ b/api/tests_v2/configs/set_value.json
@@ -1,7 +1,7 @@
 [{
     "op": "set_value",
     "param_info": {
-        "input": {
+        "x": {
             "dtype": "float32",
             "shape": "[-1L, 1000000L]",
             "type": "Variable"
@@ -19,7 +19,7 @@
 }, {
     "op": "set_value",
     "param_info": {
-        "input": {
+        "x": {
             "dtype": "float32",
             "shape": "[-1L, 60, 20000L]",
             "type": "Variable"

--- a/api/tests_v2/configs/size.json
+++ b/api/tests_v2/configs/size.json
@@ -1,7 +1,7 @@
 [{
     "op": "size",
     "param_info": {
-        "input": {
+        "x": {
             "dtype": "float32",
             "shape": "[-1L, 102400L]",
             "type": "Variable"
@@ -10,7 +10,7 @@
 }, {
     "op": "size",
     "param_info": {
-        "input": {
+        "x": {
             "dtype": "int64",
             "shape": "[512000L]",
             "type": "Variable"


### PR DESCRIPTION
本PR工作如下：
- 主体执行和日志解析部分：
  - 调整日志解析部分，nsight命令执行返回不成功也尝试去解析日志，解析成功则返回GPU时间。
  - 解析GPU时间外层添加try-except，防止字符串转float报错而退出
- 测试脚本部分
  - 添加set_value torch测试类；set_value因不存在反向算子，故加入no_backward_list
  - 添加激活函数swish的测试
  - size算子的调用从fluid接口改成`paddle.numel`
  - 添加concat、split、stack、unstack算子flop和gbs的计算
  - expand_as、slice显式调用`contiguous()`调用，关闭view机制，以获得真实的kernel时间。