### PR TITLE
nodify_benchmar_ci

### DIFF
--- a/scripts/benchmark_ci/model_ci.sh
+++ b/scripts/benchmark_ci/model_ci.sh
@@ -37,6 +37,11 @@ if [ -f "rerun_model.txt" ];then
     #install paddle develop
     cd /workspace/Paddle
     pip uninstall -y paddlepaddle_gpu
+    if ls build/python/dist/*whl >/dev/null 2>&1; then
+        pip install build/python/dist/paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl
+    elif ls dist/*whl >/dev/null 2>&1; then
+        pip install dist/paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl
+    fi
     pip install build/python/dist/paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl
     [ $? -ne 0 ] && echo "install paddle failed." && exit 1
     #running model in paddle develop


### PR DESCRIPTION
本PR修改了model_ci.sh脚本，后续Paddle主框架编译需要换成setup.py的方式，原来cmake make pip install 的方式产生的whl包在build/python/dist，而现在产生的whl包在Paddle/dist/目录下