### PR TITLE
Update hf_bert

### DIFF
--- a/frame_benchmark/pytorch/dynamic/PaddleNLP/scripts/bert_base_seqlen128_hf/benchmark_common/hf_pretrain.py
+++ b/frame_benchmark/pytorch/dynamic/PaddleNLP/scripts/bert_base_seqlen128_hf/benchmark_common/hf_pretrain.py
@@ -52,6 +52,7 @@ logger = get_logger(__name__)
 MODEL_CONFIG_CLASSES = list(MODEL_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
 
+torch.backends.cuda.matmul.allow_tf32 = True
 
 class TimeCostAverage(object):
     """

--- a/frame_benchmark/pytorch/dynamic/PaddleNLP/scripts/bert_base_seqlen128_hf/benchmark_common/run_benchmark.sh
+++ b/frame_benchmark/pytorch/dynamic/PaddleNLP/scripts/bert_base_seqlen128_hf/benchmark_common/run_benchmark.sh
@@ -65,7 +65,7 @@ function _train(){
     if [ $fp_item = "fp16" ]; then
         train_cmd="\
             --config_name ./bert_base_uncased.json \
-            --mixed_precision fp16 \
+            --mixed_precision no \
             --max_predictions_per_seq 20 \
             --batch_size ${base_batch_size} \
             --learning_rate 1e-4 \
@@ -77,6 +77,7 @@ function _train(){
             --logging_steps 10 \
             --save_steps 20000 \
             --max_steps ${max_iter} \
+            --pure_fp16 \
             --preprocessing_num_workers 8 \
             ${use_com_args}
             "
@@ -103,7 +104,7 @@ function _train(){
     SingleP) train_cmd="accelerate launch --config_file n1c1.yaml hf_pretrain.py ${train_cmd}" ;;
     MultiP)
     if [ ${device_num:3} = '32' ];then
-	train_cmd="accelerate launch --config_file n4c32.yaml --num_processes $num_workers --num_machines $node_num --machine_rank $node_rank --main_process_ip $master_addr --main_process_port $master_port train_text_to_image.py ${train_cmd}"
+	train_cmd="accelerate launch --config_file n4c32.yaml --num_processes $num_workers --num_machines $node_num --machine_rank $node_rank --main_process_ip $master_addr --main_process_port $master_port hf_pretrain.py ${train_cmd}"
     else
         train_cmd="accelerate launch --config_file n1c8.yaml hf_pretrain.py ${train_cmd}"
     fi;;


### PR DESCRIPTION
- 默认开启 torch.backends.cuda.matmul.allow_tf32 = True
- 测试fp16的时候默认开启 pure fp16

下面是测试得到的结果，波动结果符合预期，分别填写了amp和pure fp16的速度。
![image](https://github.com/PaddlePaddle/benchmark/assets/50394665/5c09533a-9dbd-4ea9-828e-e322ec56bc9a)
