### PR TITLE
Add fused_rope benchmark

### DIFF
--- a/api/tests/fused_rotary_position_embedding.py
+++ b/api/tests/fused_rotary_position_embedding.py
@@ -1,0 +1,77 @@
+import numpy as np
+from common_import import *
+
+
+def get_sin_cos_tensor(seq_len, head_dim, sign=1):
+    pos_seq = np.arange(0, seq_len, 1, dtype="float32")
+    indices = np.arange(0, head_dim, 2, dtype="float32")
+
+    indices = 1 / 10000 ** (indices / head_dim)
+    sinusoid_inp = np.expand_dims(pos_seq, axis=1) * np.expand_dims(indices, axis=0)
+
+    sin_sin = np.empty((seq_len * head_dim), dtype=np.float32)
+    cos_cos = np.empty((seq_len * head_dim), dtype=np.float32)
+    numpy_array = sinusoid_inp
+    iter_array = np.nditer(numpy_array)
+
+    i = 0
+
+    for value in iter_array:
+        sin_sin[i * 2] = sign * np.sin(value)
+        cos_cos[i * 2 + 0] = np.cos(value)
+        sin_sin[i * 2 + 1] = np.sin(value)
+        cos_cos[i * 2 + 1] = np.cos(value)
+        i += 1
+
+    return np.reshape(sin_sin, [1, seq_len, 1, head_dim]), np.reshape(cos_cos, [1, seq_len, 1, head_dim])
+
+@benchmark_registry.register("fused_rotary_position_embedding")
+class FusedRoPEConfig(APIConfig):
+    def __init__(self):
+        super(FusedRoPEConfig, self).__init__("fused_rotary_position_embedding")
+        self.run_torch = False
+
+    # TODO(MarioLulab): add fused_rope config
+    def init_from_json(self, filename, config_id=0, unknown_dim=16):
+        super(FusedRoPEConfig, self).init_from_json(filename, config_id,
+                                                  unknown_dim)
+        # check whether q,k,v are set None
+        self.has_q = True if hasattr(self, "q_shape") else False
+        self.has_k = True if hasattr(self, "k_shape") else False
+        self.has_v = True if hasattr(self, "v_shape") else False
+
+        if self.cached_sin_cos:
+            seq_len = self.q_shape[1]
+            head_dim = self.q_shape[3]
+            self.sin_value, self.cos_value = get_sin_cos_tensor(seq_len, head_dim, 1)
+
+            self.sin_shape, self.cos_shape = self.sin_value.shape, self.cos_value.shape
+            self.sin_dtype, self.cos_dtype = "float32", "float32"
+        else:
+            self.sin_value, self.cos_value = None, None
+
+@benchmark_registry.register("fused_rotary_position_embedding")
+class PaddleFusedRoPE(PaddleOpBenchmarkBase):
+    def build_graph(self, config):
+        q = self.variable(name='q', shape=config.q_shape, dtype=config.q_dtype) if config.has_q else None
+        k = self.variable(name='k', shape=config.k_shape, dtype=config.k_dtype) if config.has_k else None
+        v = self.variable(name='v', shape=config.v_shape, dtype=config.v_dtype) if config.has_v else None
+
+        sin = None if config.sin_value is None else self.variable(name='sin', shape=config.sin_shape, dtype=config.sin_dtype, value=config.sin_value)
+        cos = None if config.cos_value is None else self.variable(name='cos', shape=config.cos_shape, dtype=config.cos_dtype, value=config.cos_value)        
+        
+        results = paddle.incubate.nn.functional.fused_rotary_position_embedding(
+            q=q,
+            k=k,
+            v=v,
+            sin=sin,
+            cos=cos,
+            position_ids=config.position_ids,
+            use_neox_rotary_style=config.use_neox_rotary_style)
+
+        self.feed_list = []
+        self.fetch_list = []
+        for idx, item in enumerate([q, k, v]):
+            if item is not None:
+                self.feed_list.append(item)
+                self.feed_list.append(results[idx])

