### PR TITLE
Update the oneDNN file name for ernie inference.

### DIFF
--- a/Inference/c++/ernie/cmake/FindFluid.cmake
+++ b/Inference/c++/ernie/cmake/FindFluid.cmake
@@ -128,7 +128,7 @@ function(third_party_library TARGET_NAME TARGET_DIRNAME)
 endfunction()
 
 third_party_library(mklml ${THIRD_PARTY_ROOT}/install/mklml/lib libiomp5.so libmklml_intel.so)
-third_party_library(mkldnn ${THIRD_PARTY_ROOT}/install/mkldnn/lib libmkldnn.so.0)
+third_party_library(mkldnn ${THIRD_PARTY_ROOT}/install/mkldnn/lib libdnnl.so.3)
 if(NOT USE_SHARED)
   third_party_library(glog ${THIRD_PARTY_ROOT}/install/glog/lib libglog.a)
   third_party_library(protobuf ${THIRD_PARTY_ROOT}/install/protobuf/lib libprotobuf.a)


### PR DESCRIPTION
Since the oneDNN version in PaddlePaddle upstream has been upgraded to 3.1.1(https://github.com/PaddlePaddle/Paddle/pull/52463), The oneDNN file name has also been changed.
Update the dnn file name for ernie inference in benchmark repo.