--- a/api/tests_v2/configs/fused_rotary_position_embedding.json
+++ b/api/tests_v2/configs/fused_rotary_position_embedding.json
@@ -101,6 +101,37 @@
         },
         "k": {
             "dtype": "float32",
+            "shape": "[4L, 4096L, 32L, 128L]",
+            "type": "Variable"
+        },
+        "v": {
+            "type": "string",
+            "value": "None"
+        },
+        "cached_sin_cos": {
+            "type": "bool",
+            "value": "False"
+        },
+        "position_ids": {
+            "type": "string",
+            "value": "None"
+        },
+        "use_neox_rotary_style": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+},
+{
+    "op": "fused_rotary_position_embedding",
+    "param_info": {
+        "q": {
+            "dtype": "float32",
+            "shape": "[4L, 4096L, 32L, 128L]",
+            "type": "Variable"
+        },
+        "k": {
+            "dtype": "float32",
             "shape": "[4L, 4096L, 4L, 128L]",
             "type": "Variable"
         },

--- a/api/tests_v2/configs/fused_rotary_position_embedding.json
+++ b/api/tests_v2/configs/fused_rotary_position_embedding.json
@@ -59,5 +59,66 @@
             "value": "False"
         }
     }
-}
-]
+},
+{
+    "op": "fused_rotary_position_embedding",
+    "param_info": {
+        "q": {
+            "dtype": "float32",
+            "shape": "[4L, 4096L, 32L, 128L]",
+            "type": "Variable"
+        },
+        "k": {
+            "dtype": "float32",
+            "shape": "[4L, 4096L, 32L, 128L]",
+            "type": "Variable"
+        },
+        "v": {
+            "type": "string",
+            "value": "None"
+        },
+        "cached_sin_cos": {
+            "type": "bool",
+            "value": "True"
+        },
+        "position_ids": {
+            "type": "string",
+            "value": "None"
+        },
+        "use_neox_rotary_style": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+},
+{
+    "op": "fused_rotary_position_embedding",
+    "param_info": {
+        "q": {
+            "dtype": "float32",
+            "shape": "[4L, 4096L, 32L, 128L]",
+            "type": "Variable"
+        },
+        "k": {
+            "dtype": "float32",
+            "shape": "[4L, 4096L, 4L, 128L]",
+            "type": "Variable"
+        },
+        "v": {
+            "type": "string",
+            "value": "None"
+        },
+        "cached_sin_cos": {
+            "type": "bool",
+            "value": "True"
+        },
+        "position_ids": {
+            "type": "string",
+            "value": "None"
+        },
+        "use_neox_rotary_style": {
+            "type": "bool",
+            "value": "True"
+        }
+    }
+}]

--- a/api/tests_v2/configs/fused_rotary_position_embedding.json
+++ b/api/tests_v2/configs/fused_rotary_position_embedding.json
@@ -1,0 +1,63 @@
+[{
+    "op": "fused_rotary_position_embedding",
+    "param_info": {
+        "q": {
+            "dtype": "float32",
+            "shape": "[4L, 4096L, 32L, 128L]",
+            "type": "Variable"
+        },
+        "k": {
+            "dtype": "float32",
+            "shape": "[4L, 4096L, 32L, 128L]",
+            "type": "Variable"
+        },
+        "v": {
+            "type": "string",
+            "value": "None"
+        },
+        "cached_sin_cos": {
+            "type": "bool",
+            "value": "True"
+        },
+        "position_ids": {
+            "type": "string",
+            "value": "None"
+        },
+        "use_neox_rotary_style": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+},
+{
+    "op": "fused_rotary_position_embedding",
+    "param_info": {
+        "q": {
+            "dtype": "float32",
+            "shape": "[4L, 4096L, 32L, 128L]",
+            "type": "Variable"
+        },
+        "k": {
+            "dtype": "float32",
+            "shape": "[4L, 4096L, 4L, 128L]",
+            "type": "Variable"
+        },
+        "v": {
+            "type": "string",
+            "value": "None"
+        },
+        "cached_sin_cos": {
+            "type": "bool",
+            "value": "True"
+        },
+        "position_ids": {
+            "type": "string",
+            "value": "None"
+        },
+        "use_neox_rotary_style": {
+            "type": "bool",
+            "value": "False"
+        }
+    }
+}
+]


### PR DESCRIPTION
Add test fused_rope api and configs

results:

| dims of q | dims of k| cached_sin_cos | use_neox_rotary_style | dtype | average_time (ms) |
|:-:|:-:|:-:|:-:|:-:|:-:|
| [4, 4096, 32, 128] | [4, 4096, 32, 128] | True | False | float32 | 1.6308 |
| [4, 4096, 32, 128] | [4, 4096, 4, 128] | True | False | float32 | 0.70488 |
| [4, 4096, 32, 128] | [4, 4096, 32, 128] | True | True | float32 | 1.5846 |
| [4, 4096, 32, 128] | [4, 4096, 4, 128] | True | True | float32 | 0.65717 |



NOTE: `average_time` indicates the average time cost of testing 1000 times